### PR TITLE
Fix label consistency

### DIFF
--- a/pkg/source/reconciler/source/resources/labels.go
+++ b/pkg/source/reconciler/source/resources/labels.go
@@ -25,6 +25,6 @@ const (
 func GetLabels(name string) map[string]string {
 	return map[string]string{
 		"eventing.knative.dev/source":     controllerAgentName,
-		"eventing.knative.dev/SourceName": name,
+		"eventing.knative.dev/sourceName": name,
 	}
 }

--- a/pkg/source/reconciler/source/resources/labels_test.go
+++ b/pkg/source/reconciler/source/resources/labels_test.go
@@ -28,7 +28,7 @@ func TestGetLabels(t *testing.T) {
 
 	wantLabels := map[string]string{
 		"eventing.knative.dev/source":     "kafka-source-controller",
-		"eventing.knative.dev/SourceName": "testSourceName",
+		"eventing.knative.dev/sourceName": "testSourceName",
 	}
 
 	eq := cmp.Equal(testLabels, wantLabels)

--- a/test/e2e/helpers/kafka_helper.go
+++ b/test/e2e/helpers/kafka_helper.go
@@ -269,7 +269,7 @@ func CheckKafkaSourceState(ctx context.Context, c *testlib.Client, name string, 
 //On timeout reports error
 func CheckRADeployment(ctx context.Context, c *testlib.Client, name string, inState func(deps *appsv1.DeploymentList) (bool, error)) error {
 	listOptions := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", "eventing.knative.dev/SourceName", name),
+		LabelSelector: fmt.Sprintf("%s=%s", "eventing.knative.dev/sourceName", name),
 	}
 	kDeps := c.Kube.AppsV1().Deployments(c.Namespace)
 	var lastState *appsv1.DeploymentList


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Label source name has a different spelling in [eventing repo](https://github.com/knative/eventing/blob/241af67e1844c9363869ca4141b910d0bc9819c6/pkg/reconciler/apiserversource/resources/labels.go#L28)
- We should keep things consistent because tooling may rely on these labels etc. In my case this makes hard to parse metric labels.
- Ping source btw seems to have its [own special label](https://github.com/knative/eventing/blob/241af67e1844c9363869ca4141b910d0bc9819c6/pkg/reconciler/pingsource/resources/labels.go#L28).
<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

