### PR TITLE
Add POD_NAME to consolidated channel deployments

### DIFF
--- a/config/channel/consolidated/deployments/controller.yaml
+++ b/config/channel/consolidated/deployments/controller.yaml
@@ -42,6 +42,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election-kafka
         - name: DISPATCHER_IMAGE

--- a/config/channel/consolidated/deployments/dispatcher.yaml
+++ b/config/channel/consolidated/deployments/dispatcher.yaml
@@ -43,6 +43,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: METRICS_DOMAIN
           value: "knative.dev/eventing"
         - name: CONFIG_LOGGING_NAME


### PR DESCRIPTION
Fixes #57 

Adding POD_NAME to consolidated channel controller/dispatcher deployments now that they are relocated from contrib.


