### PR TITLE
Removing verbose info logger

### DIFF
--- a/pkg/channel/consolidated/kafka/admin.go
+++ b/pkg/channel/consolidated/kafka/admin.go
@@ -50,7 +50,7 @@ type AdminClientManager struct {
 
 func NewAdminClient(ctx context.Context, caFactory ClusterAdminFactory) (AdminClient, error) {
 	logger := logging.FromContext(ctx)
-	logger.Info("Creating a new AdminClient")
+	logger.Debug("Creating a new AdminClient")
 	kafkaClusterAdmin, err := caFactory()
 	if err != nil {
 		logger.Errorw("error while creating ClusterAdmin", zap.Error(err))
@@ -70,7 +70,7 @@ func NewAdminClient(ctx context.Context, caFactory ClusterAdminFactory) (AdminCl
 // a new ClusterAdmin will be created with every retry until the call succeeds or
 // the timeout is reached.
 func (c *AdminClientManager) ListConsumerGroups() ([]string, error) {
-	c.logger.Info("Attempting to list consumer group")
+	c.logger.Debug("Attempting to list consumer group")
 	mutex.Lock()
 	defer mutex.Unlock()
 	r := 0


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- fixing verbose logger (especially the `Attempting to list consumer group` line)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
