### PR TITLE
running misspell

### DIFF
--- a/config/channel/distributed/200-eventing-kafka-configmap.yaml
+++ b/config/channel/distributed/200-eventing-kafka-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   sarama: |
-    Version: 2.0.0 # Kafka Version Compatability From Sarama's Supported List (Major.Minor.Patch)
+    Version: 2.0.0 # Kafka Version Compatibility From Sarama's Supported List (Major.Minor.Patch)
     Admin:
       Timeout: 10000000000  # 10 seconds
     Net:

--- a/pkg/channel/distributed/dispatcher/README.md
+++ b/pkg/channel/distributed/dispatcher/README.md
@@ -23,7 +23,7 @@ changes to the Subscribable (Channelable) list of subscribers.  It also updates
 the KafkaChannel's SubscriberStatus when the Kafka ConsumerGroups are deemed to
 be operational.
 
-The Kafka brokers and credentials are obtained from mounted Secret data from the aforementiond Kafka Secret.
+The Kafka brokers and credentials are obtained from mounted Secret data from the aforementioned Kafka Secret.
 
 ## Tracing, Profiling, and Metrics
 

--- a/pkg/channel/distributed/receiver/README.md
+++ b/pkg/channel/distributed/receiver/README.md
@@ -19,7 +19,7 @@ implementation can use the hostname of the request to map incoming CloudEvents
 to the appropriate Kafka Topic.
 
 The Kafka brokers and credentials are obtained from mounted Secret data from
-the aforementiond Kafka Secret.
+the aforementioned Kafka Secret.
 
 ## Tracing, Profiling, and Metrics
 

--- a/test/config/100-strimzi-cluster-operator-0.19.0.yaml
+++ b/test/config/100-strimzi-cluster-operator-0.19.0.yaml
@@ -8428,7 +8428,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
-                            description: Refernce to a key in a ConfigMap.
+                            description: References to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -11243,7 +11243,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
-                            description: Refernce to a key in a ConfigMap.
+                            description: References to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -12543,7 +12543,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
-                            description: Refernce to a key in a ConfigMap.
+                            description: References to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

* running [misspell](https://github.com/client9/misspell)

```
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
```

