### PR TITLE
[Consolidated] Use SyncProducer to provide safer delivery  

### DIFF
--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -50,7 +50,7 @@ type KafkaDispatcher struct {
 	receiver   *eventingchannels.MessageReceiver
 	dispatcher *eventingchannels.MessageDispatcherImpl
 
-	kafkaAsyncProducer   sarama.AsyncProducer
+	kafkaSyncProducer    sarama.SyncProducer
 	channelSubscriptions map[eventingchannels.ChannelReference][]types.UID
 	subsConsumerGroups   map[types.UID]sarama.ConsumerGroup
 	subscriptions        map[types.UID]Subscription
@@ -90,9 +90,10 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 	conf := sarama.NewConfig()
 	conf.Version = sarama.V2_0_0_0
 	conf.ClientID = args.ClientID
-	conf.Consumer.Return.Errors = true // Returns the errors in ConsumerGroup#Errors() https://godoc.org/github.com/Shopify/sarama#ConsumerGroup
+	conf.Consumer.Return.Errors = true    // Returns the errors in ConsumerGroup#Errors() https://godoc.org/github.com/Shopify/sarama#ConsumerGroup
+	conf.Producer.Return.Successes = true // Must be enabled for sync producer
 
-	producer, err := sarama.NewAsyncProducer(args.Brokers, conf)
+	producer, err := sarama.NewSyncProducer(args.Brokers, conf)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create kafka producer against Kafka bootstrap servers %v : %v", args.Brokers, err)
 	}
@@ -103,7 +104,7 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 		channelSubscriptions: make(map[eventingchannels.ChannelReference][]types.UID),
 		subsConsumerGroups:   make(map[types.UID]sarama.ConsumerGroup),
 		subscriptions:        make(map[types.UID]Subscription),
-		kafkaAsyncProducer:   producer,
+		kafkaSyncProducer:    producer,
 		logger:               args.Logger,
 		topicFunc:            args.TopicFunc,
 	}
@@ -131,8 +132,15 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 
 			kafkaProducerMessage.Headers = append(kafkaProducerMessage.Headers, tracing.SerializeTrace(trace.FromContext(ctx).SpanContext())...)
 
-			dispatcher.kafkaAsyncProducer.Input() <- &kafkaProducerMessage
-			return nil
+			partition, offset, err := dispatcher.kafkaSyncProducer.SendMessage(&kafkaProducerMessage)
+
+			if err == nil {
+				dispatcher.logger.Debugw("message sent", zap.Int32("partition", partition), zap.Int64("offset", offset))
+			} else {
+				dispatcher.logger.Warnw("message not sent", zap.Error(err))
+			}
+
+			return err
 		},
 		args.Logger.Desugar(),
 		reporter,
@@ -313,23 +321,6 @@ func (d *KafkaDispatcher) Start(ctx context.Context) error {
 	if d.receiver == nil {
 		return fmt.Errorf("message receiver is not set")
 	}
-
-	if d.kafkaAsyncProducer == nil {
-		return fmt.Errorf("kafkaAsyncProducer is not set")
-	}
-
-	go func() {
-		for {
-			select {
-			case e := <-d.kafkaAsyncProducer.Errors():
-				d.logger.Warn("Got", zap.Error(e))
-			case s := <-d.kafkaAsyncProducer.Successes():
-				d.logger.Info("Sent", zap.Any("success", s))
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
 
 	return d.receiver.Start(ctx)
 }

--- a/pkg/channel/consolidated/dispatcher/dispatcher_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_test.go
@@ -19,12 +19,10 @@ package dispatcher
 import (
 	"context"
 	"errors"
-	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/Shopify/sarama"
-	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap"
@@ -422,26 +420,9 @@ func TestUnsubscribeUnknownSub(t *testing.T) {
 
 func TestKafkaDispatcher_Start(t *testing.T) {
 	d := &KafkaDispatcher{}
-	reporter := eventingchannels.NewStatsReporter("testcontainer", "testpod")
 	err := d.Start(context.TODO())
 	if err == nil {
 		t.Errorf("Expected error want %s, got %s", "message receiver is not set", err)
-	}
-
-	receiver, err := eventingchannels.NewMessageReceiver(
-		func(ctx context.Context, channel eventingchannels.ChannelReference, message binding.Message, _ []binding.Transformer, _ http.Header) error {
-			return nil
-		},
-		zap.NewNop(),
-		reporter,
-		eventingchannels.ResolveMessageChannelFromHostHeader(d.getChannelReferenceFromHost))
-	if err != nil {
-		t.Fatalf("Error creating new message receiver. Error:%s", err)
-	}
-	d.receiver = receiver
-	err = d.Start(context.TODO())
-	if err == nil {
-		t.Errorf("Expected error want %s, got %s", "kafkaAsyncProducer is not set", err)
 	}
 }
 


### PR DESCRIPTION
 <!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Consolidated KafkaChannel dispatcher now handles produced event synchronously 
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 The consolidated KafkaChannel now relies by default on SyncProducer for safer event production.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
