### PR TITLE
Revert custom .ko.yaml back to eventing-contrib value.

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: gcr.io/distroless/static-debian10
+defaultBaseImage: gcr.io/distroless/static:nonroot


### PR DESCRIPTION
The `eventing-kafka` repository historically used varying ko base images dependent upon the needs of the "distributed" KafkaChannel implementation.  Now that this implementation is based on Sarama, and the `eventing-contrib` repo has been merged into this repo, we can and should switch back to the "standard" base image used previously by the eventing-contrib repo and now used by most of the sandbox repos.