### PR TITLE
Some fmt lints

### DIFF
--- a/contrib/test/e2e/helpers/kafka_helper.go
+++ b/contrib/test/e2e/helpers/kafka_helper.go
@@ -36,8 +36,8 @@ import (
 	testlib "knative.dev/eventing/test/lib"
 	pkgtest "knative.dev/pkg/test"
 
-	kafkaclientset "knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 	sourcesv1beta1 "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
+	kafkaclientset "knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 )
 
 const (

--- a/contrib/test/lib/creation.go
+++ b/contrib/test/lib/creation.go
@@ -23,11 +23,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kafkaclientset "knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 	bindingsv1alpha1 "knative.dev/eventing-kafka/pkg/apis/bindings/v1alpha1"
 	bindingsv1beta1 "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
 	sourcesv1alpha1 "knative.dev/eventing-kafka/pkg/apis/sources/v1alpha1"
 	sourcesv1beta1 "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
+	kafkaclientset "knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 )
 
 func CreateKafkaSourceV1Alpha1OrFail(c *testlib.Client, kafkaSource *sourcesv1alpha1.KafkaSource) {

--- a/pkg/channel/consolidated/reconciler/controller/resources/service.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/service.go
@@ -24,7 +24,6 @@ import (
 	"knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/network"
-
 )
 
 const (

--- a/pkg/channel/distributed/common/health/health.go
+++ b/pkg/channel/distributed/common/health/health.go
@@ -2,11 +2,12 @@ package health
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"net"
 	"net/http"
 	"strconv"
 	"sync"
+
+	"go.uber.org/zap"
 )
 
 // Interface For Providing Overrides For Liveness And Readiness Information

--- a/pkg/channel/distributed/common/health/health_test.go
+++ b/pkg/channel/distributed/common/health/health_test.go
@@ -2,14 +2,15 @@ package health
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
-	logtesting "knative.dev/pkg/logging/testing"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	logtesting "knative.dev/pkg/logging/testing"
 )
 
 // Test Constants

--- a/pkg/channel/distributed/common/k8s/util_test.go
+++ b/pkg/channel/distributed/common/k8s/util_test.go
@@ -1,8 +1,9 @@
 package k8s
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Test The TruncateLabelValue() Functionality

--- a/pkg/channel/distributed/common/kafka/admin/admin_custom_test.go
+++ b/pkg/channel/distributed/common/kafka/admin/admin_custom_test.go
@@ -3,14 +3,15 @@ package admin
 import (
 	"context"
 	"encoding/json"
-	"github.com/Shopify/sarama"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/assert"
 
 	"k8s.io/client-go/kubernetes/fake"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/admin/custom"

--- a/pkg/channel/distributed/common/kafka/admin/admin_eventhub.go
+++ b/pkg/channel/distributed/common/kafka/admin/admin_eventhub.go
@@ -3,6 +3,10 @@ package admin
 import (
 	"context"
 	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+
 	eventhub "github.com/Azure/azure-event-hubs-go"
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
@@ -10,9 +14,6 @@ import (
 	adminutil "knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/admin/util"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
 	"knative.dev/pkg/logging"
-	"math"
-	"regexp"
-	"strconv"
 )
 
 //

--- a/pkg/channel/distributed/common/kafka/admin/admin_eventhub_test.go
+++ b/pkg/channel/distributed/common/kafka/admin/admin_eventhub_test.go
@@ -3,6 +3,9 @@ package admin
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"testing"
+
 	eventhub "github.com/Azure/azure-event-hubs-go"
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/assert"
@@ -10,8 +13,6 @@ import (
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/admin/eventhubcache"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
 	logtesting "knative.dev/pkg/logging/testing"
-	"strconv"
-	"testing"
 )
 
 // Test The NewEventHubAdminClient() Constructor - Success Path

--- a/pkg/channel/distributed/common/kafka/admin/eventhubcache/cache.go
+++ b/pkg/channel/distributed/common/kafka/admin/eventhubcache/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/channel/distributed/common/kafka/admin/eventhubcache/cache_test.go
+++ b/pkg/channel/distributed/common/kafka/admin/eventhubcache/cache_test.go
@@ -3,6 +3,9 @@ package eventhubcache
 import (
 	"context"
 	"fmt"
+	"strings"
+	"testing"
+
 	eventhub "github.com/Azure/azure-event-hubs-go"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -13,8 +16,6 @@ import (
 	injectionclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
-	"strings"
-	"testing"
 )
 
 // Test The Cache's NewCache() Constructor

--- a/pkg/channel/distributed/common/kafka/admin/eventhubcache/hubmanager.go
+++ b/pkg/channel/distributed/common/kafka/admin/eventhubcache/hubmanager.go
@@ -2,6 +2,7 @@ package eventhubcache
 
 import (
 	"context"
+
 	eventhub "github.com/Azure/azure-event-hubs-go"
 )
 

--- a/pkg/channel/distributed/common/kafka/admin/eventhubcache/namespace_test.go
+++ b/pkg/channel/distributed/common/kafka/admin/eventhubcache/namespace_test.go
@@ -2,12 +2,13 @@ package eventhubcache
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
 	logtesting "knative.dev/pkg/logging/testing"
-	"testing"
 )
 
 // Test The NewNamespace() Constructor

--- a/pkg/channel/distributed/common/kafka/testing/mocks.go
+++ b/pkg/channel/distributed/common/kafka/testing/mocks.go
@@ -2,8 +2,9 @@ package testing
 
 import (
 	"context"
-	"github.com/Shopify/sarama"
 	"testing"
+
+	"github.com/Shopify/sarama"
 )
 
 //

--- a/pkg/channel/distributed/common/metrics/stats_reporter.go
+++ b/pkg/channel/distributed/common/metrics/stats_reporter.go
@@ -2,13 +2,14 @@ package metrics
 
 import (
 	"context"
+	"log"
+	"strings"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 	"knative.dev/pkg/metrics"
-	"log"
-	"strings"
 )
 
 const (

--- a/pkg/channel/distributed/common/util/util.go
+++ b/pkg/channel/distributed/common/util/util.go
@@ -1,9 +1,10 @@
 package util
 
 import (
-	"go.uber.org/zap"
 	"os"
 	"os/signal"
+
+	"go.uber.org/zap"
 )
 
 // Block Waiting For Any Of The Specified Signals

--- a/pkg/channel/distributed/common/util/util_test.go
+++ b/pkg/channel/distributed/common/util/util_test.go
@@ -1,11 +1,12 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
-	logtesting "knative.dev/pkg/logging/testing"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	logtesting "knative.dev/pkg/logging/testing"
 )
 
 // Test The WaitForSignal Functionality

--- a/pkg/channel/distributed/controller/kafkasecretinjection/reconciler.go
+++ b/pkg/channel/distributed/controller/kafkasecretinjection/reconciler.go
@@ -4,6 +4,7 @@ import (
 	context "context"
 	json "encoding/json"
 	fmt "fmt"
+
 	zap "go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	errors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/channel/distributed/controller/kafkasecretinjection/state.go
+++ b/pkg/channel/distributed/controller/kafkasecretinjection/state.go
@@ -2,6 +2,7 @@ package kafkasecretinjection
 
 import (
 	fmt "fmt"
+
 	v1 "k8s.io/api/core/v1"
 
 	types "k8s.io/apimachinery/pkg/types"

--- a/pkg/channel/distributed/controller/util/dns_test.go
+++ b/pkg/channel/distributed/controller/util/dns_test.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Test The GenerateValidDnsName() Functionality

--- a/pkg/channel/distributed/controller/util/secret_test.go
+++ b/pkg/channel/distributed/controller/util/secret_test.go
@@ -1,12 +1,13 @@
 package util
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/constants"
 	logtesting "knative.dev/pkg/logging/testing"
-	"testing"
 )
 
 // Test The SecretLogger() Functionality

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -3,6 +3,10 @@ package dispatcher
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/url"
+	"regexp"
+
 	"github.com/Shopify/sarama"
 	kafkasaramaprotocol "github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -10,9 +14,6 @@ import (
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/kncloudevents"
-	"net/http"
-	"net/url"
-	"regexp"
 )
 
 // 3 Digit Word Boundary HTTP Status Code Regular Expression

--- a/pkg/channel/distributed/dispatcher/health/health_test.go
+++ b/pkg/channel/distributed/dispatcher/health/health_test.go
@@ -1,11 +1,12 @@
 package health
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/pkg/channel/distributed/receiver/health/health_test.go
+++ b/pkg/channel/distributed/receiver/health/health_test.go
@@ -1,11 +1,12 @@
 package health
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/pkg/channel/distributed/receiver/test/message.go
+++ b/pkg/channel/distributed/receiver/test/message.go
@@ -1,10 +1,11 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // Utility Function For Creating A CloudEvents sdk-go BindingMessage

--- a/pkg/channel/distributed/receiver/util/util_test.go
+++ b/pkg/channel/distributed/receiver/util/util_test.go
@@ -1,9 +1,10 @@
 package util
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"knative.dev/eventing/pkg/channel"
-	"testing"
 )
 
 // Test The TopicName() Functionality


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

fmt fixes, done via:

```
gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)

goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party | grep -v .pb.go | grep -v wire_gen.go)
```