### PR TITLE
add POD_NAME env var to distributed channel controller deployment

### DIFF
--- a/config/channel/distributed/400-deployment.yaml
+++ b/config/channel/distributed/400-deployment.yaml
@@ -27,6 +27,10 @@ spec:
         - containerPort: 8081
           name: metrics
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Partially addresses #57 - will need to update the "consolidated" (eventing-contrib) channel deployments once that code is merge into this repo.