### PR TITLE
Remove fixed port for health tests

### DIFF
--- a/pkg/channel/health/health.go
+++ b/pkg/channel/health/health.go
@@ -22,8 +22,7 @@ type Server struct {
 // Creates A New Server With Specified Configuration
 func NewChannelHealthServer(httpPort string) *Server {
 	channelHealth := &Server{}
-	health := health.NewHealthServer(httpPort, channelHealth)
-	channelHealth.Server = *health
+	channelHealth.Server = *health.NewHealthServer(httpPort, channelHealth)
 
 	// Return The Server
 	return channelHealth

--- a/pkg/channel/health/health_test.go
+++ b/pkg/channel/health/health_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	testHttpPort  = "8090"
+	testHttpPort  = "0"
 	testHttpHost  = "localhost"
 	readinessPath = "/healthy"
 )
@@ -55,7 +55,7 @@ func TestChannelHealthServer(t *testing.T) {
 	chs := NewChannelHealthServer(testHttpPort)
 	chs.Start(logger)
 
-	readinessUri, err := url.Parse(fmt.Sprintf("http://%s:%s%s", testHttpHost, testHttpPort, readinessPath))
+	readinessUri, err := url.Parse(fmt.Sprintf("http://%s:%s%s", testHttpHost, chs.HttpPort, readinessPath))
 	assert.Nil(t, err)
 	waitServerReady(readinessUri.String(), 3*time.Second)
 

--- a/pkg/channel/health/health_test.go
+++ b/pkg/channel/health/health_test.go
@@ -1,18 +1,15 @@
 package health
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
-	logtesting "knative.dev/pkg/logging/testing"
+	"io"
 	"net/http"
-	"net/url"
+	"net/http/httptest"
 	"testing"
-	"time"
 )
 
 const (
 	testHttpPort  = "0"
-	testHttpHost  = "localhost"
 	readinessPath = "/healthy"
 )
 
@@ -47,75 +44,64 @@ func TestReadinessFlagWrites(t *testing.T) {
 
 }
 
-// Test The Channel Health Server Via Live HTTP Calls
-func TestChannelHealthServer(t *testing.T) {
 
-	logger := logtesting.TestLogger(t).Desugar()
+// Test The Channel Health Server Via The HTTP Handlers
+func TestChannelHealthHandler(t *testing.T) {
 
+	// Create A New Health Server
 	chs := NewChannelHealthServer(testHttpPort)
-	chs.Start(logger)
-
-	readinessUri, err := url.Parse(fmt.Sprintf("http://%s:%s%s", testHttpHost, chs.HttpPort, readinessPath))
-	assert.Nil(t, err)
-	waitServerReady(readinessUri.String(), 3*time.Second)
 
 	// Verify that initially the readiness status is false
-	getEventToServer(t, readinessUri, http.StatusInternalServerError)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusInternalServerError)
 
 	// Verify that the readiness status requires setting all of the readiness flags
 	chs.SetChannelReady(true)
-	getEventToServer(t, readinessUri, http.StatusInternalServerError)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusInternalServerError)
 	chs.SetProducerReady(true)
-	getEventToServer(t, readinessUri, http.StatusOK)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusOK)
 	chs.SetChannelReady(false)
-	getEventToServer(t, readinessUri, http.StatusInternalServerError)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusInternalServerError)
 
 	// Verify that the shutdown process sets the readiness status to false
 	chs.SetProducerReady(true)
 	chs.SetChannelReady(true)
-	getEventToServer(t, readinessUri, http.StatusOK)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusOK)
 
 	chs.Shutdown()
-	getEventToServer(t, readinessUri, http.StatusInternalServerError)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusInternalServerError)
 
-	getEventToServer(t, readinessUri, http.StatusInternalServerError)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusInternalServerError)
 	chs.SetChannelReady(true)
 	chs.SetProducerReady(true)
-	getEventToServer(t, readinessUri, http.StatusOK)
-
-	chs.Stop(logger)
-
-	// Pause to let async go process finish logging :(
-	// Appears to be race condition between test finishing and logging in Stop() above
-	time.Sleep(1 * time.Second)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusOK)
 }
 
 //
 // Private Utility Functions
 //
 
-// Waits Until A GET Request Succeeds (Or Times Out)
-func waitServerReady(uri string, timeout time.Duration) {
-	// Create An HTTP Client And Send The Request Until Success Or Timeout
-	client := http.DefaultClient
-	for start := time.Now(); time.Since(start) < timeout; {
-		_, err := client.Get(uri) // Don't care what the response actually is, only if there was an error getting it
-		if err == nil {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
+// Create A Test HTTP Request For The Specified Method / Path
+func createNewRequest(t *testing.T, method string, path string, body io.Reader) *http.Request {
+	request, err := http.NewRequest(method, path, body)
+	assert.Nil(t, err)
+	return request
 }
 
-// Sends A Simple GET Event To A URL Expecting A Specific Response Code
-func getEventToServer(t *testing.T, uri *url.URL, expectedStatus int) {
+// Sends A Request To An HTTP Response Recorder Directly Expecting A Specific Response Code
+func getEventToHandler(t *testing.T, handlerFunc http.HandlerFunc, path string, expectedStatus int) {
 
-	// Create An HTTP Client And Send The Request
-	client := http.DefaultClient
-	resp, err := client.Get(uri.String())
+	// Create A Test HTTP GET Request For requested path
+	request := createNewRequest(t, http.MethodGet, path, nil)
 
-	// Verify The Client Response Is As Expected
-	assert.NotNil(t, resp)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedStatus, resp.StatusCode)
+	// Create An HTTP ResponseRecorder & Handler For Request
+	responseRecorder := httptest.NewRecorder()
+	handler := handlerFunc
+
+	// Call The HTTP Request Handler Function For Path
+	handler.ServeHTTP(responseRecorder, request)
+
+	// Verify The StatusMethodNotAllowed Response Code Is Returned
+	statusCode := responseRecorder.Code
+	assert.Equal(t, expectedStatus, statusCode)
+
 }

--- a/pkg/common/health/health.go
+++ b/pkg/common/health/health.go
@@ -58,8 +58,8 @@ func (hs *Server) Shutdown() {
 func (hs *Server) initializeServer(httpPort string) {
 
 	serveMux := http.NewServeMux()
-	serveMux.HandleFunc(LivenessPath, hs.handleLiveness)
-	serveMux.HandleFunc(ReadinessPath, hs.handleReadiness)
+	serveMux.HandleFunc(LivenessPath, hs.HandleLiveness)
+	serveMux.HandleFunc(ReadinessPath, hs.HandleReadiness)
 
 	// Create The Server For Configured HTTP Port
 	server := &http.Server{Addr: ":" + httpPort, Handler: serveMux}
@@ -103,7 +103,7 @@ func (hs *Server) Alive() bool {
 }
 
 // HTTP Request Handler For Liveness Requests (/healthz)
-func (hs *Server) handleLiveness(responseWriter http.ResponseWriter, request *http.Request) {
+func (hs *Server) HandleLiveness(responseWriter http.ResponseWriter, request *http.Request) {
 	if request.Method != http.MethodGet {
 		responseWriter.WriteHeader(http.StatusMethodNotAllowed)
 		return
@@ -116,7 +116,7 @@ func (hs *Server) handleLiveness(responseWriter http.ResponseWriter, request *ht
 }
 
 // HTTP Request Handler For Readiness Requests (/healthy)
-func (hs *Server) handleReadiness(responseWriter http.ResponseWriter, request *http.Request) {
+func (hs *Server) HandleReadiness(responseWriter http.ResponseWriter, request *http.Request) {
 	if request.Method != http.MethodGet {
 		responseWriter.WriteHeader(http.StatusMethodNotAllowed)
 		return

--- a/pkg/common/health/health.go
+++ b/pkg/common/health/health.go
@@ -75,7 +75,11 @@ func (hs *Server) Start(logger *zap.Logger) {
 		logger.Error("Server HTTP Listen Returned Error", zap.Error(err))
 	}
 
+	// Set the HttpPort field to whatever port was actually used by the system
+	// before launching the Server goroutine, so that the caller can access it.
+	// (If "0" is passed in then the Listen call will assign one arbitrarily)
 	hs.HttpPort = strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+
 	go func() {
 		logger.Info("Starting Server HTTP Server on port " + hs.HttpPort)
 

--- a/pkg/common/health/health_test.go
+++ b/pkg/common/health/health_test.go
@@ -79,21 +79,21 @@ func TestUnsupportedEventsRequests(t *testing.T) {
 	health := getTestHealthServer()
 
 	// Test All Unsupported Events Requests
-	performUnsupportedMethodRequestTest(t, http.MethodConnect, livenessPath, health.handleLiveness)
-	performUnsupportedMethodRequestTest(t, http.MethodDelete, livenessPath, health.handleLiveness)
-	performUnsupportedMethodRequestTest(t, http.MethodPost, livenessPath, health.handleLiveness)
-	performUnsupportedMethodRequestTest(t, http.MethodOptions, livenessPath, health.handleLiveness)
-	performUnsupportedMethodRequestTest(t, http.MethodPatch, livenessPath, health.handleLiveness)
-	performUnsupportedMethodRequestTest(t, http.MethodPut, livenessPath, health.handleLiveness)
-	performUnsupportedMethodRequestTest(t, http.MethodTrace, livenessPath, health.handleLiveness)
+	performUnsupportedMethodRequestTest(t, http.MethodConnect, livenessPath, health.HandleLiveness)
+	performUnsupportedMethodRequestTest(t, http.MethodDelete, livenessPath, health.HandleLiveness)
+	performUnsupportedMethodRequestTest(t, http.MethodPost, livenessPath, health.HandleLiveness)
+	performUnsupportedMethodRequestTest(t, http.MethodOptions, livenessPath, health.HandleLiveness)
+	performUnsupportedMethodRequestTest(t, http.MethodPatch, livenessPath, health.HandleLiveness)
+	performUnsupportedMethodRequestTest(t, http.MethodPut, livenessPath, health.HandleLiveness)
+	performUnsupportedMethodRequestTest(t, http.MethodTrace, livenessPath, health.HandleLiveness)
 
-	performUnsupportedMethodRequestTest(t, http.MethodConnect, readinessPath, health.handleReadiness)
-	performUnsupportedMethodRequestTest(t, http.MethodDelete, readinessPath, health.handleReadiness)
-	performUnsupportedMethodRequestTest(t, http.MethodPost, readinessPath, health.handleReadiness)
-	performUnsupportedMethodRequestTest(t, http.MethodOptions, readinessPath, health.handleReadiness)
-	performUnsupportedMethodRequestTest(t, http.MethodPatch, readinessPath, health.handleReadiness)
-	performUnsupportedMethodRequestTest(t, http.MethodPut, readinessPath, health.handleReadiness)
-	performUnsupportedMethodRequestTest(t, http.MethodTrace, readinessPath, health.handleReadiness)
+	performUnsupportedMethodRequestTest(t, http.MethodConnect, readinessPath, health.HandleReadiness)
+	performUnsupportedMethodRequestTest(t, http.MethodDelete, readinessPath, health.HandleReadiness)
+	performUnsupportedMethodRequestTest(t, http.MethodPost, readinessPath, health.HandleReadiness)
+	performUnsupportedMethodRequestTest(t, http.MethodOptions, readinessPath, health.HandleReadiness)
+	performUnsupportedMethodRequestTest(t, http.MethodPatch, readinessPath, health.HandleReadiness)
+	performUnsupportedMethodRequestTest(t, http.MethodPut, readinessPath, health.HandleReadiness)
+	performUnsupportedMethodRequestTest(t, http.MethodTrace, readinessPath, health.HandleReadiness)
 }
 
 // Test The Health Server Via The HTTP Handlers
@@ -103,16 +103,16 @@ func TestHealthHandler(t *testing.T) {
 	health := getTestHealthServer()
 
 	// Verify that initially the statuses are not live / ready
-	getEventToHandler(t, health.handleLiveness, livenessPath, http.StatusInternalServerError)
-	getEventToHandler(t, health.handleReadiness, readinessPath, http.StatusOK)
+	getEventToHandler(t, health.HandleLiveness, livenessPath, http.StatusInternalServerError)
+	getEventToHandler(t, health.HandleReadiness, readinessPath, http.StatusOK)
 
 	// Verify that the liveness status follows the health.Alive flag
 	health.SetAlive(true)
-	getEventToHandler(t, health.handleLiveness, livenessPath, http.StatusOK)
+	getEventToHandler(t, health.HandleLiveness, livenessPath, http.StatusOK)
 
 	// Verify that the shutdown process sets liveness to false
 	health.Shutdown()
-	getEventToHandler(t, health.handleLiveness, livenessPath, http.StatusInternalServerError)
+	getEventToHandler(t, health.HandleLiveness, livenessPath, http.StatusInternalServerError)
 }
 
 // Test The Health Server Via Live HTTP Calls

--- a/pkg/dispatcher/health/health.go
+++ b/pkg/dispatcher/health/health.go
@@ -20,8 +20,7 @@ type Server struct {
 // Creates A New Server With Specified Configuration
 func NewDispatcherHealthServer(httpPort string) *Server {
 	dispatcherHealth := &Server{}
-	health := health.NewHealthServer(httpPort, dispatcherHealth)
-	dispatcherHealth.Server = *health
+	dispatcherHealth.Server = *health.NewHealthServer(httpPort, dispatcherHealth)
 
 	// Return The Server
 	return dispatcherHealth

--- a/pkg/dispatcher/health/health_test.go
+++ b/pkg/dispatcher/health/health_test.go
@@ -1,18 +1,15 @@
 package health
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
-	logtesting "knative.dev/pkg/logging/testing"
+	"io"
 	"net/http"
-	"net/url"
+	"net/http/httptest"
 	"testing"
-	"time"
 )
 
 const (
 	testHttpPort  = "0"
-	testHttpHost  = "localhost"
 	readinessPath = "/healthy"
 )
 
@@ -41,65 +38,53 @@ func TestReadinessFlagWrites(t *testing.T) {
 	assert.Equal(t, true, chs.DispatcherReady())
 }
 
-// Test The Dispatcher Health Server Via Live HTTP Calls
-func TestDispatcherHealthServer(t *testing.T) {
+// Test The Dispatcher Health Server Via The HTTP Handlers
+func TestDispatcherHealthHandler(t *testing.T) {
 
-	logger := logtesting.TestLogger(t).Desugar()
-
+	// Create A New Health Server
 	chs := NewDispatcherHealthServer(testHttpPort)
-	chs.Start(logger)
-
-	readinessUri, err := url.Parse(fmt.Sprintf("http://%s:%s%s", testHttpHost, chs.HttpPort, readinessPath))
-	assert.Nil(t, err)
-	waitServerReady(readinessUri.String(), 3*time.Second)
 
 	// Verify that initially the readiness status is false
-	getEventToServer(t, readinessUri, http.StatusInternalServerError)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusInternalServerError)
 
 	// Verify that the readiness status required setting all of the readiness flags
 	chs.SetDispatcherReady(true)
-	getEventToServer(t, readinessUri, http.StatusOK)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusOK)
 
 	// Verify that the shutdown process sets all statuses to not live / not ready
 	chs.SetDispatcherReady(true)
-	getEventToServer(t, readinessUri, http.StatusOK)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusOK)
 
 	chs.Shutdown()
-	getEventToServer(t, readinessUri, http.StatusInternalServerError)
-
-	chs.Stop(logger)
-
-	// Pause to let async go process finish logging :(
-	// Appears to be race condition between test finishing and logging in Stop() above
-	time.Sleep(1 * time.Second)
+	getEventToHandler(t, chs.HandleReadiness, readinessPath, http.StatusInternalServerError)
 }
 
 //
 // Private Utility Functions
 //
 
-// Waits Until A GET Request Succeeds (Or Times Out)
-func waitServerReady(uri string, timeout time.Duration) {
-	// Create An HTTP Client And Send The Request Until Success Or Timeout
-	client := http.DefaultClient
-	for start := time.Now(); time.Since(start) < timeout; {
-		_, err := client.Get(uri) // Don't care what the response actually is, only if there was an error getting it
-		if err == nil {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
+// Create A Test HTTP Request For The Specified Method / Path
+func createNewRequest(t *testing.T, method string, path string, body io.Reader) *http.Request {
+	request, err := http.NewRequest(method, path, body)
+	assert.Nil(t, err)
+	return request
 }
 
-// Sends A Simple GET Event To A URL Expecting A Specific Response Code
-func getEventToServer(t *testing.T, uri *url.URL, expectedStatus int) {
+// Sends A Request To An HTTP Response Recorder Directly Expecting A Specific Response Code
+func getEventToHandler(t *testing.T, handlerFunc http.HandlerFunc, path string, expectedStatus int) {
 
-	// Create An HTTP Client And Send The Request
-	client := http.DefaultClient
-	resp, err := client.Get(uri.String())
+	// Create A Test HTTP GET Request For requested path
+	request := createNewRequest(t, http.MethodGet, path, nil)
 
-	// Verify The Client Response Is As Expected
-	assert.NotNil(t, resp)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedStatus, resp.StatusCode)
+	// Create An HTTP ResponseRecorder & Handler For Request
+	responseRecorder := httptest.NewRecorder()
+	handler := handlerFunc
+
+	// Call The HTTP Request Handler Function For Path
+	handler.ServeHTTP(responseRecorder, request)
+
+	// Verify The StatusMethodNotAllowed Response Code Is Returned
+	statusCode := responseRecorder.Code
+	assert.Equal(t, expectedStatus, statusCode)
+
 }

--- a/pkg/dispatcher/health/health_test.go
+++ b/pkg/dispatcher/health/health_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	testHttpPort  = "8090"
+	testHttpPort  = "0"
 	testHttpHost  = "localhost"
 	readinessPath = "/healthy"
 )
@@ -49,7 +49,7 @@ func TestDispatcherHealthServer(t *testing.T) {
 	chs := NewDispatcherHealthServer(testHttpPort)
 	chs.Start(logger)
 
-	readinessUri, err := url.Parse(fmt.Sprintf("http://%s:%s%s", testHttpHost, testHttpPort, readinessPath))
+	readinessUri, err := url.Parse(fmt.Sprintf("http://%s:%s%s", testHttpHost, chs.HttpPort, readinessPath))
 	assert.Nil(t, err)
 	waitServerReady(readinessUri.String(), 3*time.Second)
 


### PR DESCRIPTION
Fixes #18

Removed live HTTP server unit tests for health.go from dispatcher and channel (unnecessary duplication of testing between those and common).  Changed common health.go test to use a system-assigned port for the local HTTP server to avoid random port conflicts during testing.