### PR TITLE
Go with the overall default of the leader election

### DIFF
--- a/config/channel/consolidated/configmaps/leader-election.yaml
+++ b/config/channel/consolidated/configmaps/leader-election.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-leader-election-kafka
+  name: config-leader-election
   namespace: knative-eventing
 data:
   # An inactive but valid configuration follows; see example.

--- a/config/channel/consolidated/deployments/controller.yaml
+++ b/config/channel/consolidated/deployments/controller.yaml
@@ -47,7 +47,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: CONFIG_LEADERELECTION_NAME
-          value: config-leader-election-kafka
+          value: config-leader-election
         - name: DISPATCHER_IMAGE
           value: ko://knative.dev/eventing-kafka/cmd/channel/consolidated/dispatcher
         ports:

--- a/config/channel/consolidated/deployments/dispatcher.yaml
+++ b/config/channel/consolidated/deployments/dispatcher.yaml
@@ -49,11 +49,11 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: METRICS_DOMAIN
-          value: "knative.dev/eventing"
+          value: knative.dev/eventing
         - name: CONFIG_LOGGING_NAME
-          value: "config-logging"
+          value: config-logging
         - name: CONFIG_LEADERELECTION_NAME
-          value: "config-leader-election"
+          value: config-leader-election
         - name: CONTAINER_NAME
           value: dispatcher
         ports:

--- a/config/channel/consolidated/deployments/dispatcher.yaml
+++ b/config/channel/consolidated/deployments/dispatcher.yaml
@@ -53,7 +53,7 @@ spec:
         - name: CONFIG_LOGGING_NAME
           value: "config-logging"
         - name: CONFIG_LEADERELECTION_NAME
-          value: "config-leader-election-kafka"
+          value: "config-leader-election"
         - name: CONTAINER_NAME
           value: dispatcher
         ports:

--- a/config/channel/distributed/300-leaderelection-configmap.yaml
+++ b/config/channel/distributed/300-leaderelection-configmap.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-leader-election-kafkachannel
+  name: config-leader-election
   namespace: knative-eventing
 data:
   # An inactive but valid configuration follows; see example.

--- a/config/channel/distributed/500-controller-deployment.yaml
+++ b/config/channel/distributed/500-controller-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: CONFIG_LEADERELECTION_NAME
-          value: config-leader-election-kafkachannel
+          value: config-leader-election
         - name: SERVICE_ACCOUNT
           valueFrom:
             fieldRef:

--- a/config/source/configmaps/leader-election.yaml
+++ b/config/source/configmaps/leader-election.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-leader-election-kafka
+  name: config-leader-election
   namespace: knative-eventing
 data:
   # An inactive but valid configuration follows; see example.

--- a/config/source/deployments/controller.yaml
+++ b/config/source/deployments/controller.yaml
@@ -43,7 +43,7 @@ spec:
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
         - name: CONFIG_LEADERELECTION_NAME
-          value: config-leader-election-kafka
+          value: config-leader-election
         - name: KAFKA_RA_IMAGE
           value: ko://knative.dev/eventing-kafka/cmd/source/receive_adapter
         volumeMounts:

--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
@@ -112,7 +112,7 @@ func makeEnv(args DispatcherArgs) []corev1.EnvVar {
 		Value: "config-logging",
 	}, {
 		Name:  "CONFIG_LEADERELECTION_NAME",
-		Value: "config-leader-election-kafka",
+		Value: "config-leader-election",
 	}}
 
 	if args.DispatcherScope == "namespace" {

--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher_test.go
@@ -77,7 +77,7 @@ func TestNewDispatcher(t *testing.T) {
 								Value: "config-logging",
 							}, {
 								Name:  "CONFIG_LEADERELECTION_NAME",
-								Value: "config-leader-election-kafka",
+								Value: "config-leader-election",
 							}},
 							Ports: []corev1.ContainerPort{{
 								Name:          "metrics",
@@ -159,7 +159,7 @@ func TestNewNamespaceDispatcher(t *testing.T) {
 								Value: "config-logging",
 							}, {
 								Name:  "CONFIG_LEADERELECTION_NAME",
-								Value: "config-leader-election-kafka",
+								Value: "config-leader-election",
 							}, {
 								Name: "NAMESPACE",
 								ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

- with the global default of the `config-leader-election`, it is still possible to do some fine-tuning, via the `CONFIG_LEADERELECTION_NAME` env-var on the deployments (e.g. controllers/dispatchers)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
KafkaSource and KafkaChannel will be default use the `config-leader-election` CM for configs
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
