### PR TITLE
Fix flaky metrics, health, and observability tests

### DIFF
--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -96,7 +96,10 @@ func main() {
 
 	// Start The Liveness And Readiness Servers
 	healthServer := dispatcherhealth.NewDispatcherHealthServer(strconv.Itoa(environment.HealthPort))
-	healthServer.Start(logger)
+	err = healthServer.Start(logger)
+	if err != nil {
+		logger.Fatal("Failed To Initialize Health Server - Terminating", zap.Error(err))
+	}
 
 	statsReporter := metrics.NewStatsReporter(logger)
 

--- a/cmd/channel/distributed/receiver/main.go
+++ b/cmd/channel/distributed/receiver/main.go
@@ -99,8 +99,10 @@ func main() {
 
 	// Start The Liveness And Readiness Servers
 	healthServer := channelhealth.NewChannelHealthServer(strconv.Itoa(environment.HealthPort))
-	healthServer.Start(logger)
-
+	err = healthServer.Start(logger)
+	if err != nil {
+		logger.Fatal("Failed To Initialize Health Server - Terminating", zap.Error(err))
+	}
 	// Initialize The KafkaChannel Lister Used To Validate Events
 	err = channel.InitializeKafkaChannelLister(ctx, *serverURL, *kubeconfig, healthServer, environment.ResyncPeriod)
 	if err != nil {

--- a/pkg/channel/distributed/common/config/observability.go
+++ b/pkg/channel/distributed/common/config/observability.go
@@ -34,9 +34,13 @@ import (
 	"knative.dev/pkg/profiling"
 )
 
-var ListenAndServeWrapper = func(srv *nethttp.Server) func() error { return srv.ListenAndServe }
-var StartWatcherWrapper = func(cmw *configmap.InformedWatcher, done <-chan struct{}) error { return cmw.Start(done) }
-var UpdateExporterWrapper = metrics.UpdateExporter
+// These wrapper functions are to facilitate minimally-invasive unit testing of the
+// InitializeObservability functionality without requiring live servers to be started.
+var (
+	ListenAndServeWrapper = func(srv *nethttp.Server) func() error { return srv.ListenAndServe }
+	StartWatcherWrapper   = func(cmw *configmap.InformedWatcher, done <-chan struct{}) error { return cmw.Start(done) }
+	UpdateExporterWrapper = metrics.UpdateExporter
+)
 
 //
 // Initialize The Specified Context With A Profiling Server (ConfigMap Watcher And HTTP Endpoint)

--- a/pkg/channel/distributed/common/health/health.go
+++ b/pkg/channel/distributed/common/health/health.go
@@ -86,10 +86,11 @@ func (hs *Server) initializeServer(httpPort string) {
 }
 
 // Start The HTTP Server (Blocking Call)
-func (hs *Server) Start(logger *zap.Logger) {
+func (hs *Server) Start(logger *zap.Logger) error {
 	listener, err := net.Listen("tcp", ":"+hs.HttpPort)
 	if err != nil {
 		logger.Error("Server HTTP Listen Returned Error", zap.Error(err))
+		return err
 	}
 
 	// Set the HttpPort field to whatever port was actually used by the system
@@ -105,6 +106,8 @@ func (hs *Server) Start(logger *zap.Logger) {
 			logger.Info("Server HTTP Serve Returned Error", zap.Error(err)) // Info log since it could just be normal shutdown
 		}
 	}()
+
+	return nil
 }
 
 // Stop The HTTP Server Listening For Requests

--- a/pkg/channel/distributed/common/health/health_test.go
+++ b/pkg/channel/distributed/common/health/health_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package health
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io"
-	logtesting "knative.dev/pkg/logging/testing"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	logtesting "knative.dev/pkg/logging/testing"
 )
 
 // Test Constants

--- a/pkg/channel/distributed/common/health/health_test.go
+++ b/pkg/channel/distributed/common/health/health_test.go
@@ -17,20 +17,16 @@ limitations under the License.
 package health
 
 import (
+	"github.com/stretchr/testify/assert"
 	"io"
+	logtesting "knative.dev/pkg/logging/testing"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	logtesting "knative.dev/pkg/logging/testing"
 )
 
 // Test Constants
 const (
-	testHttpHost  = "localhost"
 	livenessPath  = "/healthz"
 	readinessPath = "/healthy"
 )
@@ -153,32 +149,6 @@ func TestHealthServer(t *testing.T) {
 //
 // Private Utility Functions
 //
-
-// Waits Until A GET Request Succeeds (Or Times Out)
-func waitServerReady(uri string, timeout time.Duration) {
-	// Create An HTTP Client And Send The Request Until Success Or Timeout
-	client := http.DefaultClient
-	for start := time.Now(); time.Since(start) < timeout; {
-		_, err := client.Get(uri) // Don't care what the response actually is, only if there was an error getting it
-		if err == nil {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-}
-
-// Sends A Simple GET Event To A URL Expecting A Specific Response Code
-func getEventToServer(t *testing.T, uri *url.URL, expectedStatus int) {
-
-	// Create An HTTP Client And Send The Request
-	client := http.DefaultClient
-	resp, err := client.Get(uri.String())
-
-	// Verify The Client Response Is As Expected
-	assert.NotNil(t, resp)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedStatus, resp.StatusCode)
-}
 
 // Sends A Request To An HTTP Response Recorder Directly Expecting A Specific Response Code
 func getEventToHandler(t *testing.T, handlerFunc http.HandlerFunc, path string, expectedStatus int) {

--- a/pkg/channel/distributed/common/metrics/stats_reporter.go
+++ b/pkg/channel/distributed/common/metrics/stats_reporter.go
@@ -132,7 +132,7 @@ func (r *Reporter) Report(stats map[string]map[string]interface{}) {
 						return
 					}
 
-					// RecordWrapper The Produced Message Count Metric
+					// Record The Produced Message Count Metric
 					RecordWrapper(ctx, producedMessageCount.M(msgCount))
 
 				} else {

--- a/pkg/channel/distributed/common/metrics/stats_reporter.go
+++ b/pkg/channel/distributed/common/metrics/stats_reporter.go
@@ -87,6 +87,8 @@ func NewStatsReporter(log *zap.Logger) StatsReporter {
 }
 
 // Our RecordWrapper, which defaults to the knative metrics.Record()
+// This wrapper function facilitates minimally-invasive unit testing of the
+// Report functionality without requiring live servers to be started.
 var RecordWrapper = metrics.Record
 
 //

--- a/pkg/channel/distributed/common/metrics/stats_reporter.go
+++ b/pkg/channel/distributed/common/metrics/stats_reporter.go
@@ -86,6 +86,9 @@ func NewStatsReporter(log *zap.Logger) StatsReporter {
 	return &Reporter{logger: log}
 }
 
+// Our RecordWrapper, which defaults to the knative metrics.Record()
+var RecordWrapper = metrics.Record
+
 //
 // Report The Sarama Metrics (go-metrics) Via Knative / OpenCensus Metrics
 //
@@ -129,8 +132,8 @@ func (r *Reporter) Report(stats map[string]map[string]interface{}) {
 						return
 					}
 
-					// Record The Produced Message Count Metric
-					metrics.Record(ctx, producedMessageCount.M(msgCount))
+					// RecordWrapper The Produced Message Count Metric
+					RecordWrapper(ctx, producedMessageCount.M(msgCount))
 
 				} else {
 					r.logger.Warn("Encountered Non Int64 'count' Field In Metric", zap.String("Metric", metricKey))

--- a/pkg/channel/distributed/common/metrics/stats_reporter_test.go
+++ b/pkg/channel/distributed/common/metrics/stats_reporter_test.go
@@ -18,9 +18,7 @@ package metrics
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -90,26 +88,4 @@ func createTestMetrics(topic string, count int64) map[string]map[string]interfac
 	testMetrics["response-size"] = map[string]interface{}{"75%": 503.25, "95%": 1797, "99%": 1797, "99.9%": 1797, "count": 6, "max": 1797, "mean": 359.5, "median": 72, "min": 72, "stddev": 642.8695435311895}
 	testMetrics["response-size-for-broker-0"] = map[string]interface{}{"75%": 72, "95%": 72, "99%": 72, "99.9%": 72, "count": 5, "max": 72, "mean": 72, "median": 72, "min": 72, "stddev": 0}
 	return testMetrics
-}
-
-// Verifies that the metrics response string slice contains the desired values
-// This is test code so a quick regex check will suffice rather than parsing the Prometheus output in a more structured manner
-func verifyMetric(body []string, name string, topicName string, expectedValue string) bool {
-	for _, line := range body {
-		if isMatch(line, fmt.Sprintf(`^%s`, name)) &&
-			isMatch(line, fmt.Sprintf(`topic="%s"`, topicName)) &&
-			isMatch(line, fmt.Sprintf(` %s$`, expectedValue)) {
-			return true
-		}
-	}
-	return false
-}
-
-// Simple regex match that treats errors as false, for testing only
-func isMatch(source string, regex string) bool {
-	match, err := regexp.MatchString(regex, source)
-	if err != nil {
-		return false
-	}
-	return match
 }

--- a/pkg/channel/distributed/common/metrics/stats_reporter_test.go
+++ b/pkg/channel/distributed/common/metrics/stats_reporter_test.go
@@ -53,7 +53,9 @@ func TestMetricsServer_Report(t *testing.T) {
 
 	// Set up a mock RecordWrapper() that will capture the produced message count from our stats reporter
 	RecordWrapper = func(ctx context.Context, ms ocstats.Measurement, ros ...ocstats.Options) {
-		measuredMsgCount += ms.Value()
+		if ms.Measure().Name() == "produced_msg_count" {
+			measuredMsgCount += ms.Value()
+		}
 	}
 
 	// Perform The Test


### PR DESCRIPTION
Fixes #218 

## Proposed Changes

- 🐛 The "live server" tests are not necessary for decent code coverage during unit testing; replaced with mocks
