### PR TITLE
Increase health check timeouts to allow Sarama timeouts

### DIFF
--- a/pkg/channel/distributed/controller/constants/constants.go
+++ b/pkg/channel/distributed/controller/constants/constants.go
@@ -88,12 +88,12 @@ const (
 
 	// Health Configuration
 	HealthPort                = 8082
-	ChannelLivenessDelay      = 10
+	ChannelLivenessDelay      = 30
 	ChannelLivenessPeriod     = 5
-	ChannelReadinessDelay     = 10
+	ChannelReadinessDelay     = 30
 	ChannelReadinessPeriod    = 5
-	DispatcherLivenessDelay   = 10
+	DispatcherLivenessDelay   = 30
 	DispatcherLivenessPeriod  = 5
-	DispatcherReadinessDelay  = 10
+	DispatcherReadinessDelay  = 30
 	DispatcherReadinessPeriod = 5
 )

--- a/pkg/channel/distributed/receiver/producer/producer.go
+++ b/pkg/channel/distributed/receiver/producer/producer.go
@@ -61,7 +61,7 @@ func NewProducer(logger *zap.Logger,
 	healthServer *health.Server) (*Producer, error) {
 
 	// Create The Kafka Producer Using The Specified Kafka Authentication
-	logger.Error("Creating Kafka SyncProducer")
+	logger.Info("Creating Kafka SyncProducer")
 	kafkaProducer, metricsRegistry, err := createSyncProducerWrapper(config, brokers)
 	if err != nil {
 		logger.Error("Failed To Create Kafka SyncProducer - Exiting", zap.Error(err), zap.Any("Brokers", brokers))

--- a/pkg/channel/distributed/receiver/producer/producer.go
+++ b/pkg/channel/distributed/receiver/producer/producer.go
@@ -61,6 +61,7 @@ func NewProducer(logger *zap.Logger,
 	healthServer *health.Server) (*Producer, error) {
 
 	// Create The Kafka Producer Using The Specified Kafka Authentication
+	logger.Error("Creating Kafka SyncProducer")
 	kafkaProducer, metricsRegistry, err := createSyncProducerWrapper(config, brokers)
 	if err != nil {
 		logger.Error("Failed To Create Kafka SyncProducer - Exiting", zap.Error(err), zap.Any("Brokers", brokers))


### PR DESCRIPTION
The health (liveness and readiness) checks in the distributed channel caused a restart of the pod in 25 seconds (10 + 3*5) if Sarama was not ready by that point.  The timeout for the TCP dialer defaults to 30 seconds (in sarama/config.go) so the pod would restart (and take any logging information with it) without the administration being able to see the error response in the logs.

## Proposed Changes

- 🧽  Increase initial health check timeouts to cover the default Net.Dialer.Timeout that sarama uses when connecting via the broker string to 45 seconds (30 + 5*3)

