### PR TITLE
Add kafkaSource saslType, e2e tests for auth (tls and sasl512)

### DIFF
--- a/pkg/apis/bindings/v1alpha1/kafka_conversion.go
+++ b/pkg/apis/bindings/v1alpha1/kafka_conversion.go
@@ -82,6 +82,9 @@ func (source *KafkaAuthSpec) ConvertTo(_ context.Context, obj apis.Convertible) 
 				},
 				Password: bindingsv1beta1.SecretValueFromSource{
 					SecretKeyRef: source.Net.SASL.Password.SecretKeyRef},
+				Type: bindingsv1beta1.SecretValueFromSource{
+					SecretKeyRef: source.Net.SASL.Type.SecretKeyRef,
+				},
 			},
 			TLS: bindingsv1beta1.KafkaTLSSpec{
 				Enable: source.Net.TLS.Enable,
@@ -116,6 +119,9 @@ func (sink *KafkaAuthSpec) ConvertFrom(_ context.Context, obj apis.Convertible) 
 				},
 				Password: SecretValueFromSource{
 					SecretKeyRef: source.Net.SASL.Password.SecretKeyRef},
+				Type: SecretValueFromSource{
+					SecretKeyRef: source.Net.SASL.Type.SecretKeyRef,
+				},
 			},
 			TLS: KafkaTLSSpec{
 				Enable: source.Net.TLS.Enable,

--- a/pkg/apis/bindings/v1alpha1/kafka_conversion_test.go
+++ b/pkg/apis/bindings/v1alpha1/kafka_conversion_test.go
@@ -107,6 +107,15 @@ func TestKafkaBindingConversionRoundTripV1alpha1(t *testing.T) {
 									Optional: pointer.BoolPtr(true),
 								},
 							},
+							Type: SecretValueFromSource{
+								SecretKeyRef: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "sasl-type-secret-local-obj-ref",
+									},
+									Key:      "sasl-type-secret-key",
+									Optional: pointer.BoolPtr(true),
+								},
+							},
 						},
 						TLS: KafkaTLSSpec{
 							Enable: true,
@@ -241,6 +250,15 @@ func TestKafkaBindingConversionRoundTripV1beta1(t *testing.T) {
 										Name: "sasl-password-secret-local-obj-ref",
 									},
 									Key:      "sasl-password-secret-key",
+									Optional: pointer.BoolPtr(true),
+								},
+							},
+							Type: v1beta1.SecretValueFromSource{
+								SecretKeyRef: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "sasl-type-secret-local-obj-ref",
+									},
+									Key:      "sasl-type-secret-key",
 									Optional: pointer.BoolPtr(true),
 								},
 							},

--- a/pkg/apis/bindings/v1alpha1/kafka_lifecycle.go
+++ b/pkg/apis/bindings/v1alpha1/kafka_lifecycle.go
@@ -102,6 +102,11 @@ func (kfb *KafkaBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: kfb.Spec.Net.SASL.Password.SecretKeyRef,
 				},
+			}, corev1.EnvVar{
+				Name: "KAFKA_NET_SASL_TYPE",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: kfb.Spec.Net.SASL.Type.SecretKeyRef,
+				},
 			})
 		}
 		if kfb.Spec.Net.TLS.Enable {
@@ -147,6 +152,11 @@ func (kfb *KafkaBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: kfb.Spec.Net.SASL.Password.SecretKeyRef,
 				},
+			}, corev1.EnvVar{
+				Name: "KAFKA_NET_SASL_TYPE",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: kfb.Spec.Net.SASL.Type.SecretKeyRef,
+				},
 			})
 		}
 		if kfb.Spec.Net.TLS.Enable {
@@ -184,7 +194,7 @@ func (kfb *KafkaBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "KAFKA_NET_TLS_ENABLE", "KAFKA_NET_TLS_CERT", "KAFKA_NET_TLS_KEY", "KAFKA_NET_TLS_CA_CERT",
-				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD",
+				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD", "KAFKA_NET_SASL_TYPE",
 				"KAFKA_BOOTSTRAP_SERVERS":
 
 				continue
@@ -203,7 +213,7 @@ func (kfb *KafkaBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "KAFKA_NET_TLS_ENABLE", "KAFKA_NET_TLS_CERT", "KAFKA_NET_TLS_KEY", "KAFKA_NET_TLS_CA_CERT",
-				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD",
+				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD", "KAFKA_NET_SASL_TYPE",
 				"KAFKA_BOOTSTRAP_SERVERS":
 				continue
 			default:

--- a/pkg/apis/bindings/v1alpha1/kafka_lifecycle_test.go
+++ b/pkg/apis/bindings/v1alpha1/kafka_lifecycle_test.go
@@ -144,6 +144,16 @@ func TestKafkaBindingUndo(t *testing.T) {
 										Key: corev1.BasicAuthPasswordKey,
 									},
 								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
+									},
+								},
 							}},
 						}},
 					},
@@ -273,6 +283,14 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 								Key: corev1.BasicAuthPasswordKey,
 							},
 						},
+						Type: SecretValueFromSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: secretName,
+								},
+								Key: "saslType",
+							},
+						},
 					},
 				},
 			},
@@ -318,6 +336,16 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 										Key: corev1.BasicAuthPasswordKey,
 									},
 								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
+									},
+								},
 							}},
 						}},
 					},
@@ -355,6 +383,16 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 											Name: secretName,
 										},
 										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
 									},
 								},
 							}},
@@ -410,6 +448,16 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 										Key: corev1.BasicAuthPasswordKey,
 									},
 								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
+									},
+								},
 							}},
 						}},
 					},
@@ -436,6 +484,9 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 								Value: "bad",
 							}, {
 								Name:  "KAFKA_NET_SASL_PASSWORD",
+								Value: "bad",
+							}, {
+								Name:  "KAFKA_NET_SASL_TYPE",
 								Value: "bad",
 							}},
 						}},
@@ -474,6 +525,16 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 											Name: secretName,
 										},
 										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
 									},
 								},
 							}},

--- a/pkg/apis/bindings/v1alpha1/kafka_types.go
+++ b/pkg/apis/bindings/v1alpha1/kafka_types.go
@@ -56,6 +56,10 @@ type KafkaSASLSpec struct {
 	// Password is the Kubernetes secret containing the SASL password.
 	// +optional
 	Password SecretValueFromSource `json:"password,omitempty"`
+
+	// Type of saslType, defaults to plain (vs SCRAM-SHA-512 or SCRAM-SHA-256)
+	// +optional
+	Type SecretValueFromSource `json:"saslType,omitempty"`
 }
 
 type KafkaTLSSpec struct {

--- a/pkg/apis/bindings/v1alpha1/kafka_types.go
+++ b/pkg/apis/bindings/v1alpha1/kafka_types.go
@@ -59,7 +59,7 @@ type KafkaSASLSpec struct {
 
 	// Type of saslType, defaults to plain (vs SCRAM-SHA-512 or SCRAM-SHA-256)
 	// +optional
-	Type SecretValueFromSource `json:"saslType,omitempty"`
+	Type SecretValueFromSource `json:"type,omitempty"`
 }
 
 type KafkaTLSSpec struct {

--- a/pkg/apis/bindings/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/bindings/v1alpha1/zz_generated.deepcopy.go
@@ -166,6 +166,7 @@ func (in *KafkaSASLSpec) DeepCopyInto(out *KafkaSASLSpec) {
 	*out = *in
 	in.User.DeepCopyInto(&out.User)
 	in.Password.DeepCopyInto(&out.Password)
+	in.Type.DeepCopyInto(&out.Type)
 	return
 }
 

--- a/pkg/apis/bindings/v1beta1/kafka_lifecycle.go
+++ b/pkg/apis/bindings/v1beta1/kafka_lifecycle.go
@@ -102,6 +102,11 @@ func (kfb *KafkaBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: kfb.Spec.Net.SASL.Password.SecretKeyRef,
 				},
+			}, corev1.EnvVar{
+				Name: "KAFKA_NET_SASL_TYPE",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: kfb.Spec.Net.SASL.Type.SecretKeyRef,
+				},
 			})
 		}
 		if kfb.Spec.Net.TLS.Enable {
@@ -147,6 +152,11 @@ func (kfb *KafkaBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: kfb.Spec.Net.SASL.Password.SecretKeyRef,
 				},
+			}, corev1.EnvVar{
+				Name: "KAFKA_NET_SASL_TYPE",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: kfb.Spec.Net.SASL.Type.SecretKeyRef,
+				},
 			})
 		}
 		if kfb.Spec.Net.TLS.Enable {
@@ -184,7 +194,7 @@ func (kfb *KafkaBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "KAFKA_NET_TLS_ENABLE", "KAFKA_NET_TLS_CERT", "KAFKA_NET_TLS_KEY", "KAFKA_NET_TLS_CA_CERT",
-				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD",
+				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD", "KAFKA_NET_SASL_TYPE",
 				"KAFKA_BOOTSTRAP_SERVERS":
 
 				continue
@@ -203,7 +213,7 @@ func (kfb *KafkaBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "KAFKA_NET_TLS_ENABLE", "KAFKA_NET_TLS_CERT", "KAFKA_NET_TLS_KEY", "KAFKA_NET_TLS_CA_CERT",
-				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD",
+				"KAFKA_NET_SASL_ENABLE", "KAFKA_NET_SASL_USER", "KAFKA_NET_SASL_PASSWORD", "KAFKA_NET_SASL_TYPE",
 				"KAFKA_BOOTSTRAP_SERVERS":
 				continue
 			default:

--- a/pkg/apis/bindings/v1beta1/kafka_lifecycle_test.go
+++ b/pkg/apis/bindings/v1beta1/kafka_lifecycle_test.go
@@ -144,6 +144,16 @@ func TestKafkaBindingUndo(t *testing.T) {
 										Key: corev1.BasicAuthPasswordKey,
 									},
 								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
+									},
+								},
 							}},
 						}},
 					},
@@ -273,6 +283,14 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 								Key: corev1.BasicAuthPasswordKey,
 							},
 						},
+						Type: SecretValueFromSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: secretName,
+								},
+								Key: "saslType",
+							},
+						},
 					},
 				},
 			},
@@ -318,6 +336,16 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 										Key: corev1.BasicAuthPasswordKey,
 									},
 								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
+									},
+								},
 							}},
 						}},
 					},
@@ -355,6 +383,16 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 											Name: secretName,
 										},
 										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
 									},
 								},
 							}},
@@ -410,6 +448,16 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 										Key: corev1.BasicAuthPasswordKey,
 									},
 								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
+									},
+								},
 							}},
 						}},
 					},
@@ -436,6 +484,9 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 								Value: "bad",
 							}, {
 								Name:  "KAFKA_NET_SASL_PASSWORD",
+								Value: "bad",
+							}, {
+								Name:  "KAFKA_NET_SASL_TYPE",
 								Value: "bad",
 							}},
 						}},
@@ -474,6 +525,16 @@ func TestKafkaBindingDoSASL(t *testing.T) {
 											Name: secretName,
 										},
 										Key: corev1.BasicAuthPasswordKey,
+									},
+								},
+							}, {
+								Name: "KAFKA_NET_SASL_TYPE",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: secretName,
+										},
+										Key: "saslType",
 									},
 								},
 							}},

--- a/pkg/apis/bindings/v1beta1/kafka_types.go
+++ b/pkg/apis/bindings/v1beta1/kafka_types.go
@@ -56,6 +56,10 @@ type KafkaSASLSpec struct {
 	// Password is the Kubernetes secret containing the SASL password.
 	// +optional
 	Password SecretValueFromSource `json:"password,omitempty"`
+
+	// Type of saslType, defaults to plain (vs SCRAM-SHA-512 or SCRAM-SHA-256)
+	// +optional
+	Type SecretValueFromSource `json:"type,omitempty"`
 }
 
 type KafkaTLSSpec struct {

--- a/pkg/apis/bindings/v1beta1/kafka_types.go
+++ b/pkg/apis/bindings/v1beta1/kafka_types.go
@@ -59,7 +59,7 @@ type KafkaSASLSpec struct {
 
 	// Type of saslType, defaults to plain (vs SCRAM-SHA-512 or SCRAM-SHA-256)
 	// +optional
-	Type SecretValueFromSource `json:"type,omitempty"`
+	Type SecretValueFromSource `json:"saslType,omitempty"`
 }
 
 type KafkaTLSSpec struct {

--- a/pkg/apis/bindings/v1beta1/kafka_types.go
+++ b/pkg/apis/bindings/v1beta1/kafka_types.go
@@ -59,7 +59,7 @@ type KafkaSASLSpec struct {
 
 	// Type of saslType, defaults to plain (vs SCRAM-SHA-512 or SCRAM-SHA-256)
 	// +optional
-	Type SecretValueFromSource `json:"saslType,omitempty"`
+	Type SecretValueFromSource `json:"type,omitempty"`
 }
 
 type KafkaTLSSpec struct {

--- a/pkg/apis/bindings/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/bindings/v1beta1/zz_generated.deepcopy.go
@@ -166,6 +166,7 @@ func (in *KafkaSASLSpec) DeepCopyInto(out *KafkaSASLSpec) {
 	*out = *in
 	in.User.DeepCopyInto(&out.User)
 	in.Password.DeepCopyInto(&out.Password)
+	in.Type.DeepCopyInto(&out.Type)
 	return
 }
 

--- a/pkg/source/client_test.go
+++ b/pkg/source/client_test.go
@@ -334,16 +334,160 @@ func generateCert(t *testing.T) (string, string) {
 }
 
 func TestNewConfig(t *testing.T) {
-	ctx := context.Background()
-
 	// Increasing coverage
-	_ = os.Setenv("KAFKA_BOOTSTRAP_SERVERS", "my-cluster-kafka-bootstrap.my-kafka-namespace:9092")
+	defaultBootstrapServer := "my-cluster-kafka-bootstrap.my-kafka-namespace:9092"
+	defaultSASLUser := "secret-user"
+	defaultSASLPassword := "super-seekrit-password"
+	testCases := map[string]struct {
+		env             map[string]string
+		enabledTLS      bool
+		enabledSASL     bool
+		wantErr         bool
+		saslMechanism   string
+		bootstrapServer string
+		saslUser        string
+		saslPassword    string
+	}{
+		"Just bootstrap Server": {
+			env: map[string]string{
+				"KAFKA_BOOTSTRAP_SERVERS": defaultBootstrapServer,
+			},
+			bootstrapServer: defaultBootstrapServer,
+		},
+		"Incorrect bootstrap Server": {
+			env: map[string]string{
+				"KAFKA_BOOTSTRAP_SERVERS": defaultBootstrapServer,
+			},
+			bootstrapServer: "ImADoctorNotABootstrapServerJim!",
+			wantErr:         true,
+		},
+		/*
+			TODO
+			"Multiple bootstrap servers": {
+				env: map[string]string{
 
-	servers, config, err := NewConfig(ctx)
+				},
 
-	require.NoError(t, err)
-	require.NotNil(t, config)
-	require.Equal(t, []string{"my-cluster-kafka-bootstrap.my-kafka-namespace:9092"}, servers)
+			},*/
+		"No Auth": {
+			env: map[string]string{
+				"KAFKA_BOOTSTRAP_SERVERS": defaultBootstrapServer,
+			},
+			enabledTLS:      false,
+			enabledSASL:     false,
+			bootstrapServer: defaultBootstrapServer,
+		},
+		"Defaulting to SASL-Plain Auth (none specified)": {
+			env: map[string]string{
+				"KAFKA_BOOTSTRAP_SERVERS": defaultBootstrapServer,
+				"KAFKA_NET_SASL_ENABLE":   "true",
+			},
+			enabledSASL:     true,
+			saslMechanism:   sarama.SASLTypePlaintext,
+			bootstrapServer: defaultBootstrapServer,
+		},
+		"Only SASL-PLAIN Auth": {
+			env: map[string]string{
+				"KAFKA_BOOTSTRAP_SERVERS": defaultBootstrapServer,
+				"KAFKA_NET_SASL_ENABLE":   "true",
+				"KAFKA_NET_SASL_USER":     defaultSASLUser,
+				"KAFKA_NET_SASL_PASSWORD": defaultSASLPassword,
+			},
+			enabledSASL:     true,
+			saslUser:        defaultSASLUser,
+			saslPassword:    defaultSASLPassword,
+			saslMechanism:   sarama.SASLTypePlaintext,
+			bootstrapServer: defaultBootstrapServer,
+		},
+		"SASL-PLAIN Auth, Forgot User": {
+			env: map[string]string{
+				"KAFKA_BOOTSTRAP_SERVERS": defaultBootstrapServer,
+				"KAFKA_NET_SASL_ENABLE":   "true",
+				"KAFKA_NET_SASL_PASSWORD": defaultSASLPassword,
+			},
+			enabledSASL:     true,
+			wantErr:         true,
+			saslUser:        defaultSASLUser,
+			saslPassword:    defaultSASLPassword,
+			saslMechanism:   sarama.SASLTypePlaintext,
+			bootstrapServer: defaultBootstrapServer,
+		},
+		"SASL-PLAIN Auth, Forgot Password": {
+			env: map[string]string{
+				"KAFKA_BOOTSTRAP_SERVERS": defaultBootstrapServer,
+				"KAFKA_NET_SASL_ENABLE":   "true",
+				"KAFKA_NET_SASL_USER":     defaultSASLUser,
+			},
+			enabledSASL:     true,
+			wantErr:         true,
+			saslUser:        defaultSASLUser,
+			saslPassword:    defaultSASLPassword,
+			saslMechanism:   sarama.SASLTypePlaintext,
+			bootstrapServer: defaultBootstrapServer,
+		},
+		"Only SASL-SCRAM-SHA-256 Auth": {
+			env: map[string]string{
+				"KAFKA_BOOTSTRAP_SERVERS": defaultBootstrapServer,
+				"KAFKA_NET_SASL_ENABLE":   "true",
+				"KAFKA_NET_SASL_USER":     defaultSASLUser,
+				"KAFKA_NET_SASL_PASSWORD": defaultSASLPassword,
+				"KAFKA_NET_SASL_TYPE":     sarama.SASLTypeSCRAMSHA256,
+			},
+			enabledSASL:     true,
+			saslUser:        defaultSASLUser,
+			saslPassword:    defaultSASLPassword,
+			saslMechanism:   sarama.SASLTypeSCRAMSHA256,
+			bootstrapServer: defaultBootstrapServer,
+		},
+		"Only SASL-SCRAM-SHA-512 Auth": {
+			env: map[string]string{
+				"KAFKA_BOOTSTRAP_SERVERS": defaultBootstrapServer,
+				"KAFKA_NET_SASL_ENABLE":   "true",
+				"KAFKA_NET_SASL_USER":     defaultSASLUser,
+				"KAFKA_NET_SASL_PASSWORD": defaultSASLPassword,
+				"KAFKA_NET_SASL_TYPE":     sarama.SASLTypeSCRAMSHA512,
+			},
+			enabledSASL:     true,
+			saslUser:        defaultSASLUser,
+			saslPassword:    defaultSASLPassword,
+			saslMechanism:   sarama.SASLTypeSCRAMSHA512,
+			bootstrapServer: defaultBootstrapServer,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			for k, v := range tc.env {
+				_ = os.Setenv(k, v)
+			}
+			servers, config, err := NewConfig(context.Background())
+			if err != nil && tc.wantErr != true {
+				t.Fatal(err)
+			}
+			if servers[0] != tc.bootstrapServer && tc.wantErr != true {
+				t.Fatalf("Incorrect bootstrapServers, got: %s vs want: %s", servers[0], tc.bootstrapServer)
+			}
+			if tc.enabledSASL {
+				if tc.saslMechanism != string(config.Net.SASL.Mechanism) {
+					t.Fatalf("Incorrect SASL mechanism, got: %s vs want: %s", string(config.Net.SASL.Mechanism), tc.saslMechanism)
+				}
+
+				if config.Net.SASL.Enable != true {
+					t.Fatal("Incorrect SASL Configuration (not enabled)")
+				}
+
+				if config.Net.SASL.User != tc.saslUser && !tc.wantErr {
+					t.Fatalf("Incorrect SASL User, got: %s vs want: %s", config.Net.SASL.User, tc.saslUser)
+				}
+				if config.Net.SASL.Password != tc.saslPassword && !tc.wantErr {
+					t.Fatalf("Incorrect SASL Password, got: %s vs want: %s", config.Net.SASL.Password, tc.saslPassword)
+				}
+			}
+			require.NotNil(t, config)
+			for k := range tc.env {
+				_ = os.Unsetenv(k)
+			}
+		})
+	}
 }
 
 func TestAdminClient(t *testing.T) {

--- a/pkg/source/reconciler/source/resources/receive_adapter.go
+++ b/pkg/source/reconciler/source/resources/receive_adapter.go
@@ -72,6 +72,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 
 	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_SASL_USER", args.Source.Spec.Net.SASL.User.SecretKeyRef)
 	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_SASL_PASSWORD", args.Source.Spec.Net.SASL.Password.SecretKeyRef)
+	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_SASL_TYPE", args.Source.Spec.Net.SASL.Type.SecretKeyRef)
 	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_TLS_CERT", args.Source.Spec.Net.TLS.Cert.SecretKeyRef)
 	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_TLS_KEY", args.Source.Spec.Net.TLS.Key.SecretKeyRef)
 	env = appendEnvFromSecretKeyRef(env, "KAFKA_NET_TLS_CA_CERT", args.Source.Spec.Net.TLS.CACert.SecretKeyRef)

--- a/pkg/source/reconciler/source/resources/receive_adapter_test.go
+++ b/pkg/source/reconciler/source/resources/receive_adapter_test.go
@@ -59,6 +59,14 @@ func TestMakeReceiveAdapter(t *testing.T) {
 								Key: "password",
 							},
 						},
+						Type: bindingsv1beta1.SecretValueFromSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "the-sasltype-secret",
+								},
+								Key: "saslType",
+							},
+						},
 					},
 					TLS: bindingsv1beta1.KafkaTLSSpec{
 						Enable: true,
@@ -188,6 +196,17 @@ func TestMakeReceiveAdapter(t *testing.T) {
 												Name: "the-password-secret",
 											},
 											Key: "password",
+										},
+									},
+								},
+								{
+									Name: "KAFKA_NET_SASL_TYPE",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "the-saslType-secret",
+											},
+											Key: "saslType",
 										},
 									},
 								},
@@ -408,6 +427,17 @@ func TestMakeReceiveAdapterNoNet(t *testing.T) {
 								Name: "the-password-secret",
 							},
 							Key: "password",
+						},
+					},
+				},
+				{
+					Name: "KAFKA_NET_SASL_TYPE",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "the-saslType-secret",
+							},
+							Key: "saslType",
 						},
 					},
 				},

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -69,6 +69,7 @@ fi
 
 export SYSTEM_NAMESPACE
 create_tls_secrets
+create_sasl_secrets
 if [[ $TEST_CONSOLIDATED_CHANNEL == 1 ]]; then
   echo "Launching the PLAIN TESTS:"
   test_consolidated_channel_plain || exit 1

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -68,7 +68,7 @@ if [[ $TEST_CONSOLIDATED_CHANNEL != 1 ]] && [[ $TEST_CONSOLIDATED_CHANNEL_TLS !=
 fi
 
 export SYSTEM_NAMESPACE
-
+create_tls_secrets
 if [[ $TEST_CONSOLIDATED_CHANNEL == 1 ]]; then
   echo "Launching the PLAIN TESTS:"
   test_consolidated_channel_plain || exit 1
@@ -76,13 +76,11 @@ fi
 
 if [[ $TEST_CONSOLIDATED_CHANNEL_TLS == 1 ]]; then
   echo "Launching the TLS TESTS:"
-  create_tls_secrets
   test_consolidated_channel_tls || exit 1
 fi
 
 if [[ $TEST_CONSOLIDATED_CHANNEL_SASL == 1 ]]; then
   echo "Launching the SASL TESTS:"
-  create_sasl_secrets
   test_consolidated_channel_sasl || exit 1
 fi
 

--- a/test/e2e/kafka_binding_test.go
+++ b/test/e2e/kafka_binding_test.go
@@ -53,13 +53,13 @@ func testKafkaBinding(t *testing.T, version string, messageKey string, messageHe
 	switch version {
 	case "v1alpha1":
 		contribtestlib.CreateKafkaSourceV1Alpha1OrFail(client, contribresources.KafkaSourceV1Alpha1(
-			kafkaBootstrapUrl,
+			kafkaBootstrapUrlPlain,
 			kafkaTopicName,
 			resources.ServiceRef(loggerPodName),
 		))
 	case "v1beta1":
 		contribtestlib.CreateKafkaSourceV1Beta1OrFail(client, contribresources.KafkaSourceV1Beta1(
-			kafkaBootstrapUrl,
+			kafkaBootstrapUrlPlain,
 			kafkaTopicName,
 			resources.ServiceRef(loggerPodName),
 		))
@@ -74,7 +74,7 @@ func testKafkaBinding(t *testing.T, version string, messageKey string, messageHe
 	switch version {
 	case "v1alpha1":
 		contribtestlib.CreateKafkaBindingV1Alpha1OrFail(client, contribresources.KafkaBindingV1Alpha1(
-			kafkaBootstrapUrl,
+			kafkaBootstrapUrlPlain,
 			&tracker.Reference{
 				APIVersion: "batch/v1",
 				Kind:       "Job",
@@ -85,7 +85,7 @@ func testKafkaBinding(t *testing.T, version string, messageKey string, messageHe
 		))
 	case "v1beta1":
 		contribtestlib.CreateKafkaBindingV1Beta1OrFail(client, contribresources.KafkaBindingV1Beta1(
-			kafkaBootstrapUrl,
+			kafkaBootstrapUrlPlain,
 			&tracker.Reference{
 				APIVersion: "batch/v1",
 				Kind:       "Job",

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -112,7 +112,7 @@ func createKafkaSourceWithSinkMissing(c *testlib.Client) {
 	helpers.MustCreateTopic(c, kafkaClusterName, kafkaClusterNamespace, rtKafkaTopicName)
 
 	contribtestlib.CreateKafkaSourceV1Beta1OrFail(c, contribresources.KafkaSourceV1Beta1(
-		kafkaBootstrapUrl,
+		kafkaBootstrapUrlPlain,
 		rtKafkaTopicName,
 		pkgTest.CoreV1ObjectReference(resources.InMemoryChannelKind, resources.MessagingAPIVersion, rtChannelName),
 		contribresources.WithNameV1Beta1(rtKafkaSourceName),


### PR DESCRIPTION
Fixes #200 

Adds SASL mechanism support for the kafkasource, adds a variety of testing, including e2e testing with plain (no auth), sasl512 and tls