### PR TITLE
E2e remove source from distributed

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -356,8 +356,8 @@ function test_distributed_channel() {
   install_distributed_channel_crds || return 1
 
   # TODO: Enable v1alpha1 testing once we have the auto-converting webhook in our config/yaml
-  go_test_e2e -timeout=40m -test.parallel=${TEST_PARALLEL} ./test/e2e -channels=messaging.knative.dev/v1beta1:KafkaChannel  || fail_test
-  go_test_e2e -timeout=5m -test.parallel=${TEST_PARALLEL} ./test/conformance -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test
+  go_test_e2e -tags=e2e -timeout=40m -test.parallel=${TEST_PARALLEL} ./test/e2e -channels=messaging.knative.dev/v1beta1:KafkaChannel  || fail_test
+  go_test_e2e -tags=e2e -timeout=5m -test.parallel=${TEST_PARALLEL} ./test/conformance -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test
 
   uninstall_channel_crds || return 1
 }

--- a/test/e2e/kafka_binding_test.go
+++ b/test/e2e/kafka_binding_test.go
@@ -1,4 +1,5 @@
 //+build e2e
+//+build source
 
 /*
 Copyright 2019 The Knative Authors

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -1,4 +1,5 @@
 //+build e2e
+//+build source
 
 /*
 Copyright 2020 The Knative Authors

--- a/test/e2e/kafka_source_test.go
+++ b/test/e2e/kafka_source_test.go
@@ -1,4 +1,5 @@
 //+build e2e
+//+build source
 
 /*
 Copyright 2019 The Knative Authors


### PR DESCRIPTION
## Proposed Changes

- 🧽 Remove the "source" tests from the distributed channel tests, as they are duplicated by the consolidated tests.  A future enhancement to separate the source tests into their own distinct test would probably be good but for now this at least avoids the glaring redundancy.
- 🐛 Increased timeout on channel teardown/cleanup for "ko delete" and added some namespace/kafkachannel logging to help diagnose a sporadic failure of the distributed tests
