### PR TITLE
Upconvert kafka errors to sarama TopicError

### DIFF
--- a/pkg/channel/distributed/common/kafka/admin/admin_eventhub.go
+++ b/pkg/channel/distributed/common/kafka/admin/admin_eventhub.go
@@ -176,7 +176,7 @@ func (c *EventHubAdminClient) DeleteTopic(ctx context.Context, topicName string)
 
 		// Delete API Returns Success For Non-Existent Topics - Nothing To Map - Just Return Error
 		c.logger.Error("Failed To Delete EventHub", zap.String("TopicName", topicName), zap.Error(err))
-		return adminutil.PromoteErrorToTopicError(err)
+		return adminutil.NewTopicError(sarama.ErrUnknown, err.Error())
 	}
 
 	// Remove The EventHub From The Cache

--- a/pkg/channel/distributed/common/kafka/admin/util/util_test.go
+++ b/pkg/channel/distributed/common/kafka/admin/util/util_test.go
@@ -151,7 +151,7 @@ func TestPromoteErrorToTopicError(t *testing.T) {
 	topicError = PromoteErrorToTopicError(invalidKError)
 	assert.NotNil(t, topicError)
 	assert.Equal(t, sarama.ErrUnknown, topicError.Err)
-	assert.Equal(t, fmt.Sprintf("Unknown error, how did this happen? Error code = %d", invalidKError), *topicError.ErrMsg)
+	assert.Equal(t, fmt.Sprint("Unknown error, how did this happen? Error code = ", int(invalidKError)), *topicError.ErrMsg)
 
 	// Test Valid TopicError
 	topicErrorMessage := "TopicErrorMessage"

--- a/pkg/channel/distributed/controller/kafkachannel/topic.go
+++ b/pkg/channel/distributed/controller/kafkachannel/topic.go
@@ -97,6 +97,7 @@ func (r *Reconciler) createTopic(ctx context.Context, logger *zap.Logger, topicN
 	// Attempt To Create The Topic & Process TopicError Results (Including Success ;)
 	err := r.adminClient.CreateTopic(ctx, topicName, topicDetail)
 	if err != nil {
+		logger := logger.With(zap.Int16("KError", int16(err.Err)))
 		switch err.Err {
 		case sarama.ErrNoError:
 			logger.Info("Successfully Created New Kafka Topic (ErrNoError)")
@@ -105,7 +106,7 @@ func (r *Reconciler) createTopic(ctx context.Context, logger *zap.Logger, topicN
 			logger.Info("Kafka Topic Already Exists - No Creation Required")
 			return nil
 		default:
-			logger.Error("Failed To Create Topic", zap.Any("TopicError", err))
+			logger.Error("Failed To Create Topic")
 			return err
 		}
 	} else {
@@ -120,6 +121,7 @@ func (r *Reconciler) deleteTopic(ctx context.Context, logger *zap.Logger, topicN
 	// Attempt To Delete The Topic & Process Results
 	err := r.adminClient.DeleteTopic(ctx, topicName)
 	if err != nil {
+		logger := logger.With(zap.Int16("KError", int16(err.Err)))
 		switch err.Err {
 		case sarama.ErrNoError:
 			logger.Info("Successfully Deleted Existing Kafka Topic (ErrNoError)")
@@ -134,14 +136,14 @@ func (r *Reconciler) deleteTopic(ctx context.Context, logger *zap.Logger, topicN
 				// happen when an EventHub could not be created due to exceeding the number of allowable EventHubs.  The
 				// KafkaChannel is then in an "UNKNOWN" state having never been fully reconciled.  We want to swallow this
 				// error here so that the deletion of the Topic / EventHub doesn't block the deletion of the KafkaChannel.
-				logger.Warn("Unable To Delete Topic Due To Invalid Kafka Topic Config (Likely EventHub Namespace Cache)", zap.Error(err))
+				logger.Warn("Unable To Delete Topic Due To Invalid Kafka Topic Config (Likely EventHub Namespace Cache)")
 				return nil
 			} else {
-				logger.Error("Failed To Delete Topic Due To Invalid Config", zap.Any("TopicError", err))
+				logger.Error("Failed To Delete Topic Due To Invalid Config")
 				return err
 			}
 		default:
-			logger.Error("Failed To Delete Topic", zap.Any("TopicError", err))
+			logger.Error("Failed To Delete Topic")
 			return err
 		}
 	} else {


### PR DESCRIPTION
It seems that Strimzi can return normal Golang errors instead of Sarama TopicErrors (which are errors).  The distributed channel contains logic for "promoting" these to TopicErrors for consistent handling upstream.  This PR enhances that implementation to String match the normal Golang errors against the Sarama/Kafka error strings.  If a match is found then the promotion is accurately performed to a specific KError instead of just to ErrUnknown.

The specific use case which highlighted this was an edge case and was ultimately handled correctly by the reconciler, but the logging was somewhat confusing.  To reproduce manually do the following...
1. Create a KafkaChannel
2. Manually add some bogus finalizer to prevent deletion.
3. Delete the KafkaChannel
4. Review logs and see an error with the following...
```
"TopicError":"kafka server: Unexpected (unknown?) server error. - kafka server: Request was for a topic or partition that does not exist on this broker.",
```
...which has nested the `does not exist` error string inside an `unknown`.   This will no longer happen and the logging / handling will be more precise.