### PR TITLE
[consolidated] Disable KafkaChannel dispatcher leader election

### DIFF
--- a/cmd/channel/consolidated/dispatcher/main.go
+++ b/cmd/channel/consolidated/dispatcher/main.go
@@ -35,5 +35,8 @@ func main() {
 		ctx = injection.WithNamespaceScope(ctx, ns)
 	}
 
+	// Do not run the dispatcher in leader-election mode
+	ctx = sharedmain.WithHADisabled(ctx)
+
 	sharedmain.MainWithContext(ctx, component, controller.NewController)
 }

--- a/config/channel/consolidated/roles/dispatcher-clusterrole.yaml
+++ b/config/channel/consolidated/roles/dispatcher-clusterrole.yaml
@@ -68,14 +68,3 @@ rules:
     verbs:
       - create
       - patch
-  - apiGroups:
-      - "coordination.k8s.io"
-    resources:
-      - leases
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - patch
-      - update


### PR DESCRIPTION
Fixes https://github.com/knative/eventing-contrib/issues/1659

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-  Disable KafkaChannel dispatcher leader election
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 The consolidated KafkaChannel dispatcher does not attempt anymore to acquire a lease
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

Must to be backported to 0.17
