### PR TITLE
Fix error format in adapter

### DIFF
--- a/pkg/source/adapter/adapter.go
+++ b/pkg/source/adapter/adapter.go
@@ -106,7 +106,7 @@ func (a *Adapter) start(stopCh <-chan struct{}) error {
 	// Track errors
 	go func() {
 		for err := range group.Errors() {
-			a.logger.Errorw("An error has occurred while consuming messages occurred: ", zap.Error(err))
+			a.logger.Errorw("Error while consuming messages", zap.Error(err))
 		}
 	}()
 


### PR DESCRIPTION
## Proposed Changes

Someone reported that error in Slack, and the repetition of "occurred" caught my attention.

I also shortened the message while I was at it. Less is more.

**Release Note**

```release-note
```

**Docs**