### PR TITLE
Don't crash when KafkaSource dispatcher fails to start consumer group

### DIFF
--- a/pkg/source/adapter/adapter_test.go
+++ b/pkg/source/adapter/adapter_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/v2/types"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/source"
@@ -441,9 +440,24 @@ func TestAdapter_Start(t *testing.T) { // just increase code coverage
 	_ = os.Setenv("KAFKA_BOOTSTRAP_SERVERS", "my-cluster-kafka-bootstrap.my-kafka-namespace:9092")
 
 	a := NewAdapter(ctx, NewEnvConfig(), nil, nil)
-	require.Panics(t, func() {
-		_ = a.Start(ctx)
-	})
+
+	stopped := make(chan bool, 1)
+	go func() {
+		err := a.Start(ctx)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		stopped <- true
+	}()
+
+	// Wait a bit to make sure the adapter gets a few runs
+	time.Sleep(2 * time.Second)
 
 	cancel()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Error("adapter failed to stop after 5 seconds")
+	case <-stopped:
+	}
 }

--- a/pkg/source/adapter/adapter_test.go
+++ b/pkg/source/adapter/adapter_test.go
@@ -445,7 +445,7 @@ func TestAdapter_Start(t *testing.T) { // just increase code coverage
 	go func() {
 		err := a.Start(ctx)
 		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+			t.Error("unexpected error:", err)
 		}
 		stopped <- true
 	}()


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Loop forever when config is invalid and/or the broker is not yet accessible
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix crash when the KafkaSource dispatcher fails to start consumer group
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
