### PR TITLE
fix half-baked table tests

### DIFF
--- a/pkg/channel/distributed/common/k8s/util_test.go
+++ b/pkg/channel/distributed/common/k8s/util_test.go
@@ -42,7 +42,9 @@ func TestTruncateLabelValue(t *testing.T) {
 
 	// Run The TestCases
 	for _, testCase := range testCases {
-		result := TruncateLabelValue(testCase.Value)
-		assert.Equal(t, result, testCase.Result)
+		t.Run(testCase.Value, func(t *testing.T) {
+			result := TruncateLabelValue(testCase.Value)
+			assert.Equal(t, result, testCase.Result)
+		})
 	}
 }

--- a/pkg/channel/distributed/controller/config/config_test.go
+++ b/pkg/channel/distributed/controller/config/config_test.go
@@ -169,48 +169,47 @@ func TestVerifyConfiguration(t *testing.T) {
 	testCase.expectedError = ControllerConfigurationError("Invalid / Unknown Kafka Admin Type: invalidadmintype")
 	testCases = append(testCases, testCase)
 
-	// Loop Over All The TestCases
 	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testConfig := &config.EventingKafkaConfig{}
+			testConfig.Kafka.Topic.DefaultNumPartitions = testCase.kafkaTopicDefaultNumPartitions
+			testConfig.Kafka.Topic.DefaultReplicationFactor = testCase.kafkaTopicDefaultReplicationFactor
+			testConfig.Kafka.Topic.DefaultRetentionMillis = testCase.kafkaTopicDefaultRetentionMillis
+			testConfig.Kafka.AdminType = testCase.kafkaAdminType
+			testConfig.Dispatcher.CpuLimit = testCase.dispatcherCpuLimit
+			testConfig.Dispatcher.CpuRequest = testCase.dispatcherCpuRequest
+			testConfig.Dispatcher.MemoryLimit = testCase.dispatcherMemoryLimit
+			testConfig.Dispatcher.MemoryRequest = testCase.dispatcherMemoryRequest
+			testConfig.Dispatcher.Replicas = testCase.dispatcherReplicas
+			testConfig.Receiver.CpuLimit = testCase.channelCpuLimit
+			testConfig.Receiver.CpuRequest = testCase.channelCpuRequest
+			testConfig.Receiver.MemoryLimit = testCase.channelMemoryLimit
+			testConfig.Receiver.MemoryRequest = testCase.channelMemoryRequest
+			testConfig.Receiver.Replicas = testCase.channelReplicas
 
-		testConfig := &config.EventingKafkaConfig{}
-		testConfig.Kafka.Topic.DefaultNumPartitions = testCase.kafkaTopicDefaultNumPartitions
-		testConfig.Kafka.Topic.DefaultReplicationFactor = testCase.kafkaTopicDefaultReplicationFactor
-		testConfig.Kafka.Topic.DefaultRetentionMillis = testCase.kafkaTopicDefaultRetentionMillis
-		testConfig.Kafka.AdminType = testCase.kafkaAdminType
-		testConfig.Dispatcher.CpuLimit = testCase.dispatcherCpuLimit
-		testConfig.Dispatcher.CpuRequest = testCase.dispatcherCpuRequest
-		testConfig.Dispatcher.MemoryLimit = testCase.dispatcherMemoryLimit
-		testConfig.Dispatcher.MemoryRequest = testCase.dispatcherMemoryRequest
-		testConfig.Dispatcher.Replicas = testCase.dispatcherReplicas
-		testConfig.Receiver.CpuLimit = testCase.channelCpuLimit
-		testConfig.Receiver.CpuRequest = testCase.channelCpuRequest
-		testConfig.Receiver.MemoryLimit = testCase.channelMemoryLimit
-		testConfig.Receiver.MemoryRequest = testCase.channelMemoryRequest
-		testConfig.Receiver.Replicas = testCase.channelReplicas
+			// Perform The Test
+			err := VerifyConfiguration(testConfig)
 
-		// Perform The Test
-		err := VerifyConfiguration(testConfig)
-
-		// Verify The Results
-		if testCase.expectedError == nil {
-			assert.Nil(t, err)
-			assert.Equal(t, testCase.kafkaTopicDefaultNumPartitions, testConfig.Kafka.Topic.DefaultNumPartitions)
-			assert.Equal(t, testCase.kafkaTopicDefaultReplicationFactor, testConfig.Kafka.Topic.DefaultReplicationFactor)
-			assert.Equal(t, testCase.kafkaTopicDefaultRetentionMillis, testConfig.Kafka.Topic.DefaultRetentionMillis)
-			assert.Equal(t, testCase.kafkaAdminType, testConfig.Kafka.AdminType)
-			assert.Equal(t, testCase.dispatcherCpuLimit, testConfig.Dispatcher.CpuLimit)
-			assert.Equal(t, testCase.dispatcherCpuRequest, testConfig.Dispatcher.CpuRequest)
-			assert.Equal(t, testCase.dispatcherMemoryLimit, testConfig.Dispatcher.MemoryLimit)
-			assert.Equal(t, testCase.dispatcherMemoryRequest, testConfig.Dispatcher.MemoryRequest)
-			assert.Equal(t, testCase.dispatcherReplicas, testConfig.Dispatcher.Replicas)
-			assert.Equal(t, testCase.channelCpuLimit, testConfig.Receiver.CpuLimit)
-			assert.Equal(t, testCase.channelCpuRequest, testConfig.Receiver.CpuRequest)
-			assert.Equal(t, testCase.channelMemoryLimit, testConfig.Receiver.MemoryLimit)
-			assert.Equal(t, testCase.channelMemoryRequest, testConfig.Receiver.MemoryRequest)
-			assert.Equal(t, testCase.channelReplicas, testConfig.Receiver.Replicas)
-		} else {
-			assert.Equal(t, testCase.expectedError, err)
-		}
-
+			// Verify The Results
+			if testCase.expectedError == nil {
+				assert.Nil(t, err)
+				assert.Equal(t, testCase.kafkaTopicDefaultNumPartitions, testConfig.Kafka.Topic.DefaultNumPartitions)
+				assert.Equal(t, testCase.kafkaTopicDefaultReplicationFactor, testConfig.Kafka.Topic.DefaultReplicationFactor)
+				assert.Equal(t, testCase.kafkaTopicDefaultRetentionMillis, testConfig.Kafka.Topic.DefaultRetentionMillis)
+				assert.Equal(t, testCase.kafkaAdminType, testConfig.Kafka.AdminType)
+				assert.Equal(t, testCase.dispatcherCpuLimit, testConfig.Dispatcher.CpuLimit)
+				assert.Equal(t, testCase.dispatcherCpuRequest, testConfig.Dispatcher.CpuRequest)
+				assert.Equal(t, testCase.dispatcherMemoryLimit, testConfig.Dispatcher.MemoryLimit)
+				assert.Equal(t, testCase.dispatcherMemoryRequest, testConfig.Dispatcher.MemoryRequest)
+				assert.Equal(t, testCase.dispatcherReplicas, testConfig.Dispatcher.Replicas)
+				assert.Equal(t, testCase.channelCpuLimit, testConfig.Receiver.CpuLimit)
+				assert.Equal(t, testCase.channelCpuRequest, testConfig.Receiver.CpuRequest)
+				assert.Equal(t, testCase.channelMemoryLimit, testConfig.Receiver.MemoryLimit)
+				assert.Equal(t, testCase.channelMemoryRequest, testConfig.Receiver.MemoryRequest)
+				assert.Equal(t, testCase.channelReplicas, testConfig.Receiver.Replicas)
+			} else {
+				assert.Equal(t, testCase.expectedError, err)
+			}
+		})
 	}
 }

--- a/pkg/channel/distributed/controller/env/environment_test.go
+++ b/pkg/channel/distributed/controller/env/environment_test.go
@@ -110,29 +110,29 @@ func TestGetEnvironment(t *testing.T) {
 
 	// Loop Over All The TestCases
 	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// (Re)Setup The Environment Variables From TestCase
+			setupTestEnvironment(t, testCase)
 
-		// (Re)Setup The Environment Variables From TestCase
-		setupTestEnvironment(t, testCase)
+			// Perform The Test
+			environment, err := GetEnvironment(logger)
 
-		// Perform The Test
-		environment, err := GetEnvironment(logger)
+			// Verify The Results
+			if testCase.expectedError == nil {
 
-		// Verify The Results
-		if testCase.expectedError == nil {
+				assert.Nil(t, err)
+				assert.NotNil(t, environment)
+				assert.Equal(t, testCase.serviceAccount, environment.ServiceAccount)
+				assert.Equal(t, testCase.metricsPort, strconv.Itoa(environment.MetricsPort))
+				assert.Equal(t, testCase.channelImage, environment.ReceiverImage)
+				assert.Equal(t, testCase.dispatcherImage, environment.DispatcherImage)
+				assert.Equal(t, testCase.expectedResyncPeriod, strconv.Itoa(int(environment.ResyncPeriod/time.Minute)))
 
-			assert.Nil(t, err)
-			assert.NotNil(t, environment)
-			assert.Equal(t, testCase.serviceAccount, environment.ServiceAccount)
-			assert.Equal(t, testCase.metricsPort, strconv.Itoa(environment.MetricsPort))
-			assert.Equal(t, testCase.channelImage, environment.ReceiverImage)
-			assert.Equal(t, testCase.dispatcherImage, environment.DispatcherImage)
-			assert.Equal(t, testCase.expectedResyncPeriod, strconv.Itoa(int(environment.ResyncPeriod/time.Minute)))
-
-		} else {
-			assert.Equal(t, testCase.expectedError, err)
-			assert.Nil(t, environment)
-		}
-
+			} else {
+				assert.Equal(t, testCase.expectedError, err)
+				assert.Nil(t, environment)
+			}
+		})
 	}
 }
 

--- a/pkg/channel/distributed/controller/util/dispatcher_test.go
+++ b/pkg/channel/distributed/controller/util/dispatcher_test.go
@@ -63,18 +63,21 @@ func TestDispatcherDnsSafeName(t *testing.T) {
 
 	// Run The TestCases
 	for _, testCase := range testCases {
-		// Test Data
-		channel := &kafkav1beta1.KafkaChannel{ObjectMeta: metav1.ObjectMeta{Name: testCase.Name, Namespace: testCase.Namespace}}
+		t.Run(testCase.Name, func(t *testing.T) {
 
-		// Perform The Test
-		actualResult := DispatcherDnsSafeName(channel)
-		hash := GenerateHash(testCase.Name+testCase.Namespace, 8)
-		truncateName := fmt.Sprintf("%.26s", testCase.Name)
-		truncateNamespace := fmt.Sprintf("%.16s", testCase.Namespace)
-		expectedResult := fmt.Sprintf("%s-%s-%s-dispatcher", truncateName, truncateNamespace, hash)
+			// Test Data
+			channel := &kafkav1beta1.KafkaChannel{ObjectMeta: metav1.ObjectMeta{Name: testCase.Name, Namespace: testCase.Namespace}}
 
-		// Verify The Results
-		assert.Equal(t, expectedResult, actualResult)
+			// Perform The Test
+			actualResult := DispatcherDnsSafeName(channel)
+			hash := GenerateHash(testCase.Name+testCase.Namespace, 8)
+			truncateName := fmt.Sprintf("%.26s", testCase.Name)
+			truncateNamespace := fmt.Sprintf("%.16s", testCase.Namespace)
+			expectedResult := fmt.Sprintf("%s-%s-%s-dispatcher", truncateName, truncateNamespace, hash)
+
+			// Verify The Results
+			assert.Equal(t, expectedResult, actualResult)
+		})
 	}
 }
 
@@ -133,26 +136,29 @@ func TestDispatcherDnsSafeName_LongNamesDifferent(t *testing.T) {
 
 	// Run The TestCases
 	for _, testCase := range testCases {
-		// Test Data
-		channel1 := &kafkav1beta1.KafkaChannel{ObjectMeta: metav1.ObjectMeta{Name: testCase.Name1, Namespace: testCase.Namespace1}}
-		channel2 := &kafkav1beta1.KafkaChannel{ObjectMeta: metav1.ObjectMeta{Name: testCase.Name2, Namespace: testCase.Namespace2}}
+		t.Run(testCase.Name1, func(t *testing.T) {
 
-		// Perform The Test
-		actualResult1 := DispatcherDnsSafeName(channel1)
-		hash1 := GenerateHash(testCase.Name1+testCase.Namespace1, 8)
-		truncateName1 := fmt.Sprintf("%.26s", testCase.Name1)
-		truncateNamespace1 := fmt.Sprintf("%.16s", testCase.Namespace1)
-		expectedResult1 := fmt.Sprintf("%s-%s-%s-dispatcher", truncateName1, truncateNamespace1, hash1)
+			// Test Data
+			channel1 := &kafkav1beta1.KafkaChannel{ObjectMeta: metav1.ObjectMeta{Name: testCase.Name1, Namespace: testCase.Namespace1}}
+			channel2 := &kafkav1beta1.KafkaChannel{ObjectMeta: metav1.ObjectMeta{Name: testCase.Name2, Namespace: testCase.Namespace2}}
 
-		actualResult2 := DispatcherDnsSafeName(channel2)
-		hash2 := GenerateHash(testCase.Name2+testCase.Namespace2, 8)
-		truncateName2 := fmt.Sprintf("%.26s", testCase.Name2)
-		truncateNamespace2 := fmt.Sprintf("%.16s", testCase.Namespace2)
-		expectedResult2 := fmt.Sprintf("%s-%s-%s-dispatcher", truncateName2, truncateNamespace2, hash2)
+			// Perform The Test
+			actualResult1 := DispatcherDnsSafeName(channel1)
+			hash1 := GenerateHash(testCase.Name1+testCase.Namespace1, 8)
+			truncateName1 := fmt.Sprintf("%.26s", testCase.Name1)
+			truncateNamespace1 := fmt.Sprintf("%.16s", testCase.Namespace1)
+			expectedResult1 := fmt.Sprintf("%s-%s-%s-dispatcher", truncateName1, truncateNamespace1, hash1)
 
-		// Verify The Results
-		assert.Equal(t, expectedResult1, actualResult1)
-		assert.Equal(t, expectedResult2, actualResult2)
-		assert.NotEqual(t, actualResult1, actualResult2)
+			actualResult2 := DispatcherDnsSafeName(channel2)
+			hash2 := GenerateHash(testCase.Name2+testCase.Namespace2, 8)
+			truncateName2 := fmt.Sprintf("%.26s", testCase.Name2)
+			truncateNamespace2 := fmt.Sprintf("%.16s", testCase.Namespace2)
+			expectedResult2 := fmt.Sprintf("%s-%s-%s-dispatcher", truncateName2, truncateNamespace2, hash2)
+
+			// Verify The Results
+			assert.Equal(t, expectedResult1, actualResult1)
+			assert.Equal(t, expectedResult2, actualResult2)
+			assert.NotEqual(t, actualResult1, actualResult2)
+		})
 	}
 }

--- a/pkg/channel/distributed/controller/util/dns_test.go
+++ b/pkg/channel/distributed/controller/util/dns_test.go
@@ -56,7 +56,9 @@ func TestGenerateValidDnsName(t *testing.T) {
 
 	// Run The TestCases
 	for _, testCase := range testCases {
-		actualDnsName := GenerateValidDnsName(testCase.Name, testCase.Length, testCase.Prefix, testCase.Suffix)
-		assert.Equal(t, testCase.Result, actualDnsName)
+		t.Run(testCase.Name, func(t *testing.T) {
+			actualDnsName := GenerateValidDnsName(testCase.Name, testCase.Length, testCase.Prefix, testCase.Suffix)
+			assert.Equal(t, testCase.Result, actualDnsName)
+		})
 	}
 }

--- a/pkg/channel/distributed/controller/util/hash_test.go
+++ b/pkg/channel/distributed/controller/util/hash_test.go
@@ -44,9 +44,10 @@ func TestGenerateHash(t *testing.T) {
 
 	// Run The TestCases
 	for _, testCase := range testCases {
-		hash := GenerateHash(testCase.Name, testCase.Length)
-		expected := fmt.Sprintf("%x", md5.Sum([]byte(testCase.Name)))[0:testCase.Length]
-		assert.Equal(t, expected, hash)
+		t.Run(testCase.Name, func(t *testing.T) {
+			hash := GenerateHash(testCase.Name, testCase.Length)
+			expected := fmt.Sprintf("%x", md5.Sum([]byte(testCase.Name)))[0:testCase.Length]
+			assert.Equal(t, expected, hash)
+		})
 	}
-
 }

--- a/pkg/channel/distributed/dispatcher/env/environment_test.go
+++ b/pkg/channel/distributed/dispatcher/env/environment_test.go
@@ -142,47 +142,48 @@ func TestGetEnvironment(t *testing.T) {
 
 	// Loop Over All The TestCases
 	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
 
-		// (Re)Setup The Environment Variables From TestCase
-		os.Clearenv()
-		assertSetenv(t, commonenv.MetricsDomainEnvVarKey, testCase.metricsDomain)
-		assertSetenvNonempty(t, commonenv.MetricsPortEnvVarKey, testCase.metricsPort)
-		assertSetenvNonempty(t, commonenv.HealthPortEnvVarKey, testCase.healthPort)
-		assertSetenvNonempty(t, commonenv.ResyncPeriodMinutesEnvVarKey, testCase.resyncPeriodMinutes)
-		assertSetenv(t, commonenv.KafkaBrokerEnvVarKey, testCase.kafkaBrokers)
-		assertSetenv(t, commonenv.KafkaTopicEnvVarKey, testCase.kafkaTopic)
-		assertSetenv(t, commonenv.ChannelKeyEnvVarKey, testCase.channelKey)
-		assertSetenv(t, commonenv.ServiceNameEnvVarKey, testCase.serviceName)
-		assertSetenv(t, commonenv.KafkaUsernameEnvVarKey, testCase.kafkaUsername)
-		assertSetenv(t, commonenv.KafkaPasswordEnvVarKey, testCase.kafkaPassword)
-		assertSetenv(t, commonenv.PodNameEnvVarKey, testCase.podName)
-		assertSetenv(t, commonenv.ContainerNameEnvVarKey, testCase.containerName)
+			// (Re)Setup The Environment Variables From TestCase
+			os.Clearenv()
+			assertSetenv(t, commonenv.MetricsDomainEnvVarKey, testCase.metricsDomain)
+			assertSetenvNonempty(t, commonenv.MetricsPortEnvVarKey, testCase.metricsPort)
+			assertSetenvNonempty(t, commonenv.HealthPortEnvVarKey, testCase.healthPort)
+			assertSetenvNonempty(t, commonenv.ResyncPeriodMinutesEnvVarKey, testCase.resyncPeriodMinutes)
+			assertSetenv(t, commonenv.KafkaBrokerEnvVarKey, testCase.kafkaBrokers)
+			assertSetenv(t, commonenv.KafkaTopicEnvVarKey, testCase.kafkaTopic)
+			assertSetenv(t, commonenv.ChannelKeyEnvVarKey, testCase.channelKey)
+			assertSetenv(t, commonenv.ServiceNameEnvVarKey, testCase.serviceName)
+			assertSetenv(t, commonenv.KafkaUsernameEnvVarKey, testCase.kafkaUsername)
+			assertSetenv(t, commonenv.KafkaPasswordEnvVarKey, testCase.kafkaPassword)
+			assertSetenv(t, commonenv.PodNameEnvVarKey, testCase.podName)
+			assertSetenv(t, commonenv.ContainerNameEnvVarKey, testCase.containerName)
 
-		// Perform The Test
-		environment, err := GetEnvironment(logger)
+			// Perform The Test
+			environment, err := GetEnvironment(logger)
 
-		// Verify The Results
-		if testCase.expectedError == nil {
+			// Verify The Results
+			if testCase.expectedError == nil {
 
-			assert.Nil(t, err)
-			assert.NotNil(t, environment)
-			assert.Equal(t, testCase.metricsPort, strconv.Itoa(environment.MetricsPort))
-			assert.Equal(t, testCase.healthPort, strconv.Itoa(environment.HealthPort))
-			assert.Equal(t, testCase.kafkaBrokers, environment.KafkaBrokers)
-			assert.Equal(t, testCase.kafkaTopic, environment.KafkaTopic)
-			assert.Equal(t, testCase.channelKey, environment.ChannelKey)
-			assert.Equal(t, testCase.serviceName, environment.ServiceName)
-			assert.Equal(t, testCase.kafkaUsername, environment.KafkaUsername)
-			assert.Equal(t, testCase.kafkaPassword, environment.KafkaPassword)
-			assert.Equal(t, testCase.podName, environment.PodName)
-			assert.Equal(t, testCase.containerName, environment.ContainerName)
-			assert.Equal(t, testCase.expectedResyncPeriod, strconv.Itoa(int(environment.ResyncPeriod/time.Minute)))
+				assert.Nil(t, err)
+				assert.NotNil(t, environment)
+				assert.Equal(t, testCase.metricsPort, strconv.Itoa(environment.MetricsPort))
+				assert.Equal(t, testCase.healthPort, strconv.Itoa(environment.HealthPort))
+				assert.Equal(t, testCase.kafkaBrokers, environment.KafkaBrokers)
+				assert.Equal(t, testCase.kafkaTopic, environment.KafkaTopic)
+				assert.Equal(t, testCase.channelKey, environment.ChannelKey)
+				assert.Equal(t, testCase.serviceName, environment.ServiceName)
+				assert.Equal(t, testCase.kafkaUsername, environment.KafkaUsername)
+				assert.Equal(t, testCase.kafkaPassword, environment.KafkaPassword)
+				assert.Equal(t, testCase.podName, environment.PodName)
+				assert.Equal(t, testCase.containerName, environment.ContainerName)
+				assert.Equal(t, testCase.expectedResyncPeriod, strconv.Itoa(int(environment.ResyncPeriod/time.Minute)))
 
-		} else {
-			assert.Equal(t, testCase.expectedError, err)
-			assert.Nil(t, environment)
-		}
-
+			} else {
+				assert.Equal(t, testCase.expectedError, err)
+				assert.Nil(t, environment)
+			}
+		})
 	}
 }
 

--- a/pkg/channel/distributed/receiver/env/environment_test.go
+++ b/pkg/channel/distributed/receiver/env/environment_test.go
@@ -128,43 +128,44 @@ func TestGetEnvironment(t *testing.T) {
 
 	// Loop Over All The TestCases
 	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
 
-		// (Re)Setup The Environment Variables From TestCase
-		os.Clearenv()
-		assertSetenv(t, env.MetricsDomainEnvVarKey, testCase.metricsDomain)
-		assertSetenvNonempty(t, env.MetricsPortEnvVarKey, testCase.metricsPort)
-		assertSetenvNonempty(t, env.HealthPortEnvVarKey, testCase.healthPort)
-		assertSetenv(t, env.KafkaBrokerEnvVarKey, testCase.kafkaBrokers)
-		assertSetenv(t, env.ServiceNameEnvVarKey, testCase.serviceName)
-		assertSetenv(t, env.KafkaUsernameEnvVarKey, testCase.kafkaUsername)
-		assertSetenv(t, env.KafkaPasswordEnvVarKey, testCase.kafkaPassword)
-		assertSetenv(t, env.PodNameEnvVarKey, testCase.podName)
-		assertSetenv(t, env.ContainerNameEnvVarKey, testCase.containerName)
-		assertSetenvNonempty(t, env.ResyncPeriodMinutesEnvVarKey, testCase.resyncPeriodMinutes)
+			// (Re)Setup The Environment Variables From TestCase
+			os.Clearenv()
+			assertSetenv(t, env.MetricsDomainEnvVarKey, testCase.metricsDomain)
+			assertSetenvNonempty(t, env.MetricsPortEnvVarKey, testCase.metricsPort)
+			assertSetenvNonempty(t, env.HealthPortEnvVarKey, testCase.healthPort)
+			assertSetenv(t, env.KafkaBrokerEnvVarKey, testCase.kafkaBrokers)
+			assertSetenv(t, env.ServiceNameEnvVarKey, testCase.serviceName)
+			assertSetenv(t, env.KafkaUsernameEnvVarKey, testCase.kafkaUsername)
+			assertSetenv(t, env.KafkaPasswordEnvVarKey, testCase.kafkaPassword)
+			assertSetenv(t, env.PodNameEnvVarKey, testCase.podName)
+			assertSetenv(t, env.ContainerNameEnvVarKey, testCase.containerName)
+			assertSetenvNonempty(t, env.ResyncPeriodMinutesEnvVarKey, testCase.resyncPeriodMinutes)
 
-		// Perform The Test
-		environment, err := GetEnvironment(logger)
+			// Perform The Test
+			environment, err := GetEnvironment(logger)
 
-		// Verify The Results
-		if testCase.expectedError == nil {
+			// Verify The Results
+			if testCase.expectedError == nil {
 
-			assert.Nil(t, err)
-			assert.NotNil(t, environment)
-			assert.Equal(t, testCase.metricsPort, strconv.Itoa(environment.MetricsPort))
-			assert.Equal(t, testCase.healthPort, strconv.Itoa(environment.HealthPort))
-			assert.Equal(t, testCase.kafkaBrokers, environment.KafkaBrokers)
-			assert.Equal(t, testCase.serviceName, environment.ServiceName)
-			assert.Equal(t, testCase.kafkaUsername, environment.KafkaUsername)
-			assert.Equal(t, testCase.kafkaPassword, environment.KafkaPassword)
-			assert.Equal(t, testCase.podName, environment.PodName)
-			assert.Equal(t, testCase.containerName, environment.ContainerName)
-			assert.Equal(t, testCase.expectedResyncPeriod, strconv.Itoa(int(environment.ResyncPeriod/time.Minute)))
+				assert.Nil(t, err)
+				assert.NotNil(t, environment)
+				assert.Equal(t, testCase.metricsPort, strconv.Itoa(environment.MetricsPort))
+				assert.Equal(t, testCase.healthPort, strconv.Itoa(environment.HealthPort))
+				assert.Equal(t, testCase.kafkaBrokers, environment.KafkaBrokers)
+				assert.Equal(t, testCase.serviceName, environment.ServiceName)
+				assert.Equal(t, testCase.kafkaUsername, environment.KafkaUsername)
+				assert.Equal(t, testCase.kafkaPassword, environment.KafkaPassword)
+				assert.Equal(t, testCase.podName, environment.PodName)
+				assert.Equal(t, testCase.containerName, environment.ContainerName)
+				assert.Equal(t, testCase.expectedResyncPeriod, strconv.Itoa(int(environment.ResyncPeriod/time.Minute)))
 
-		} else {
-			assert.Equal(t, testCase.expectedError, err)
-			assert.Nil(t, environment)
-		}
-
+			} else {
+				assert.Equal(t, testCase.expectedError, err)
+				assert.Nil(t, environment)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
There are a bunch of legacy "table" tests in the distributed KafkaChannel implementation which don't use the testing framework correctly and make it hard to debug the individual test case failures.  This PR corrects those tests.  No production code was changed in this PR.
