### PR TITLE
Read resp body for connection reuse

### DIFF
--- a/pkg/source/adapter/adapter.go
+++ b/pkg/source/adapter/adapter.go
@@ -18,6 +18,8 @@ package kafka
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -136,8 +138,9 @@ func (a *Adapter) Handle(ctx context.Context, msg *sarama.ConsumerMessage) (bool
 		a.logger.Debug("Error while sending the message", zap.Error(err))
 		return false, err // Error while sending, don't commit offset
 	}
-	// Always try to close body so the connection can be reused afterwards
+	// Always try to read and close body so the connection can be reused afterwards
 	if res.Body != nil {
+		io.Copy(ioutil.Discard, res.Body)
 		res.Body.Close()
 	}
 


### PR DESCRIPTION
Fixes #

This PR works as a complement for [Pull 239](https://github.com/knative-sandbox/eventing-kafka/pull/239). 
Inorder to reuse TCP connection for HTTP requests with `KeepAlive: true`, request body MUST be read and closed manually. Otherwise, lots of tcp connections will be created and stays TIME_WAIT, resulting errors like "cannot assign requested address".

Without this code change, users may adjust sysctl parameters below as workaround:
```
net.ipv4.tcp_tw_reuse=1
net.ipv4.tcp_fin_timeout=15
```