### PR TITLE
Handle missing or invalid kafka secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+################################################################################
+##
+##                     Eventing-Kafka Makefile
+##
+################################################################################
+
+# Project Directories
+BUILD_ROOT:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+BUILD_DIR:=$(BUILD_ROOT)/build
+CHANNEL_BUILD_DIR=$(BUILD_DIR)/channel
+COMMON_BUILD_DIR=$(BUILD_DIR)/common
+CONTROLLER_BUILD_DIR=$(BUILD_DIR)/controller
+DISPATCHER_BUILD_DIR=$(BUILD_DIR)/dispatcher
+
+
+#
+# Mod / Fmt / Vet / Lint
+#
+
+mod:
+	@echo 'Ensuring Dependencies'
+	cd $(BUILD_ROOT); go mod vendor; go mod tidy
+
+format:
+	@echo 'Formatting Go Source'
+	go fmt ./...
+
+vet:
+	@echo 'Vetting Packages'
+	go vet -v ./cmd/...
+	go vet -v ./pkg/...
+
+lint:
+	@echo 'Linting Packages'
+	golint ./cmd/...
+	golint ./pkg/...
+
+.PHONY: mod format vet lint
+
+
+#
+# Testing
+#
+
+test-channel:
+	@echo 'Testing Channel'
+	mkdir -p $(CHANNEL_BUILD_DIR)
+	cd $(BUILD_ROOT); go test -v ./pkg/channel/... -coverprofile ${CHANNEL_BUILD_DIR}/coverage.out
+	cd $(BUILD_ROOT); go tool cover -func=${CHANNEL_BUILD_DIR}/coverage.out
+
+test-common:
+	@echo 'Testing Common'
+	mkdir -p $(COMMON_BUILD_DIR)
+	cd $(BUILD_ROOT); go test -v ./pkg/common/... -coverprofile ${COMMON_BUILD_DIR}/coverage.out
+	cd $(BUILD_ROOT); go tool cover -func=${COMMON_BUILD_DIR}/coverage.out
+
+test-controller:
+	@echo 'Testing Controller'
+	mkdir -p $(CONTROLLER_BUILD_DIR)
+	cd $(BUILD_ROOT); go test -v ./pkg/controller/... -coverprofile ${CONTROLLER_BUILD_DIR}/coverage.out
+	cd $(BUILD_ROOT); go tool cover -func=${CONTROLLER_BUILD_DIR}/coverage.out
+
+test-dispatcher:
+	@echo 'Testing Dispatcher'
+	mkdir -p $(DISPATCHER_BUILD_DIR)
+	cd $(BUILD_ROOT); go test -v ./pkg/dispatcher/... -coverprofile ${DISPATCHER_BUILD_DIR}/coverage.out
+	cd $(BUILD_ROOT); go tool cover -func=${DISPATCHER_BUILD_DIR}/coverage.out
+
+test-all: test-channel test-common test-controller test-dispatcher
+
+.PHONY: test-channel test-common test-controller test-dispatcher test-all

--- a/pkg/common/kafka/admin/admin_kafka.go
+++ b/pkg/common/kafka/admin/admin_kafka.go
@@ -56,7 +56,7 @@ func NewKafkaAdminClient(ctx context.Context, namespace string) (AdminClientInte
 		return nil, err
 	}
 
-	// Handle Various Numbers Of Kafka Secrets - Currently Only Support One!
+	//  Currently Only Support One Kafka Secret - Invalid AdminClient For All Other Cases!
 	if len(kafkaSecrets.Items) != 1 {
 		logger.Warn(fmt.Sprintf("Expected 1 Kafka Secret But Found %d - Kafka AdminClient Will Not Be Functional!", len(kafkaSecrets.Items)))
 		return &KafkaAdminClient{logger: logger, namespace: namespace}, nil

--- a/pkg/common/kafka/admin/admin_kafka_test.go
+++ b/pkg/common/kafka/admin/admin_kafka_test.go
@@ -55,8 +55,8 @@ func TestNewKafkaAdminClientNoSecrets(t *testing.T) {
 	adminClient, err := NewKafkaAdminClient(ctx, namespace)
 
 	// Verify The Results
-	assert.NotNil(t, err)
-	assert.Nil(t, adminClient)
+	assert.Nil(t, err)
+	assert.NotNil(t, adminClient)
 }
 
 // Test The Kafka AdminClient CreateTopics() Functionality
@@ -103,6 +103,36 @@ func TestKafkaAdminClientCreateTopics(t *testing.T) {
 	mockConfluentAdminClient.AssertExpectations(t)
 }
 
+// Test The Kafka AdminClient CreateTopics() Without AdminClient Functionality
+func TestKafkaAdminClientCreateTopicsInvalidAdminClient(t *testing.T) {
+
+	// Test Data
+	ctx := context.TODO()
+	topicName := "TestTopicName"
+	topicNumPartitions := 4
+	topicRetentionMillis := int64(3 * constants.MillisPerDay)
+
+	// Create The Kafka TopicSpecification For The Topic/EventHub To Be Created
+	topicSpecifications := []kafka.TopicSpecification{{
+		Topic:         topicName,
+		NumPartitions: topicNumPartitions,
+		Config:        map[string]string{constants.TopicSpecificationConfigRetentionMs: strconv.FormatInt(topicRetentionMillis, 10)},
+	}}
+
+	// Test Logger
+	logger := logtesting.TestLogger(t).Desugar()
+
+	// Create A New Kafka AdminClient To Test
+	adminClient := &KafkaAdminClient{logger: logger}
+
+	// Perform The Test
+	kafkaTopicResults, err := adminClient.CreateTopics(ctx, topicSpecifications)
+
+	// Verify The Results
+	assert.NotNil(t, err)
+	assert.Nil(t, kafkaTopicResults)
+}
+
 // Test The Kafka AdminClient DeleteTopics() Functionality
 func TestKafkaAdminClientDeleteTopics(t *testing.T) {
 
@@ -138,6 +168,27 @@ func TestKafkaAdminClientDeleteTopics(t *testing.T) {
 	mockConfluentAdminClient.AssertExpectations(t)
 }
 
+// Test The Kafka AdminClient DeleteTopics() Without AdminClient Functionality
+func TestKafkaAdminClientDeleteTopicsInvalidAdminClient(t *testing.T) {
+
+	// Test Data
+	ctx := context.TODO()
+	topicName := "TestTopicName"
+
+	// Test Logger
+	logger := logtesting.TestLogger(t).Desugar()
+
+	// Create A New Kafka AdminClient To Test
+	adminClient := &KafkaAdminClient{logger: logger}
+
+	// Perform The Test
+	kafkaTopicResults, err := adminClient.DeleteTopics(ctx, []string{topicName})
+
+	// Verify The Results
+	assert.NotNil(t, err)
+	assert.Nil(t, kafkaTopicResults)
+}
+
 // Test The Kafka AdminClient Close() Functionality
 func TestKafkaAdminClientClose(t *testing.T) {
 
@@ -159,6 +210,21 @@ func TestKafkaAdminClientClose(t *testing.T) {
 
 	// Verify The Results
 	mockConfluentAdminClient.AssertExpectations(t)
+}
+
+// Test The Kafka AdminClient Close() Without AdminClient Functionality
+func TestKafkaAdminClientCloseInvalidAdminClient(t *testing.T) {
+
+	// Test Logger
+	logger := logtesting.TestLogger(t).Desugar()
+
+	// Create A New Kafka AdminClient To Test
+	adminClient := &KafkaAdminClient{logger: logger}
+
+	// Perform The Test
+	adminClient.Close()
+
+	// Nothing To Verify
 }
 
 // Test The Kafka AdminClient GetKafkaSecretName() Functionality


### PR DESCRIPTION
Fixes #12 

Added minimal stability fixes so that the "Kafka" use case behaves similar to the "EventHubs" use case when the Kafka Secret is missing or invalid.

Also re-added the Makefile which was accidentally removed.  We can refactor it out into hack scripts or something else at some point, but it still has useful development utilities (partial test runs with code coverage and such...)

