### PR TITLE
populate newly required env vars in receiver/dispatcher

### DIFF
--- a/pkg/channel/distributed/controller/constants/constants.go
+++ b/pkg/channel/distributed/controller/constants/constants.go
@@ -61,6 +61,10 @@ const (
 	// Eventing-Kafka Finalizers Prefix
 	EventingKafkaFinalizerPrefix = "eventing-kafka/"
 
+	// Container Names
+	DispatcherContainerName = "kafkachannel-dispatcher"
+	ReceiverContainerName   = "kafkachannel-receiver"
+
 	// Labels
 	AppLabel                    = "app"
 	KafkaChannelNameLabel       = "kafkachannel-name"

--- a/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
+++ b/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
@@ -329,6 +329,18 @@ func (r *Reconciler) dispatcherDeploymentEnvVars(channel *kafkav1beta1.KafkaChan
 			Value: commonconstants.KnativeEventingNamespace,
 		},
 		{
+			Name: commonenv.PodNameEnvVarKey,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name:  commonenv.ContainerNameEnvVarKEy,
+			Value: constants.DispatcherContainerName,
+		},
+		{
 			Name:  commonenv.KnativeLoggingConfigMapNameEnvVarKey,
 			Value: logging.ConfigMapName(),
 		},

--- a/pkg/channel/distributed/controller/kafkasecret/receiver.go
+++ b/pkg/channel/distributed/controller/kafkasecret/receiver.go
@@ -194,7 +194,7 @@ func (r *Reconciler) reconcileReceiverDeployment(ctx context.Context, secret *co
 
 			// Then Create The New Receiver Deployment
 			r.logger.Info("Receiver Deployment Not Found - Creating New One")
-			deployment, err := r.newChannelDeployment(secret)
+			deployment, err := r.newReceiverDeployment(secret)
 			if err != nil {
 				r.logger.Error("Failed To Create Receiver Deployment YAML", zap.Error(err))
 				return err
@@ -237,7 +237,7 @@ func (r *Reconciler) getReceiverDeployment(secret *corev1.Secret) (*appsv1.Deplo
 }
 
 // Create Receiver Deployment Model For The Specified Secret
-func (r *Reconciler) newChannelDeployment(secret *corev1.Secret) (*appsv1.Deployment, error) {
+func (r *Reconciler) newReceiverDeployment(secret *corev1.Secret) (*appsv1.Deployment, error) {
 
 	// Get The Receiver Deployment Name (One Receiver Deployment Per Kafka Auth Secret)
 	deploymentName := util.ReceiverDnsSafeName(secret.Name)
@@ -345,6 +345,18 @@ func (r *Reconciler) receiverDeploymentEnvVars(secret *corev1.Secret) ([]corev1.
 		{
 			Name:  system.NamespaceEnvKey,
 			Value: commonconstants.KnativeEventingNamespace,
+		},
+		{
+			Name: commonenv.PodNameEnvVarKey,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name:  commonenv.ContainerNameEnvVarKEy,
+			Value: constants.ReceiverContainerName,
 		},
 		{
 			Name:  commonenv.KnativeLoggingConfigMapNameEnvVarKey,

--- a/pkg/channel/distributed/controller/testing/data.go
+++ b/pkg/channel/distributed/controller/testing/data.go
@@ -558,6 +558,18 @@ func NewKafkaChannelReceiverDeployment() *appsv1.Deployment {
 									Value: commonconstants.KnativeEventingNamespace,
 								},
 								{
+									Name: commonenv.PodNameEnvVarKey,
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+								{
+									Name:  commonenv.ContainerNameEnvVarKEy,
+									Value: constants.ReceiverContainerName,
+								},
+								{
 									Name:  commonenv.KnativeLoggingConfigMapNameEnvVarKey,
 									Value: logging.ConfigMapName(),
 								},
@@ -737,6 +749,18 @@ func NewKafkaChannelDispatcherDeployment() *appsv1.Deployment {
 								{
 									Name:  system.NamespaceEnvKey,
 									Value: commonconstants.KnativeEventingNamespace,
+								},
+								{
+									Name: commonenv.PodNameEnvVarKey,
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+								{
+									Name:  commonenv.ContainerNameEnvVarKEy,
+									Value: constants.DispatcherContainerName,
 								},
 								{
 									Name:  commonenv.KnativeLoggingConfigMapNameEnvVarKey,


### PR DESCRIPTION
The recent merge of https://github.com/knative-sandbox/eventing-kafka/pull/133 has broken the distributed kafka channel implementation.  It added new required environment variables to the receiver/dispatcher but failed to populate them in Deployment created by the controller.  This PR provides the missing logic to do so.

> Note - This was not caught by automated testing because we are still in the process of standing up our e2e (integration) tests.  All unit tests were/are passing.