### PR TITLE
Allow registering custom conditions for different channel implementations

### DIFF
--- a/pkg/apis/messaging/v1alpha1/kafka_channel_lifecycle.go
+++ b/pkg/apis/messaging/v1alpha1/kafka_channel_lifecycle.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"sync"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
@@ -31,6 +33,7 @@ var kc = apis.NewLivingConditionSet(
 	KafkaChannelConditionAddressable,
 	KafkaChannelConditionChannelServiceReady,
 	KafkaChannelConditionConfigReady)
+var channelCondSetLock = sync.RWMutex{}
 
 const (
 	// KafkaChannelConditionReady has status True when all subconditions below have been set to True.
@@ -66,24 +69,43 @@ const (
 	KafkaChannelConditionConfigReady apis.ConditionType = "ConfigurationReady"
 )
 
+// RegisterAlternateKafkaChannelConditionSet register a different apis.ConditionSet.
+func RegisterAlternateKafkaChannelConditionSet(conditionSet apis.ConditionSet) {
+	channelCondSetLock.Lock()
+	defer channelCondSetLock.Unlock()
+
+	kc = conditionSet
+}
+
 // GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
 func (*KafkaChannel) GetConditionSet() apis.ConditionSet {
+	channelCondSetLock.RLock()
+	defer channelCondSetLock.RUnlock()
+
+	return kc
+}
+
+// GetConditionSet retrieves the condition set for this resource.
+func (*KafkaChannelStatus) GetConditionSet() apis.ConditionSet {
+	channelCondSetLock.RLock()
+	defer channelCondSetLock.RUnlock()
+
 	return kc
 }
 
 // GetCondition returns the condition currently associated with the given type, or nil.
 func (cs *KafkaChannelStatus) GetCondition(t apis.ConditionType) *apis.Condition {
-	return kc.Manage(cs).GetCondition(t)
+	return cs.GetConditionSet().Manage(cs).GetCondition(t)
 }
 
 // IsReady returns true if the resource is ready overall.
 func (cs *KafkaChannelStatus) IsReady() bool {
-	return kc.Manage(cs).IsHappy()
+	return cs.GetConditionSet().Manage(cs).IsHappy()
 }
 
 // InitializeConditions sets relevant unset conditions to Unknown state.
 func (cs *KafkaChannelStatus) InitializeConditions() {
-	kc.Manage(cs).InitializeConditions()
+	cs.GetConditionSet().Manage(cs).InitializeConditions()
 }
 
 // SetAddress sets the address (as part of Addressable contract) and marks the correct condition.
@@ -94,20 +116,20 @@ func (cs *KafkaChannelStatus) SetAddress(url *apis.URL) {
 	if url != nil {
 		cs.Address.Hostname = url.Host
 		cs.Address.URL = url
-		kc.Manage(cs).MarkTrue(KafkaChannelConditionAddressable)
+		cs.GetConditionSet().Manage(cs).MarkTrue(KafkaChannelConditionAddressable)
 	} else {
 		cs.Address.Hostname = ""
 		cs.Address.URL = nil
-		kc.Manage(cs).MarkFalse(KafkaChannelConditionAddressable, "EmptyHostname", "hostname is the empty string")
+		cs.GetConditionSet().Manage(cs).MarkFalse(KafkaChannelConditionAddressable, "EmptyHostname", "hostname is the empty string")
 	}
 }
 
 func (cs *KafkaChannelStatus) MarkDispatcherFailed(reason, messageFormat string, messageA ...interface{}) {
-	kc.Manage(cs).MarkFalse(KafkaChannelConditionDispatcherReady, reason, messageFormat, messageA...)
+	cs.GetConditionSet().Manage(cs).MarkFalse(KafkaChannelConditionDispatcherReady, reason, messageFormat, messageA...)
 }
 
 func (cs *KafkaChannelStatus) MarkDispatcherUnknown(reason, messageFormat string, messageA ...interface{}) {
-	kc.Manage(cs).MarkUnknown(KafkaChannelConditionDispatcherReady, reason, messageFormat, messageA...)
+	cs.GetConditionSet().Manage(cs).MarkUnknown(KafkaChannelConditionDispatcherReady, reason, messageFormat, messageA...)
 }
 
 // TODO: Unify this with the ones from Eventing. Say: Broker, Trigger.
@@ -115,7 +137,7 @@ func (cs *KafkaChannelStatus) PropagateDispatcherStatus(ds *appsv1.DeploymentSta
 	for _, cond := range ds.Conditions {
 		if cond.Type == appsv1.DeploymentAvailable {
 			if cond.Status == corev1.ConditionTrue {
-				kc.Manage(cs).MarkTrue(KafkaChannelConditionDispatcherReady)
+				cs.GetConditionSet().Manage(cs).MarkTrue(KafkaChannelConditionDispatcherReady)
 			} else if cond.Status == corev1.ConditionFalse {
 				cs.MarkDispatcherFailed("DispatcherDeploymentFalse", "The status of Dispatcher Deployment is False: %s : %s", cond.Reason, cond.Message)
 			} else if cond.Status == corev1.ConditionUnknown {
@@ -126,45 +148,45 @@ func (cs *KafkaChannelStatus) PropagateDispatcherStatus(ds *appsv1.DeploymentSta
 }
 
 func (cs *KafkaChannelStatus) MarkServiceFailed(reason, messageFormat string, messageA ...interface{}) {
-	kc.Manage(cs).MarkFalse(KafkaChannelConditionServiceReady, reason, messageFormat, messageA...)
+	cs.GetConditionSet().Manage(cs).MarkFalse(KafkaChannelConditionServiceReady, reason, messageFormat, messageA...)
 }
 
 func (cs *KafkaChannelStatus) MarkServiceUnknown(reason, messageFormat string, messageA ...interface{}) {
-	kc.Manage(cs).MarkUnknown(KafkaChannelConditionServiceReady, reason, messageFormat, messageA...)
+	cs.GetConditionSet().Manage(cs).MarkUnknown(KafkaChannelConditionServiceReady, reason, messageFormat, messageA...)
 }
 
 func (cs *KafkaChannelStatus) MarkServiceTrue() {
-	kc.Manage(cs).MarkTrue(KafkaChannelConditionServiceReady)
+	cs.GetConditionSet().Manage(cs).MarkTrue(KafkaChannelConditionServiceReady)
 }
 
 func (cs *KafkaChannelStatus) MarkChannelServiceFailed(reason, messageFormat string, messageA ...interface{}) {
-	kc.Manage(cs).MarkFalse(KafkaChannelConditionChannelServiceReady, reason, messageFormat, messageA...)
+	cs.GetConditionSet().Manage(cs).MarkFalse(KafkaChannelConditionChannelServiceReady, reason, messageFormat, messageA...)
 }
 
 func (cs *KafkaChannelStatus) MarkChannelServiceTrue() {
-	kc.Manage(cs).MarkTrue(KafkaChannelConditionChannelServiceReady)
+	cs.GetConditionSet().Manage(cs).MarkTrue(KafkaChannelConditionChannelServiceReady)
 }
 
 func (cs *KafkaChannelStatus) MarkEndpointsFailed(reason, messageFormat string, messageA ...interface{}) {
-	kc.Manage(cs).MarkFalse(KafkaChannelConditionEndpointsReady, reason, messageFormat, messageA...)
+	cs.GetConditionSet().Manage(cs).MarkFalse(KafkaChannelConditionEndpointsReady, reason, messageFormat, messageA...)
 }
 
 func (cs *KafkaChannelStatus) MarkEndpointsTrue() {
-	kc.Manage(cs).MarkTrue(KafkaChannelConditionEndpointsReady)
+	cs.GetConditionSet().Manage(cs).MarkTrue(KafkaChannelConditionEndpointsReady)
 }
 
 func (cs *KafkaChannelStatus) MarkTopicTrue() {
-	kc.Manage(cs).MarkTrue(KafkaChannelConditionTopicReady)
+	cs.GetConditionSet().Manage(cs).MarkTrue(KafkaChannelConditionTopicReady)
 }
 
 func (cs *KafkaChannelStatus) MarkTopicFailed(reason, messageFormat string, messageA ...interface{}) {
-	kc.Manage(cs).MarkFalse(KafkaChannelConditionTopicReady, reason, messageFormat, messageA...)
+	cs.GetConditionSet().Manage(cs).MarkFalse(KafkaChannelConditionTopicReady, reason, messageFormat, messageA...)
 }
 
 func (cs *KafkaChannelStatus) MarkConfigTrue() {
-	kc.Manage(cs).MarkTrue(KafkaChannelConditionConfigReady)
+	cs.GetConditionSet().Manage(cs).MarkTrue(KafkaChannelConditionConfigReady)
 }
 
 func (cs *KafkaChannelStatus) MarkConfigFailed(reason, messageFormat string, messageA ...interface{}) {
-	kc.Manage(cs).MarkFalse(KafkaChannelConditionConfigReady, reason, messageFormat, messageA...)
+	cs.GetConditionSet().Manage(cs).MarkFalse(KafkaChannelConditionConfigReady, reason, messageFormat, messageA...)
 }

--- a/pkg/apis/messaging/v1alpha1/kafka_channel_lifecycle_test.go
+++ b/pkg/apis/messaging/v1alpha1/kafka_channel_lifecycle_test.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"knative.dev/pkg/apis"
 
 	"github.com/google/go-cmp/cmp"
@@ -418,4 +419,16 @@ func TestKafkaChannelStatus_SetAddressable(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRegisterAlternateKafkaChannelConditionSet(t *testing.T) {
+
+	cs := apis.NewLivingConditionSet(apis.ConditionReady, "hello")
+
+	RegisterAlternateKafkaChannelConditionSet(cs)
+
+	kc := KafkaChannel{}
+
+	assert.Equal(t, cs, kc.GetConditionSet())
+	assert.Equal(t, cs, kc.Status.GetConditionSet())
 }

--- a/pkg/apis/messaging/v1beta1/kafka_channel_lifecycle_test.go
+++ b/pkg/apis/messaging/v1beta1/kafka_channel_lifecycle_test.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"knative.dev/pkg/apis"
 
 	"github.com/google/go-cmp/cmp"
@@ -433,4 +434,16 @@ func TestKafkaChannelStatus_SetAddressable(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRegisterAlternateKafkaChannelConditionSet(t *testing.T) {
+
+	cs := apis.NewLivingConditionSet(apis.ConditionReady, "hello")
+
+	RegisterAlternateKafkaChannelConditionSet(cs)
+
+	kc := KafkaChannel{}
+
+	assert.Equal(t, cs, kc.GetConditionSet())
+	assert.Equal(t, cs, kc.Status.GetConditionSet())
 }


### PR DESCRIPTION
Different KafkaChannel implementation might want to have different
conditions, this PR adds the ability to register custom conditions
like we did upstream in https://github.com/knative/eventing/pull/3545
for the Broker.

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

Fixes #26 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Allow registering custom conditions for different channel implementation
