### PR TITLE
Close request body for tcp connection reuse

### DIFF
--- a/pkg/source/adapter/adapter.go
+++ b/pkg/source/adapter/adapter.go
@@ -136,6 +136,10 @@ func (a *Adapter) Handle(ctx context.Context, msg *sarama.ConsumerMessage) (bool
 		a.logger.Debug("Error while sending the message", zap.Error(err))
 		return false, err // Error while sending, don't commit offset
 	}
+	// Always try to close body so the connection can be reused afterwards
+	if res.Body != nil {
+		res.Body.Close()
+	}
 
 	if res.StatusCode/100 != 2 {
 		a.logger.Debug("Unexpected status code", zap.Int("status code", res.StatusCode))


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

Missing Close() for unused response body blocked tcp connections from being reused within process scope. This significantly reduces performance.

## Proposed Changes

- 🧽 Improved performance of delivering messages
