### PR TITLE
Use server flag for kubernetes server url

### DIFF
--- a/cmd/channel/main.go
+++ b/cmd/channel/main.go
@@ -33,7 +33,7 @@ const (
 // Variables
 var (
 	logger        *zap.Logger
-	masterURL     = flag.String("masterurl", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	serverURL     = flag.String("server", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	kubeconfig    = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	kafkaProducer *producer.Producer
 )
@@ -45,7 +45,7 @@ func main() {
 	flag.Parse()
 
 	// Initialize A Knative Injection Lite Context (K8S Client & Logger)
-	ctx := commonk8s.LoggingContext(context.Background(), constants.Component, *masterURL, *kubeconfig)
+	ctx := commonk8s.LoggingContext(context.Background(), constants.Component, *serverURL, *kubeconfig)
 
 	// Get The Logger From The Context & Defer Flushing Any Buffered Log Entries On Exit
 	logger = logging.FromContext(ctx).Desugar()
@@ -83,7 +83,7 @@ func main() {
 	healthServer.Start(logger)
 
 	// Initialize The KafkaChannel Lister Used To Validate Events
-	err = channel.InitializeKafkaChannelLister(ctx, *masterURL, *kubeconfig, healthServer)
+	err = channel.InitializeKafkaChannelLister(ctx, *serverURL, *kubeconfig, healthServer)
 	if err != nil {
 		logger.Fatal("Failed To Initialize KafkaChannel Lister", zap.Error(err))
 	}

--- a/cmd/dispatcher/main.go
+++ b/cmd/dispatcher/main.go
@@ -36,7 +36,7 @@ const (
 var (
 	logger     *zap.Logger
 	dispatcher dispatch.Dispatcher
-	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	serverURL  = flag.String("server", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 )
 
@@ -47,7 +47,7 @@ func main() {
 	flag.Parse()
 
 	// Initialize A Knative Injection Lite Context (K8S Client & Logger)
-	ctx := commonk8s.LoggingContext(signals.NewContext(), Component, *masterURL, *kubeconfig)
+	ctx := commonk8s.LoggingContext(signals.NewContext(), Component, *serverURL, *kubeconfig)
 
 	// Get The Logger From The Context & Defer Flushing Any Buffered Log Entries On Exit
 	logger = logging.FromContext(ctx).Desugar()
@@ -117,7 +117,7 @@ func main() {
 		logger.Fatal("Failed To Initialize ConfigMap Watcher", zap.Error(err))
 	}
 
-	config, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
+	config, err := clientcmd.BuildConfigFromFlags(*serverURL, *kubeconfig)
 	if err != nil {
 		logger.Fatal("Error building kubeconfig", zap.Error(err))
 	}


### PR DESCRIPTION
Part of https://github.com/knative/community/issues/193.

Similarly to https://github.com/knative/pkg/pull/1693 in pkg, and in line with latest kubectl, drop `--master` flags in favour of `--server`.