### PR TITLE
[distributed] Use same configmap name, for the channels

### DIFF
--- a/config/channel/distributed/300-eventing-kafka-configmap.yaml
+++ b/config/channel/distributed/300-eventing-kafka-configmap.yaml
@@ -59,5 +59,5 @@ data:
       adminType: kafka # One of "kafka", "azure", "custom"
 kind: ConfigMap
 metadata:
-  name: config-eventing-kafka
+  name: config-kafka
   namespace: knative-eventing

--- a/pkg/channel/distributed/common/config/configwatcher.go
+++ b/pkg/channel/distributed/common/config/configwatcher.go
@@ -30,7 +30,7 @@ import (
 )
 
 // The EventingKafkaConfig and these EK sub-structs contain our custom configuration settings,
-// stored in the config-eventing-kafka configmap.  The sub-structs are explicitly declared so that they
+// stored in the config-kafka configmap.  The sub-structs are explicitly declared so that they
 // can have their own JSON tags in the overall EventingKafkaConfig
 type EKKubernetesConfig struct {
 	CpuLimit      resource.Quantity `json:"cpuLimit,omitempty"`

--- a/pkg/channel/distributed/common/config/constants.go
+++ b/pkg/channel/distributed/common/config/constants.go
@@ -19,7 +19,7 @@ package config
 // Package Constants
 const (
 	// The name of the configmap used to hold eventing-kafka settings
-	SettingsConfigMapName = "config-eventing-kafka"
+	SettingsConfigMapName = "config-kafka"
 	// The name of the keys in the Data section of the eventing-kafka configmap that holds Sarama and Eventing-Kafka configuration YAML
 	SaramaSettingsConfigKey        = "sarama"
 	EventingKafkaSettingsConfigKey = "eventing-kafka"

--- a/pkg/channel/distributed/common/kafka/sarama/sarama.go
+++ b/pkg/channel/distributed/common/kafka/sarama/sarama.go
@@ -131,7 +131,7 @@ The following shows an example of the expected usage...
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-eventing-kafka
+  name: config-kafka
   namespace: knative-eventing
 data:
   sarama: |

--- a/pkg/channel/distributed/common/testing/constants.go
+++ b/pkg/channel/distributed/common/testing/constants.go
@@ -25,7 +25,7 @@ const (
 	NewPassword = "TestNewPassword"
 
 	KnativeEventingNamespace       = "knative-eventing"
-	SettingsConfigMapName          = "config-eventing-kafka"
+	SettingsConfigMapName          = "config-kafka"
 	SaramaSettingsConfigKey        = "sarama"
 	EventingKafkaSettingsConfigKey = "eventing-kafka"
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -299,7 +299,7 @@ function install_distributed_channel_crds() {
   # Update The Kafka Secret With Strimzi Kafka Cluster Brokers (No Authentication)
   sed -i "s/brokers: \"\"/brokers: ${STRIMZI_KAFKA_CLUSTER_BROKERS_ENCODED}/" "${KAFKA_CRD_CONFIG_DIR}/${EVENTING_KAFKA_SECRET_TEMPLATE}"
 
-  # Update the config-eventing-kafka configmap to disable SASL/TLS for the tests
+  # Update the config-kafka configmap to disable SASL/TLS for the tests
   sed -i '/^ *TLS:/{n;s/true/false/};/^ *SASL:/{n;s/true/false/}' "${KAFKA_CRD_CONFIG_DIR}/${EVENTING_KAFKA_CONFIG_TEMPLATE}"
 
   # Install The eventing-kafka KafkaChannel Implementation


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- align name of the configmap with the consolidated
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
