### PR TITLE
Remove default limits

### DIFF
--- a/config/channel/distributed/300-eventing-kafka-configmap.yaml
+++ b/config/channel/distributed/300-eventing-kafka-configmap.yaml
@@ -39,15 +39,11 @@ data:
       RequiredAcks: -1  # -1 = WaitForAll, Most stringent option for "at-least-once" delivery.
   eventing-kafka: |
     receiver:
-      cpuLimit: 200m
       cpuRequest: 100m
-      memoryLimit: 100Mi
       memoryRequest: 50Mi
       replicas: 1
     dispatcher:
-      cpuLimit: 500m
-      cpuRequest: 300m
-      memoryLimit: 128Mi
+      cpuRequest: 100m
       memoryRequest: 50Mi
       replicas: 1
     kafka:

--- a/config/channel/distributed/500-controller-deployment.yaml
+++ b/config/channel/distributed/500-controller-deployment.yaml
@@ -67,5 +67,5 @@ spec:
           value: "ko://knative.dev/eventing-kafka/cmd/channel/distributed/dispatcher"
         resources:
           requests:
-            cpu: 100m
-            memory: 50Mi
+            cpu: 20m
+            memory: 25Mi

--- a/config/channel/distributed/500-controller-deployment.yaml
+++ b/config/channel/distributed/500-controller-deployment.yaml
@@ -67,8 +67,5 @@ spec:
           value: "ko://knative.dev/eventing-kafka/cmd/channel/distributed/dispatcher"
         resources:
           requests:
-            cpu: 20m
-            memory: 25Mi
-          limits:
             cpu: 100m
             memory: 50Mi

--- a/pkg/channel/distributed/common/kafka/sarama/sarama_test.go
+++ b/pkg/channel/distributed/common/kafka/sarama/sarama_test.go
@@ -39,15 +39,11 @@ const (
 	// EKDefaultConfigYaml is intended to match what's in 200-eventing-kafka-configmap.yaml
 	EKDefaultConfigYaml = `
 receiver:
-  cpuLimit: 200m
   cpuRequest: 100m
-  memoryLimit: 100Mi
   memoryRequest: 50Mi
   replicas: 1
 dispatcher:
-  cpuLimit: 500m
-  cpuRequest: 300m
-  memoryLimit: 128Mi
+  cpuRequest: 100m
   memoryRequest: 50Mi
   replicas: 1
 kafka:
@@ -214,17 +210,17 @@ func TestLoadDefaultSaramaSettings(t *testing.T) {
 
 	// Make sure all of our default eventing-kafka settings were loaded properly
 	// Specifically checking the type (e.g. int64, int16, int) is important
-	assert.Equal(t, resource.MustParse("200m"), configuration.Receiver.CpuLimit)
+	assert.Equal(t, resource.Quantity{}, configuration.Receiver.CpuLimit)
 	assert.Equal(t, resource.MustParse("100m"), configuration.Receiver.CpuRequest)
-	assert.Equal(t, resource.MustParse("100Mi"), configuration.Receiver.MemoryLimit)
+	assert.Equal(t, resource.Quantity{}, configuration.Receiver.MemoryLimit)
 	assert.Equal(t, resource.MustParse("50Mi"), configuration.Receiver.MemoryRequest)
 	assert.Equal(t, 1, configuration.Receiver.Replicas)
 	assert.Equal(t, int32(4), configuration.Kafka.Topic.DefaultNumPartitions)
 	assert.Equal(t, int16(1), configuration.Kafka.Topic.DefaultReplicationFactor)
 	assert.Equal(t, int64(604800000), configuration.Kafka.Topic.DefaultRetentionMillis)
-	assert.Equal(t, resource.MustParse("500m"), configuration.Dispatcher.CpuLimit)
-	assert.Equal(t, resource.MustParse("300m"), configuration.Dispatcher.CpuRequest)
-	assert.Equal(t, resource.MustParse("128Mi"), configuration.Dispatcher.MemoryLimit)
+	assert.Equal(t, resource.Quantity{}, configuration.Dispatcher.CpuLimit)
+	assert.Equal(t, resource.MustParse("100m"), configuration.Dispatcher.CpuRequest)
+	assert.Equal(t, resource.Quantity{}, configuration.Dispatcher.MemoryLimit)
 	assert.Equal(t, resource.MustParse("50Mi"), configuration.Dispatcher.MemoryRequest)
 	assert.Equal(t, 1, configuration.Dispatcher.Replicas)
 	assert.Equal(t, "azure", configuration.Kafka.AdminType)

--- a/pkg/channel/distributed/controller/config/config.go
+++ b/pkg/channel/distributed/controller/config/config.go
@@ -19,7 +19,6 @@ package config
 import (
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/config"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/constants"
 )
@@ -53,15 +52,15 @@ func VerifyConfiguration(configuration *config.EventingKafkaConfig) error {
 		return ControllerConfigurationError("Kafka.Topic.DefaultReplicationFactor must be > 0")
 	case configuration.Kafka.Topic.DefaultRetentionMillis < 1:
 		return ControllerConfigurationError("Kafka.Topic.DefaultRetentionMillis must be > 0")
-	case configuration.Dispatcher.CpuRequest == resource.Quantity{}:
+	case configuration.Dispatcher.CpuRequest.IsZero():
 		return ControllerConfigurationError("Dispatcher.CpuRequest must be nonzero")
-	case configuration.Dispatcher.MemoryRequest == resource.Quantity{}:
+	case configuration.Dispatcher.MemoryRequest.IsZero():
 		return ControllerConfigurationError("Dispatcher.MemoryRequest must be nonzero")
 	case configuration.Dispatcher.Replicas < 1:
 		return ControllerConfigurationError("Dispatcher.Replicas must be > 0")
-	case configuration.Receiver.CpuRequest == resource.Quantity{}:
+	case configuration.Receiver.CpuRequest.IsZero():
 		return ControllerConfigurationError("Receiver.CpuRequest must be nonzero")
-	case configuration.Receiver.MemoryRequest == resource.Quantity{}:
+	case configuration.Receiver.MemoryRequest.IsZero():
 		return ControllerConfigurationError("Receiver.MemoryRequest must be nonzero")
 	case configuration.Receiver.Replicas < 1:
 		return ControllerConfigurationError("Receiver.Replicas must be > 0")

--- a/pkg/channel/distributed/controller/config/config.go
+++ b/pkg/channel/distributed/controller/config/config.go
@@ -52,16 +52,8 @@ func VerifyConfiguration(configuration *config.EventingKafkaConfig) error {
 		return ControllerConfigurationError("Kafka.Topic.DefaultReplicationFactor must be > 0")
 	case configuration.Kafka.Topic.DefaultRetentionMillis < 1:
 		return ControllerConfigurationError("Kafka.Topic.DefaultRetentionMillis must be > 0")
-	case configuration.Dispatcher.CpuRequest.IsZero():
-		return ControllerConfigurationError("Dispatcher.CpuRequest must be nonzero")
-	case configuration.Dispatcher.MemoryRequest.IsZero():
-		return ControllerConfigurationError("Dispatcher.MemoryRequest must be nonzero")
 	case configuration.Dispatcher.Replicas < 1:
 		return ControllerConfigurationError("Dispatcher.Replicas must be > 0")
-	case configuration.Receiver.CpuRequest.IsZero():
-		return ControllerConfigurationError("Receiver.CpuRequest must be nonzero")
-	case configuration.Receiver.MemoryRequest.IsZero():
-		return ControllerConfigurationError("Receiver.MemoryRequest must be nonzero")
 	case configuration.Receiver.Replicas < 1:
 		return ControllerConfigurationError("Receiver.Replicas must be > 0")
 	}

--- a/pkg/channel/distributed/controller/config/config.go
+++ b/pkg/channel/distributed/controller/config/config.go
@@ -53,22 +53,14 @@ func VerifyConfiguration(configuration *config.EventingKafkaConfig) error {
 		return ControllerConfigurationError("Kafka.Topic.DefaultReplicationFactor must be > 0")
 	case configuration.Kafka.Topic.DefaultRetentionMillis < 1:
 		return ControllerConfigurationError("Kafka.Topic.DefaultRetentionMillis must be > 0")
-	case configuration.Dispatcher.CpuLimit == resource.Quantity{}:
-		return ControllerConfigurationError("Dispatcher.CpuLimit must be nonzero")
 	case configuration.Dispatcher.CpuRequest == resource.Quantity{}:
 		return ControllerConfigurationError("Dispatcher.CpuRequest must be nonzero")
-	case configuration.Dispatcher.MemoryLimit == resource.Quantity{}:
-		return ControllerConfigurationError("Dispatcher.MemoryLimit must be nonzero")
 	case configuration.Dispatcher.MemoryRequest == resource.Quantity{}:
 		return ControllerConfigurationError("Dispatcher.MemoryRequest must be nonzero")
 	case configuration.Dispatcher.Replicas < 1:
 		return ControllerConfigurationError("Dispatcher.Replicas must be > 0")
-	case configuration.Receiver.CpuLimit == resource.Quantity{}:
-		return ControllerConfigurationError("Receiver.CpuLimit must be nonzero")
 	case configuration.Receiver.CpuRequest == resource.Quantity{}:
 		return ControllerConfigurationError("Receiver.CpuRequest must be nonzero")
-	case configuration.Receiver.MemoryLimit == resource.Quantity{}:
-		return ControllerConfigurationError("Receiver.MemoryLimit must be nonzero")
 	case configuration.Receiver.MemoryRequest == resource.Quantity{}:
 		return ControllerConfigurationError("Receiver.MemoryRequest must be nonzero")
 	case configuration.Receiver.Replicas < 1:

--- a/pkg/channel/distributed/controller/config/config_test.go
+++ b/pkg/channel/distributed/controller/config/config_test.go
@@ -52,18 +52,18 @@ type TestCase struct {
 	// Config settings
 	kafkaTopicDefaultNumPartitions     int32
 	kafkaTopicDefaultReplicationFactor int16
-	kafkaTopicDefaultRetentionMillis int64
-	kafkaAdminType          string
-	dispatcherCpuLimit      resource.Quantity
-	dispatcherCpuRequest    resource.Quantity
-	dispatcherMemoryLimit   resource.Quantity
-	dispatcherMemoryRequest resource.Quantity
-	dispatcherReplicas      int
-	receiverCpuLimit        resource.Quantity
-	receiverCpuRequest      resource.Quantity
-	receiverMemoryLimit     resource.Quantity
-	receiverMemoryRequest   resource.Quantity
-	receiverReplicas        int
+	kafkaTopicDefaultRetentionMillis   int64
+	kafkaAdminType                     string
+	dispatcherCpuLimit                 resource.Quantity
+	dispatcherCpuRequest               resource.Quantity
+	dispatcherMemoryLimit              resource.Quantity
+	dispatcherMemoryRequest            resource.Quantity
+	dispatcherReplicas                 int
+	receiverCpuLimit                   resource.Quantity
+	receiverCpuRequest                 resource.Quantity
+	receiverMemoryLimit                resource.Quantity
+	receiverMemoryRequest              resource.Quantity
+	receiverReplicas                   int
 
 	expectedError error
 }
@@ -129,7 +129,7 @@ func TestVerifyConfiguration(t *testing.T) {
 	testCase = getValidTestCase("Valid Config - Dispatcher.MemoryRequest = Zero (unlimited)")
 	testCase.dispatcherMemoryRequest = resource.Quantity{}
 	testCases = append(testCases, testCase)
-	
+
 	testCase = getValidTestCase("Invalid Config - Dispatcher.Replicas")
 	testCase.dispatcherReplicas = -1
 	testCase.expectedError = ControllerConfigurationError("Dispatcher.Replicas must be > 0")

--- a/pkg/channel/distributed/controller/config/config_test.go
+++ b/pkg/channel/distributed/controller/config/config_test.go
@@ -114,19 +114,9 @@ func TestVerifyConfiguration(t *testing.T) {
 	testCase.expectedError = ControllerConfigurationError("Kafka.Topic.DefaultRetentionMillis must be > 0")
 	testCases = append(testCases, testCase)
 
-	testCase = getValidTestCase("Invalid Config - Dispatcher.CpuLimit")
-	testCase.dispatcherCpuLimit = resource.Quantity{}
-	testCase.expectedError = ControllerConfigurationError("Dispatcher.CpuLimit must be nonzero")
-	testCases = append(testCases, testCase)
-
 	testCase = getValidTestCase("Invalid Config - Dispatcher.CpuRequest")
 	testCase.dispatcherCpuRequest = resource.Quantity{}
 	testCase.expectedError = ControllerConfigurationError("Dispatcher.CpuRequest must be nonzero")
-	testCases = append(testCases, testCase)
-
-	testCase = getValidTestCase("Invalid Config - Dispatcher.MemoryLimit")
-	testCase.dispatcherMemoryLimit = resource.Quantity{}
-	testCase.expectedError = ControllerConfigurationError("Dispatcher.MemoryLimit must be nonzero")
 	testCases = append(testCases, testCase)
 
 	testCase = getValidTestCase("Invalid Config - Dispatcher.MemoryRequest")
@@ -139,19 +129,9 @@ func TestVerifyConfiguration(t *testing.T) {
 	testCase.expectedError = ControllerConfigurationError("Dispatcher.Replicas must be > 0")
 	testCases = append(testCases, testCase)
 
-	testCase = getValidTestCase("Invalid Config - Receiver.CpuLimit")
-	testCase.channelCpuLimit = resource.Quantity{}
-	testCase.expectedError = ControllerConfigurationError("Receiver.CpuLimit must be nonzero")
-	testCases = append(testCases, testCase)
-
 	testCase = getValidTestCase("Invalid Config - Receiver.CpuRequest")
 	testCase.channelCpuRequest = resource.Quantity{}
 	testCase.expectedError = ControllerConfigurationError("Receiver.CpuRequest must be nonzero")
-	testCases = append(testCases, testCase)
-
-	testCase = getValidTestCase("Invalid Config - Receiver.MemoryLimit")
-	testCase.channelMemoryLimit = resource.Quantity{}
-	testCase.expectedError = ControllerConfigurationError("Receiver.MemoryLimit must be nonzero")
 	testCases = append(testCases, testCase)
 
 	testCase = getValidTestCase("Invalid Config - Receiver.MemoryRequest")

--- a/pkg/channel/distributed/controller/config/config_test.go
+++ b/pkg/channel/distributed/controller/config/config_test.go
@@ -122,6 +122,14 @@ func TestVerifyConfiguration(t *testing.T) {
 	testCase.dispatcherMemoryLimit = resource.Quantity{}
 	testCases = append(testCases, testCase)
 
+	testCase = getValidTestCase("Valid Config - Dispatcher.CpuRequest = Zero (unlimited)")
+	testCase.dispatcherCpuRequest = resource.Quantity{}
+	testCases = append(testCases, testCase)
+
+	testCase = getValidTestCase("Valid Config - Dispatcher.MemoryRequest = Zero (unlimited)")
+	testCase.dispatcherMemoryRequest = resource.Quantity{}
+	testCases = append(testCases, testCase)
+	
 	testCase = getValidTestCase("Invalid Config - Dispatcher.Replicas")
 	testCase.dispatcherReplicas = -1
 	testCase.expectedError = ControllerConfigurationError("Dispatcher.Replicas must be > 0")
@@ -133,6 +141,14 @@ func TestVerifyConfiguration(t *testing.T) {
 
 	testCase = getValidTestCase("Valid Config - Receiver.MemoryLimit = Zero (unlimited)")
 	testCase.receiverMemoryLimit = resource.Quantity{}
+	testCases = append(testCases, testCase)
+
+	testCase = getValidTestCase("Valid Config - Receiver.CpuRequest = Zero (unlimited)")
+	testCase.receiverCpuRequest = resource.Quantity{}
+	testCases = append(testCases, testCase)
+
+	testCase = getValidTestCase("Valid Config - Receiver.MemoryRequest = Zero (unlimited)")
+	testCase.receiverMemoryRequest = resource.Quantity{}
 	testCases = append(testCases, testCase)
 
 	testCase = getValidTestCase("Invalid Config - Receiver.Replicas")

--- a/pkg/channel/distributed/controller/config/config_test.go
+++ b/pkg/channel/distributed/controller/config/config_test.go
@@ -38,11 +38,11 @@ const (
 	dispatcherMemoryLimit   = "50Mi"
 	dispatcherCpuLimit      = "300m"
 
-	channelReplicas      = 1
-	channelMemoryRequest = "10Mi"
-	channelCpuRquest     = "10m"
-	channelMemoryLimit   = "20Mi"
-	channelCpuLimit      = "100m"
+	receiverReplicas      = 1
+	receiverMemoryRequest = "10Mi"
+	receiverCpuRquest     = "10m"
+	receiverMemoryLimit   = "20Mi"
+	receiverCpuLimit      = "100m"
 )
 
 // Define The TestCase Struct
@@ -52,18 +52,18 @@ type TestCase struct {
 	// Config settings
 	kafkaTopicDefaultNumPartitions     int32
 	kafkaTopicDefaultReplicationFactor int16
-	kafkaTopicDefaultRetentionMillis   int64
-	kafkaAdminType                     string
-	dispatcherCpuLimit                 resource.Quantity
-	dispatcherCpuRequest               resource.Quantity
-	dispatcherMemoryLimit              resource.Quantity
-	dispatcherMemoryRequest            resource.Quantity
-	dispatcherReplicas                 int
-	channelCpuLimit                    resource.Quantity
-	channelCpuRequest                  resource.Quantity
-	channelMemoryLimit                 resource.Quantity
-	channelMemoryRequest               resource.Quantity
-	channelReplicas                    int
+	kafkaTopicDefaultRetentionMillis int64
+	kafkaAdminType          string
+	dispatcherCpuLimit      resource.Quantity
+	dispatcherCpuRequest    resource.Quantity
+	dispatcherMemoryLimit   resource.Quantity
+	dispatcherMemoryRequest resource.Quantity
+	dispatcherReplicas      int
+	receiverCpuLimit        resource.Quantity
+	receiverCpuRequest      resource.Quantity
+	receiverMemoryLimit     resource.Quantity
+	receiverMemoryRequest   resource.Quantity
+	receiverReplicas        int
 
 	expectedError error
 }
@@ -81,11 +81,11 @@ func getValidTestCase(name string) TestCase {
 		dispatcherMemoryLimit:              resource.MustParse(dispatcherMemoryLimit),
 		dispatcherMemoryRequest:            resource.MustParse(dispatcherMemoryRequest),
 		dispatcherReplicas:                 dispatcherReplicas,
-		channelCpuLimit:                    resource.MustParse(channelCpuLimit),
-		channelCpuRequest:                  resource.MustParse(channelCpuRquest),
-		channelMemoryLimit:                 resource.MustParse(channelMemoryLimit),
-		channelMemoryRequest:               resource.MustParse(channelMemoryRequest),
-		channelReplicas:                    channelReplicas,
+		receiverCpuLimit:                   resource.MustParse(receiverCpuLimit),
+		receiverCpuRequest:                 resource.MustParse(receiverCpuRquest),
+		receiverMemoryLimit:                resource.MustParse(receiverMemoryLimit),
+		receiverMemoryRequest:              resource.MustParse(receiverMemoryRequest),
+		receiverReplicas:                   receiverReplicas,
 		expectedError:                      nil,
 	}
 }
@@ -114,14 +114,12 @@ func TestVerifyConfiguration(t *testing.T) {
 	testCase.expectedError = ControllerConfigurationError("Kafka.Topic.DefaultRetentionMillis must be > 0")
 	testCases = append(testCases, testCase)
 
-	testCase = getValidTestCase("Invalid Config - Dispatcher.CpuRequest")
-	testCase.dispatcherCpuRequest = resource.Quantity{}
-	testCase.expectedError = ControllerConfigurationError("Dispatcher.CpuRequest must be nonzero")
+	testCase = getValidTestCase("Valid Config - Dispatcher.CpuLimit = Zero (unlimited)")
+	testCase.dispatcherCpuLimit = resource.Quantity{}
 	testCases = append(testCases, testCase)
 
-	testCase = getValidTestCase("Invalid Config - Dispatcher.MemoryRequest")
-	testCase.dispatcherMemoryRequest = resource.Quantity{}
-	testCase.expectedError = ControllerConfigurationError("Dispatcher.MemoryRequest must be nonzero")
+	testCase = getValidTestCase("Valid Config - Dispatcher.MemoryLimit = Zero (unlimited)")
+	testCase.dispatcherMemoryLimit = resource.Quantity{}
 	testCases = append(testCases, testCase)
 
 	testCase = getValidTestCase("Invalid Config - Dispatcher.Replicas")
@@ -129,18 +127,16 @@ func TestVerifyConfiguration(t *testing.T) {
 	testCase.expectedError = ControllerConfigurationError("Dispatcher.Replicas must be > 0")
 	testCases = append(testCases, testCase)
 
-	testCase = getValidTestCase("Invalid Config - Receiver.CpuRequest")
-	testCase.channelCpuRequest = resource.Quantity{}
-	testCase.expectedError = ControllerConfigurationError("Receiver.CpuRequest must be nonzero")
+	testCase = getValidTestCase("Valid Config - Receiver.CpuLimit = Zero (unlimited)")
+	testCase.receiverCpuLimit = resource.Quantity{}
 	testCases = append(testCases, testCase)
 
-	testCase = getValidTestCase("Invalid Config - Receiver.MemoryRequest")
-	testCase.channelMemoryRequest = resource.Quantity{}
-	testCase.expectedError = ControllerConfigurationError("Receiver.MemoryRequest must be nonzero")
+	testCase = getValidTestCase("Valid Config - Receiver.MemoryLimit = Zero (unlimited)")
+	testCase.receiverMemoryLimit = resource.Quantity{}
 	testCases = append(testCases, testCase)
 
 	testCase = getValidTestCase("Invalid Config - Receiver.Replicas")
-	testCase.channelReplicas = -1
+	testCase.receiverReplicas = -1
 	testCase.expectedError = ControllerConfigurationError("Receiver.Replicas must be > 0")
 	testCases = append(testCases, testCase)
 
@@ -161,11 +157,11 @@ func TestVerifyConfiguration(t *testing.T) {
 			testConfig.Dispatcher.MemoryLimit = testCase.dispatcherMemoryLimit
 			testConfig.Dispatcher.MemoryRequest = testCase.dispatcherMemoryRequest
 			testConfig.Dispatcher.Replicas = testCase.dispatcherReplicas
-			testConfig.Receiver.CpuLimit = testCase.channelCpuLimit
-			testConfig.Receiver.CpuRequest = testCase.channelCpuRequest
-			testConfig.Receiver.MemoryLimit = testCase.channelMemoryLimit
-			testConfig.Receiver.MemoryRequest = testCase.channelMemoryRequest
-			testConfig.Receiver.Replicas = testCase.channelReplicas
+			testConfig.Receiver.CpuLimit = testCase.receiverCpuLimit
+			testConfig.Receiver.CpuRequest = testCase.receiverCpuRequest
+			testConfig.Receiver.MemoryLimit = testCase.receiverMemoryLimit
+			testConfig.Receiver.MemoryRequest = testCase.receiverMemoryRequest
+			testConfig.Receiver.Replicas = testCase.receiverReplicas
 
 			// Perform The Test
 			err := VerifyConfiguration(testConfig)
@@ -182,11 +178,11 @@ func TestVerifyConfiguration(t *testing.T) {
 				assert.Equal(t, testCase.dispatcherMemoryLimit, testConfig.Dispatcher.MemoryLimit)
 				assert.Equal(t, testCase.dispatcherMemoryRequest, testConfig.Dispatcher.MemoryRequest)
 				assert.Equal(t, testCase.dispatcherReplicas, testConfig.Dispatcher.Replicas)
-				assert.Equal(t, testCase.channelCpuLimit, testConfig.Receiver.CpuLimit)
-				assert.Equal(t, testCase.channelCpuRequest, testConfig.Receiver.CpuRequest)
-				assert.Equal(t, testCase.channelMemoryLimit, testConfig.Receiver.MemoryLimit)
-				assert.Equal(t, testCase.channelMemoryRequest, testConfig.Receiver.MemoryRequest)
-				assert.Equal(t, testCase.channelReplicas, testConfig.Receiver.Replicas)
+				assert.Equal(t, testCase.receiverCpuLimit, testConfig.Receiver.CpuLimit)
+				assert.Equal(t, testCase.receiverCpuRequest, testConfig.Receiver.CpuRequest)
+				assert.Equal(t, testCase.receiverMemoryLimit, testConfig.Receiver.MemoryLimit)
+				assert.Equal(t, testCase.receiverMemoryRequest, testConfig.Receiver.MemoryRequest)
+				assert.Equal(t, testCase.receiverReplicas, testConfig.Receiver.Replicas)
 			} else {
 				assert.Equal(t, testCase.expectedError, err)
 			}

--- a/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
+++ b/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
@@ -464,7 +464,7 @@ func (r *Reconciler) newDispatcherDeployment(logger *zap.Logger, channel *kafkav
 							Env:             envVars,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: corev1.ResourceRequirements{
-								Limits: limits,
+								Limits:   limits,
 								Requests: requests,
 							},
 						},

--- a/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
+++ b/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
@@ -19,9 +19,10 @@ package kafkachannel
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -386,10 +387,10 @@ func (r *Reconciler) newDispatcherDeployment(logger *zap.Logger, channel *kafkav
 	// There is a difference between setting an entry in the limits map to the zero-value of a Quantity and
 	// not actually having that entry in the map at all.  If we want "no limit" then the entry must not be present.
 	limits := make(map[corev1.ResourceName]resource.Quantity)
-	if ! r.config.Dispatcher.MemoryLimit.IsZero() {
+	if !r.config.Dispatcher.MemoryLimit.IsZero() {
 		limits[corev1.ResourceMemory] = r.config.Dispatcher.MemoryLimit
 	}
-	if ! r.config.Dispatcher.CpuLimit.IsZero() {
+	if !r.config.Dispatcher.CpuLimit.IsZero() {
 		limits[corev1.ResourceCPU] = r.config.Dispatcher.CpuLimit
 	}
 

--- a/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
+++ b/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
@@ -386,21 +386,21 @@ func (r *Reconciler) newDispatcherDeployment(logger *zap.Logger, channel *kafkav
 
 	// There is a difference between setting an entry in the limits or requests map to the zero-value
 	// of a Quantity and not actually having that entry in the map at all.
-	// If we want "no limit" or "no request" then the entry must not be present in the map at all.
+	// If we want "no limit" or "no request" then the entry must not be present in the map.
 	// Note: Since a "Quantity" type has no nil value, we use the Zero value to represent unlimited.
-	limits := make(map[corev1.ResourceName]resource.Quantity)
+	resourceLimits := make(map[corev1.ResourceName]resource.Quantity)
 	if !r.config.Dispatcher.MemoryLimit.IsZero() {
-		limits[corev1.ResourceMemory] = r.config.Dispatcher.MemoryLimit
+		resourceLimits[corev1.ResourceMemory] = r.config.Dispatcher.MemoryLimit
 	}
 	if !r.config.Dispatcher.CpuLimit.IsZero() {
-		limits[corev1.ResourceCPU] = r.config.Dispatcher.CpuLimit
+		resourceLimits[corev1.ResourceCPU] = r.config.Dispatcher.CpuLimit
 	}
-	requests := make(map[corev1.ResourceName]resource.Quantity)
+	resourceRequests := make(map[corev1.ResourceName]resource.Quantity)
 	if !r.config.Dispatcher.MemoryRequest.IsZero() {
-		requests[corev1.ResourceMemory] = r.config.Dispatcher.MemoryRequest
+		resourceRequests[corev1.ResourceMemory] = r.config.Dispatcher.MemoryRequest
 	}
 	if !r.config.Dispatcher.CpuRequest.IsZero() {
-		requests[corev1.ResourceCPU] = r.config.Dispatcher.CpuRequest
+		resourceRequests[corev1.ResourceCPU] = r.config.Dispatcher.CpuRequest
 	}
 
 	// Create The Dispatcher's Deployment
@@ -464,8 +464,8 @@ func (r *Reconciler) newDispatcherDeployment(logger *zap.Logger, channel *kafkav
 							Env:             envVars,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: corev1.ResourceRequirements{
-								Limits:   limits,
-								Requests: requests,
+								Limits:   resourceLimits,
+								Requests: resourceRequests,
 							},
 						},
 					},

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
@@ -237,7 +237,7 @@ func TestReconcile(t *testing.T) {
 				controllertesting.NewKafkaChannelSuccessfulReconciliationEvent(),
 			},
 			OtherTestData: map[string]interface{}{
-				"configOptions": []controllertesting.KafkaConfigOption { controllertesting.WithNoDispatcherResources },
+				"configOptions": []controllertesting.KafkaConfigOption{controllertesting.WithNoDispatcherResources},
 			},
 		},
 

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
@@ -190,13 +190,8 @@ func TestReconcile(t *testing.T) {
 				controllertesting.NewKafkaChannelSuccessfulReconciliationEvent(),
 			},
 		},
-
-		//
-		// Full Reconciliation (No Dispatcher Resource Requests Or Limits)
-		//
-
 		{
-			Name:                    "Complete Reconciliation Success",
+			Name:                    "Complete Reconciliation Success, No Dispatcher Resource Requests Or Limits",
 			SkipNamespaceValidation: true,
 			Key:                     controllertesting.KafkaChannelKey,
 			Objects: []runtime.Object{

--- a/pkg/channel/distributed/controller/kafkasecret/receiver.go
+++ b/pkg/channel/distributed/controller/kafkasecret/receiver.go
@@ -266,21 +266,21 @@ func (r *Reconciler) newReceiverDeployment(logger *zap.Logger, secret *corev1.Se
 
 	// There is a difference between setting an entry in the limits or requests map to the zero-value
 	// of a Quantity and not actually having that entry in the map at all.
-	// If we want "no limit" or "no request" then the entry must not be present in the map at all.
+	// If we want "no limit" or "no request" then the entry must not be present in the map.
 	// Note: Since a "Quantity" type has no nil value, we use the Zero value to represent unlimited.
-	limits := make(map[corev1.ResourceName]resource.Quantity)
+	resourceLimits := make(map[corev1.ResourceName]resource.Quantity)
 	if !r.config.Receiver.MemoryLimit.IsZero() {
-		limits[corev1.ResourceMemory] = r.config.Receiver.MemoryLimit
+		resourceLimits[corev1.ResourceMemory] = r.config.Receiver.MemoryLimit
 	}
 	if !r.config.Receiver.CpuLimit.IsZero() {
-		limits[corev1.ResourceCPU] = r.config.Receiver.CpuLimit
+		resourceLimits[corev1.ResourceCPU] = r.config.Receiver.CpuLimit
 	}
-	requests := make(map[corev1.ResourceName]resource.Quantity)
+	resourceRequests := make(map[corev1.ResourceName]resource.Quantity)
 	if !r.config.Receiver.MemoryRequest.IsZero() {
-		requests[corev1.ResourceMemory] = r.config.Receiver.MemoryRequest
+		resourceRequests[corev1.ResourceMemory] = r.config.Receiver.MemoryRequest
 	}
 	if !r.config.Receiver.CpuRequest.IsZero() {
-		requests[corev1.ResourceCPU] = r.config.Receiver.CpuRequest
+		resourceRequests[corev1.ResourceCPU] = r.config.Receiver.CpuRequest
 	}
 
 	// Create The Receiver Deployment
@@ -348,8 +348,8 @@ func (r *Reconciler) newReceiverDeployment(logger *zap.Logger, secret *corev1.Se
 							Env:             channelEnvVars,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: corev1.ResourceRequirements{
-								Requests: requests,
-								Limits:   limits,
+								Requests: resourceRequests,
+								Limits:   resourceLimits,
 							},
 						},
 					},

--- a/pkg/channel/distributed/controller/kafkasecret/receiver.go
+++ b/pkg/channel/distributed/controller/kafkasecret/receiver.go
@@ -263,11 +263,11 @@ func (r *Reconciler) newReceiverDeployment(logger *zap.Logger, secret *corev1.Se
 		logger.Error("Failed To Create Receiver Deployment Environment Variables", zap.Error(err))
 		return nil, err
 	}
-	
+
 	// There is a difference between setting an entry in the limits or requests map to the zero-value
 	// of a Quantity and not actually having that entry in the map at all.
 	// If we want "no limit" or "no request" then the entry must not be present in the map at all.
-	// Note: Since a "Quantity" type has no nil value, we use the Zero value to represent unlimited. 
+	// Note: Since a "Quantity" type has no nil value, we use the Zero value to represent unlimited.
 	limits := make(map[corev1.ResourceName]resource.Quantity)
 	if !r.config.Receiver.MemoryLimit.IsZero() {
 		limits[corev1.ResourceMemory] = r.config.Receiver.MemoryLimit
@@ -349,7 +349,7 @@ func (r *Reconciler) newReceiverDeployment(logger *zap.Logger, secret *corev1.Se
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: corev1.ResourceRequirements{
 								Requests: requests,
-								Limits: limits,
+								Limits:   limits,
 							},
 						},
 					},

--- a/pkg/channel/distributed/controller/kafkasecret/receiver.go
+++ b/pkg/channel/distributed/controller/kafkasecret/receiver.go
@@ -19,9 +19,10 @@ package kafkasecret
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -266,10 +267,10 @@ func (r *Reconciler) newReceiverDeployment(logger *zap.Logger, secret *corev1.Se
 	// There is a difference between setting an entry in the limits map to the zero-value of a Quantity and
 	// not actually having that entry in the map at all.  If we want "no limit" then the entry must not be present.
 	limits := make(map[corev1.ResourceName]resource.Quantity)
-	if ! r.config.Receiver.MemoryLimit.IsZero() {
+	if !r.config.Receiver.MemoryLimit.IsZero() {
 		limits[corev1.ResourceMemory] = r.config.Receiver.MemoryLimit
 	}
-	if ! r.config.Receiver.CpuLimit.IsZero() {
+	if !r.config.Receiver.CpuLimit.IsZero() {
 		limits[corev1.ResourceCPU] = r.config.Receiver.CpuLimit
 	}
 

--- a/pkg/channel/distributed/controller/kafkasecret/reconciler_test.go
+++ b/pkg/channel/distributed/controller/kafkasecret/reconciler_test.go
@@ -147,6 +147,7 @@ func TestReconcile(t *testing.T) {
 				"configOptions": []controllertesting.KafkaConfigOption{controllertesting.WithNoReceiverResources},
 			},
 		},
+
 		//
 		// KafkaChannel Secret Deletion (Finalizer)
 		//

--- a/pkg/channel/distributed/controller/kafkasecret/reconciler_test.go
+++ b/pkg/channel/distributed/controller/kafkasecret/reconciler_test.go
@@ -144,7 +144,7 @@ func TestReconcile(t *testing.T) {
 				controllertesting.NewKafkaSecretSuccessfulReconciliationEvent(),
 			},
 			OtherTestData: map[string]interface{}{
-				"configOptions": []controllertesting.KafkaConfigOption { controllertesting.WithNoReceiverResources },
+				"configOptions": []controllertesting.KafkaConfigOption{controllertesting.WithNoReceiverResources},
 			},
 		},
 		//

--- a/pkg/channel/distributed/controller/testing/factory.go
+++ b/pkg/channel/distributed/controller/testing/factory.go
@@ -43,7 +43,7 @@ const (
 )
 
 // Ctor functions create a k8s controller with given params.
-type Ctor func(context.Context, *Listers, configmap.Watcher) controller.Reconciler
+type Ctor func(context.Context, *Listers, configmap.Watcher, []KafkaConfigOption) controller.Reconciler
 
 // MakeFactory creates a reconciler factory with fake clients and controller created by `ctor`.
 func MakeFactory(ctor Ctor, logger *zap.Logger) Factory {
@@ -67,8 +67,13 @@ func MakeFactory(ctor Ctor, logger *zap.Logger) Factory {
 		eventRecorder := record.NewFakeRecorder(maxEventBufferSize)
 		ctx = controller.WithEventRecorder(ctx, eventRecorder)
 
+		configOptions, ok := r.OtherTestData["configOptions"]
+		if !ok || configOptions == nil {
+			configOptions = []KafkaConfigOption{}
+		}
+
 		// Set up our Controller from the fakes.
-		c := ctor(ctx, &ls, configmap.NewStaticWatcher())
+		c := ctor(ctx, &ls, configmap.NewStaticWatcher(), configOptions.([]KafkaConfigOption))
 
 		// The Reconciler won't do any work until it becomes the leader.
 		if la, ok := c.(reconciler.LeaderAware); ok {


### PR DESCRIPTION
## Proposed Changes

- 🎁 Allow not having the cpu/memory resource requests and/or limits in the config-kafka configmap for eventing-kafka.receiver and eventing-kafka.dispatcher
- 🧽 Default to no limit for receiver and dispatcher (but still allow a limit if defined by the admin in the config-kafka configmap) and a reasonable (100m / 50Mi) initial request size based on empirical small-cluster and small-message-size testing.
