### PR TITLE
Move AuthConfig code to one place and add tests

### DIFF
--- a/pkg/channel/consolidated/utils/util.go
+++ b/pkg/channel/consolidated/utils/util.go
@@ -46,9 +46,6 @@ const (
 	SaslPassword = "password"
 	SaslType     = "saslType"
 
-	SASLTypeSCRAMSHA256 = "scram_sha256"
-	SASLTypeSCRAMSHA512 = "scram_sha512"
-
 	KafkaChannelSeparator = "."
 
 	knativeKafkaTopicPrefix = "knative-messaging-kafka"

--- a/pkg/source/client.go
+++ b/pkg/source/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"time"
 
 	"knative.dev/eventing-kafka/pkg/channel/consolidated/utils"
@@ -132,13 +133,22 @@ func MakeAdminClient(clientID string, kafkaAuthCfg *utils.KafkaAuthConfig, boots
 	saramaConf.Version = sarama.V2_0_0_0
 	saramaConf.ClientID = clientID
 
+	err := UpdateSaramaConfigWithKafkaAuthConfig(saramaConf, kafkaAuthCfg)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating the Admin Client: %w", err)
+	}
+
+	return sarama.NewClusterAdmin(bootstrapServers, saramaConf)
+}
+
+func UpdateSaramaConfigWithKafkaAuthConfig(saramaConf *sarama.Config, kafkaAuthCfg *utils.KafkaAuthConfig) error {
 	if kafkaAuthCfg != nil {
 		// tls
 		if kafkaAuthCfg.TLS != nil {
 			saramaConf.Net.TLS.Enable = true
 			tlsConfig, err := NewTLSConfig(kafkaAuthCfg.TLS.Usercert, kafkaAuthCfg.TLS.Userkey, kafkaAuthCfg.TLS.Cacert)
 			if err != nil {
-				return nil, err
+				return fmt.Errorf("Error creating TLS config: %w", err)
 			}
 			saramaConf.Net.TLS.Config = tlsConfig
 		}
@@ -147,20 +157,25 @@ func MakeAdminClient(clientID string, kafkaAuthCfg *utils.KafkaAuthConfig, boots
 			saramaConf.Net.SASL.Enable = true
 			saramaConf.Net.SASL.Handshake = true
 
-			// if SASLTypeSCRAMSHA256 is provided we use that. Defaulting to SASLTypeSCRAMSHA512
-			if kafkaAuthCfg.SASL.SaslType == utils.SASLTypeSCRAMSHA256 {
+			// if SaslType is not provided we are defaulting to PLAIN
+			if kafkaAuthCfg.SASL.SaslType == "" {
+				kafkaAuthCfg.SASL.SaslType = sarama.SASLTypePlaintext
+			}
+
+			if kafkaAuthCfg.SASL.SaslType == sarama.SASLTypeSCRAMSHA256 {
 				saramaConf.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA256} }
 				saramaConf.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
-			} else {
+			}
+
+			if kafkaAuthCfg.SASL.SaslType == sarama.SASLTypeSCRAMSHA512 {
 				saramaConf.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
 				saramaConf.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
 			}
-
 			saramaConf.Net.SASL.User = kafkaAuthCfg.SASL.User
 			saramaConf.Net.SASL.Password = kafkaAuthCfg.SASL.Password
 		}
 	}
-	return sarama.NewClusterAdmin(bootstrapServers, saramaConf)
+	return nil
 }
 
 // verifyCertSkipHostname verifies certificates in the same way that the

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -364,6 +364,7 @@ function create_auth_secrets() {
   kubectl create secret --namespace knative-eventing generic strimzi-sasl-secret \
     --from-literal=ca.crt="$STRIMZI_CRT" \
     --from-literal=password="$SASL_PASSWD" \
+    --from-literal=saslType="SCRAM-SHA-512" \
     --from-literal=user="my-sasl-user"
 }
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

- If no `saslType` is provided, we should default to "PLAIN" (the source only supports plain)
- moving code to one central place
- adding tests

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
