### PR TITLE
Move Sarama YAML related functions into common

### DIFF
--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -37,6 +37,7 @@ import (
 	dispatcherhealth "knative.dev/eventing-kafka/pkg/channel/distributed/dispatcher/health"
 	"knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 	"knative.dev/eventing-kafka/pkg/client/informers/externalversions"
+	"knative.dev/eventing-kafka/pkg/common/client"
 	kncontroller "knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	eventingmetrics "knative.dev/pkg/metrics"
@@ -77,7 +78,7 @@ func main() {
 	}
 
 	// Update The Sarama Config - Username/Password Overrides (EnvVars From Secret Take Precedence Over ConfigMap)
-	sarama.UpdateSaramaConfig(saramaConfig, constants.Component, environment.KafkaUsername, environment.KafkaPassword)
+	client.UpdateSaramaConfig(saramaConfig, constants.Component, environment.KafkaUsername, environment.KafkaPassword)
 
 	// Enable Sarama Logging If Specified In ConfigMap
 	sarama.EnableSaramaLogging(ekConfig.Kafka.EnableSaramaLogging)

--- a/cmd/channel/distributed/receiver/main.go
+++ b/cmd/channel/distributed/receiver/main.go
@@ -37,6 +37,7 @@ import (
 	"knative.dev/eventing-kafka/pkg/channel/distributed/receiver/env"
 	channelhealth "knative.dev/eventing-kafka/pkg/channel/distributed/receiver/health"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/receiver/producer"
+	"knative.dev/eventing-kafka/pkg/common/client"
 	eventingchannel "knative.dev/eventing/pkg/channel"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
@@ -80,7 +81,7 @@ func main() {
 	}
 
 	// Update The Sarama Config - Username/Password Overrides (EnvVars From Secret Take Precedence Over ConfigMap)
-	sarama.UpdateSaramaConfig(saramaConfig, constants.Component, environment.KafkaUsername, environment.KafkaPassword)
+	client.UpdateSaramaConfig(saramaConfig, constants.Component, environment.KafkaUsername, environment.KafkaPassword)
 
 	// Enable Sarama Logging If Specified In ConfigMap
 	sarama.EnableSaramaLogging(ekConfig.Kafka.EnableSaramaLogging)

--- a/pkg/channel/distributed/common/kafka/admin/admin_kafka.go
+++ b/pkg/channel/distributed/common/kafka/admin/admin_kafka.go
@@ -27,7 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	adminutil "knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/admin/util"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
-	kafkasarama "knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/sarama"
+	"knative.dev/eventing-kafka/pkg/common/client"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 )
@@ -87,7 +87,7 @@ func NewKafkaAdminClient(ctx context.Context, saramaConfig *sarama.Config, clien
 	password := string(kafkaSecret.Data[constants.KafkaSecretKeyPassword])
 
 	// Update The Sarama ClusterAdmin Configuration With Our Values
-	kafkasarama.UpdateSaramaConfig(saramaConfig, clientId, username, password)
+	client.UpdateSaramaConfig(saramaConfig, clientId, username, password)
 
 	// Create A New Sarama ClusterAdmin
 	clusterAdmin, err := NewClusterAdminWrapper(brokers, saramaConfig)

--- a/pkg/channel/distributed/common/kafka/consumer/consumer_test.go
+++ b/pkg/channel/distributed/common/kafka/consumer/consumer_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/assert"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
-	kafkasarama "knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/sarama"
 	kafkatesting "knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/testing"
 	commontesting "knative.dev/eventing-kafka/pkg/channel/distributed/common/testing"
+	"knative.dev/eventing-kafka/pkg/common/client"
 )
 
 // Test Constants
@@ -65,7 +65,7 @@ func TestCreateConsumerGroup(t *testing.T) {
 
 	// Perform The Test
 	config := commontesting.GetDefaultSaramaConfig(t)
-	kafkasarama.UpdateSaramaConfig(config, ClientId, KafkaUsername, KafkaPassword)
+	client.UpdateSaramaConfig(config, ClientId, KafkaUsername, KafkaPassword)
 	consumerGroup, registry, err := CreateConsumerGroup(brokers, config, GroupId)
 
 	// Verify The Results
@@ -77,7 +77,7 @@ func TestCreateConsumerGroup(t *testing.T) {
 // Test that the UpdateSaramaConfig sets values as expected
 func TestUpdateConfig(t *testing.T) {
 	config := sarama.NewConfig()
-	kafkasarama.UpdateSaramaConfig(config, ClientId, KafkaUsername, KafkaPassword)
+	client.UpdateSaramaConfig(config, ClientId, KafkaUsername, KafkaPassword)
 	assert.Equal(t, ClientId, config.ClientID)
 	assert.Equal(t, KafkaUsername, config.Net.SASL.User)
 	assert.Equal(t, KafkaPassword, config.Net.SASL.Password)

--- a/pkg/channel/distributed/common/kafka/producer/producer_test.go
+++ b/pkg/channel/distributed/common/kafka/producer/producer_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/assert"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
-	kafkasarama "knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/sarama"
 	commontesting "knative.dev/eventing-kafka/pkg/channel/distributed/common/testing"
+	"knative.dev/eventing-kafka/pkg/common/client"
 )
 
 // Test Constants
@@ -64,7 +64,7 @@ func performCreateSyncProducerTest(t *testing.T, username string, password strin
 
 	// Perform The Test
 	config := commontesting.GetDefaultSaramaConfig(t)
-	kafkasarama.UpdateSaramaConfig(config, ClientId, username, password)
+	client.UpdateSaramaConfig(config, ClientId, username, password)
 	producer, registry, err := CreateSyncProducer([]string{KafkaBrokers}, config)
 
 	// Verify The Results
@@ -77,7 +77,7 @@ func performCreateSyncProducerTest(t *testing.T, username string, password strin
 // Test that the UpdateSaramaConfig sets values as expected
 func TestUpdateConfig(t *testing.T) {
 	config := sarama.NewConfig()
-	kafkasarama.UpdateSaramaConfig(config, ClientId, KafkaUsername, KafkaPassword)
+	client.UpdateSaramaConfig(config, ClientId, KafkaUsername, KafkaPassword)
 	assert.Equal(t, ClientId, config.ClientID)
 	assert.Equal(t, KafkaUsername, config.Net.SASL.User)
 	assert.Equal(t, KafkaPassword, config.Net.SASL.Password)

--- a/pkg/channel/distributed/common/kafka/sarama/sarama.go
+++ b/pkg/channel/distributed/common/kafka/sarama/sarama.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"regexp"
 
 	"github.com/Shopify/sarama"
 	"github.com/ghodss/yaml"
@@ -35,12 +34,10 @@ import (
 	commonconfig "knative.dev/eventing-kafka/pkg/channel/distributed/common/config"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/testing"
+	"knative.dev/eventing-kafka/pkg/common/client"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/system"
 )
-
-// Regular Expression To Find All Certificates In Net.TLS.Config.RootPEMs Field
-var regexRootPEMs = regexp.MustCompile(`(?s)\s*RootPEMs:.*-----END CERTIFICATE-----`)
 
 // Utility Function For Enabling Sarama Logging (Debugging)
 func EnableSaramaLogging(enable bool) {
@@ -66,139 +63,6 @@ func UpdateSaramaConfig(config *sarama.Config, clientId string, username string,
 
 	// We Always Want Success Messages From Producer
 	config.Producer.Return.Successes = true
-}
-
-//
-// Extract (Parse & Remove) Top Level Kafka Version From Specified Sarama Confirm YAML String
-//
-// The Sarama.Config struct contains a top-level 'Version' field of type sarama.KafkaVersion.
-// This type contains a package scoped [4]uint field called 'version' which we cannot unmarshal
-// the yaml into.  Therefore, we instead support the user providing a 'Version' string of the
-// format "major.minor.patch" (e.g. "2.3.0") which we will "extract" out of the YAML string
-// and return as an actual sarama.KafkaVersion.  In the case where the user has NOT specified
-// a Version string we will return a default version.
-//
-func extractKafkaVersion(saramaConfigYamlString string) (string, sarama.KafkaVersion, error) {
-
-	// Define Inline Struct To Marshall The Top Level Sarama Config "Kafka" Version Into
-	type saramaConfigShell struct {
-		Version string
-	}
-
-	// Unmarshal The Sarama Config Into The Shell
-	shell := &saramaConfigShell{}
-	err := yaml.Unmarshal([]byte(saramaConfigYamlString), shell)
-	if err != nil {
-		return saramaConfigYamlString, constants.ConfigKafkaVersionDefault, err
-	}
-
-	// Return Default Kafka Version If Not Specified
-	if len(shell.Version) <= 0 {
-		return saramaConfigYamlString, constants.ConfigKafkaVersionDefault, nil
-	}
-
-	// Attempt To Parse The Version String Into A Sarama.KafkaVersion
-	kafkaVersion, err := sarama.ParseKafkaVersion(shell.Version)
-	if err != nil {
-		return saramaConfigYamlString, constants.ConfigKafkaVersionDefault, err
-	}
-
-	// Remove The Version From The Sarama Config YAML String
-	regex, err := regexp.Compile("\\s*Version:\\s*" + shell.Version + "\\s*")
-	if err != nil {
-		return saramaConfigYamlString, constants.ConfigKafkaVersionDefault, err
-	} else {
-		updatedSaramaConfigYamlBytes := regex.ReplaceAll([]byte(saramaConfigYamlString), []byte{})
-		return string(updatedSaramaConfigYamlBytes), kafkaVersion, nil
-	}
-}
-
-/* Extract (Parse & Remove) TLS.Config Level RootPEMs From Specified Sarama Confirm YAML String
-
-The Sarama.Config struct contains Net.TLS.Config which is a *tls.Config which cannot be parsed.
-due to it being from another package and containing lots of func()s.  We do need the ability
-however to provide Root Certificates in order to avoid having to disable verification via the
-InsecureSkipVerify field.  Therefore, we support a custom 'RootPEMs' field which is an array
-of strings containing the PEM file content.  This function will "extract" that content out
-of the YAML string and return as a populated *x509.CertPool which can be assigned to the
-Sarama.Config.Net.TLS.Config.RootCAs field.  In the case where the user has NOT specified
-any PEM files we will return nil.
-
-In order for the PEM file content to pass cleanly from the YAML string, which is itself
-already a YAML string inside the K8S ConfigMap, it must be formatted and spaced correctly.
-The following shows an example of the expected usage...
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-kafka
-  namespace: knative-eventing
-data:
-  sarama: |
-    Admin:
-      Timeout: 10000000000
-    Net:
-      KeepAlive: 30000000000
-      TLS:
-        Enable: true
-        Config:
-          RootCaPems:
-          - |-
-            -----BEGIN CERTIFICATE-----
-            MIIGBDCCA+ygAwIBAgIJAKi1aEV58cQ1MA0GCSqGSIb3DQEBCwUAMIGOMQswCQYD
-            ...
-            2wk9rLRZaQnhspt6MhlmU0qkaEZpYND3emR2XZ07m51jXqDUgTjXYCSggImUsARs
-            NAehp9bMeco=
-            -----END CERTIFICATE-----
-      SASL:
-        Enable: true
-
-...where you should make sure to use the YAML string syntax of "|-" in order to
-prevent trailing linefeed. The indentation of the PEM content is also important
-and must be aligned as shown.
-*/
-func extractRootCerts(saramaConfigYamlString string) (string, *x509.CertPool, error) {
-
-	// Define Inline Struct To Marshall The TLS Config 'RootPEMs' Into
-	type tlsConfigShell struct {
-		Net struct {
-			TLS struct {
-				Config struct {
-					RootPEMs []string
-				}
-			}
-		}
-	}
-
-	// Unmarshal The TLS Config Into The Shell
-	shell := &tlsConfigShell{}
-	err := yaml.Unmarshal([]byte(saramaConfigYamlString), shell)
-	if err != nil {
-		return saramaConfigYamlString, nil, err
-	}
-
-	// Convenience Variable For The RootPEMs
-	rootPEMs := shell.Net.TLS.Config.RootPEMs
-
-	// Exit Early If No RootCert PEMs
-	if rootPEMs == nil || len(rootPEMs) < 1 {
-		return saramaConfigYamlString, nil, nil
-	}
-
-	// Create A New CertPool To Contain The Root PEMs
-	certPool := x509.NewCertPool()
-
-	// Populate The CertPool With The PEMs
-	for _, rootPEM := range rootPEMs {
-		ok := certPool.AppendCertsFromPEM([]byte(rootPEM))
-		if !ok {
-			return saramaConfigYamlString, nil, fmt.Errorf("failed to parse root certificate PEM: %s", rootPEM)
-		}
-	}
-
-	// Remove The RootPEMs From The Sarama YAML String (Multi-Line / Greedy To Collect All PEMs)
-	updatedSaramaConfigYamlBytes := regexRootPEMs.ReplaceAll([]byte(saramaConfigYamlString), []byte{})
-	return string(updatedSaramaConfigYamlBytes), certPool, nil
 }
 
 // ConfigEqual is a convenience function to determine if two given sarama.Config structs are identical aside
@@ -260,13 +124,13 @@ func MergeSaramaSettings(config *sarama.Config, configMap *corev1.ConfigMap) (*s
 	saramaSettingsYamlString := configMap.Data[testing.SaramaSettingsConfigKey]
 
 	// Extract (Remove) The KafkaVersion From The Sarama Config YAML
-	saramaSettingsYamlString, kafkaVersion, err := extractKafkaVersion(saramaSettingsYamlString)
+	saramaSettingsYamlString, kafkaVersion, err := client.ExtractKafkaVersion(saramaSettingsYamlString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract KafkaVersion from Sarama Config YAML: err=%s : config=%+v", err, saramaSettingsYamlString)
 	}
 
 	// Extract (Remove) Any TLS.Config RootCAs & Set In Sarama.Config
-	saramaSettingsYamlString, certPool, err := extractRootCerts(saramaSettingsYamlString)
+	saramaSettingsYamlString, certPool, err := client.ExtractRootCerts(saramaSettingsYamlString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract RootPEMs from Sarama Config YAML: err=%s : config=%+v", err, saramaSettingsYamlString)
 	}

--- a/pkg/channel/distributed/common/kafka/sarama/sarama_test.go
+++ b/pkg/channel/distributed/common/kafka/sarama/sarama_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -430,35 +429,4 @@ func getTestSaramaContext(t *testing.T, saramaConfig string, eventingKafkaConfig
 	ctx := context.WithValue(context.Background(), injectionclient.Key{}, fakeK8sClient)
 	assert.NotNil(t, ctx)
 	return ctx
-}
-
-// Test The ExtractRoots() Functionality
-func TestExtractRootCerts(t *testing.T) {
-
-	// The Sarama Config YAML String To Test
-	beforeSaramaConfigYaml := EKDefaultSaramaConfigWithRootCert
-
-	// Perform The Test (Extract The RootCert)
-	afterSaramaConfigYaml, certPool, err := extractRootCerts(beforeSaramaConfigYaml)
-
-	// Verify The RootCert Was Extracted Successfully & Returned In CertPool
-	assert.NotNil(t, afterSaramaConfigYaml)
-	assert.NotEqual(t, beforeSaramaConfigYaml, afterSaramaConfigYaml)
-	assert.False(t, strings.Contains(afterSaramaConfigYaml, "RootPEMs"))
-	assert.False(t, strings.Contains(afterSaramaConfigYaml, "-----BEGIN CERTIFICATE-----"))
-	assert.False(t, strings.Contains(afterSaramaConfigYaml, "-----END CERTIFICATE-----"))
-	assert.NotNil(t, certPool)
-	assert.Nil(t, err)
-	subjects := certPool.Subjects()
-	assert.NotNil(t, subjects)
-	assert.Len(t, subjects, 1)
-
-	// Attempt To Extract Again (Now That There Arent' Any RootPEMs)
-	finalSaramaConfigYaml, certPool, err := extractRootCerts(afterSaramaConfigYaml)
-
-	// Verify The YAML String Is Unchanged And CertPool Is Nil
-	assert.NotNil(t, finalSaramaConfigYaml)
-	assert.Equal(t, afterSaramaConfigYaml, finalSaramaConfigYaml)
-	assert.Nil(t, certPool)
-	assert.Nil(t, err)
 }

--- a/pkg/channel/distributed/common/kafka/sarama/sarama_test.go
+++ b/pkg/channel/distributed/common/kafka/sarama/sarama_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -31,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	commonconfig "knative.dev/eventing-kafka/pkg/channel/distributed/common/config"
 	commontesting "knative.dev/eventing-kafka/pkg/channel/distributed/common/testing"
+	"knative.dev/eventing-kafka/pkg/common/client"
 	injectionclient "knative.dev/pkg/client/injection/kube/client"
 )
 
@@ -126,25 +126,6 @@ Consumer:
   Return:
     Errors: true
 `
-	EKDefaultSaramaConfigWithInsecureSkipVerify = `
-Net:
-  TLS:
-    Enable: true
-    Config:
-      InsecureSkipVerify: true
-  SASL:
-    Mechanism: PLAIN
-    Version: 1
-Metadata:
-  RefreshFrequency: 300000000000
-Consumer:
-  Offsets:
-    AutoCommit:
-        Interval: 5000000000
-    Retention: 604800000000000
-  Return:
-    Errors: true
-`
 )
 
 // Test Enabling Sarama Logging
@@ -166,26 +147,6 @@ func TestEnableSaramaLogging(t *testing.T) {
 
 	// Verify Results Visually
 	sarama.Logger.Print("TestMessage - Should Be Hidden")
-}
-
-// Test The UpdateSaramaConfig() Functionality
-func TestUpdateSaramaConfig(t *testing.T) {
-
-	// Test Data
-	clientId := "TestClientId"
-	username := "TestUsername"
-	password := "TestPassword"
-
-	// Perform The Test
-	config := sarama.NewConfig()
-	UpdateSaramaConfig(config, clientId, username, password)
-
-	// Verify The Results
-	assert.Equal(t, clientId, config.ClientID)
-	assert.Equal(t, username, config.Net.SASL.User)
-	assert.Equal(t, password, config.Net.SASL.Password)
-	assert.Equal(t, sarama.V1_0_0_0, config.Version)
-	assert.Nil(t, config.Net.TLS.Config)
 }
 
 // This test is specifically to validate that our default settings (used in 200-eventing-kafka-configmap.yaml)
@@ -223,66 +184,6 @@ func TestLoadDefaultSaramaSettings(t *testing.T) {
 	assert.Equal(t, resource.MustParse("50Mi"), configuration.Dispatcher.MemoryRequest)
 	assert.Equal(t, 1, configuration.Dispatcher.Replicas)
 	assert.Equal(t, "azure", configuration.Kafka.AdminType)
-}
-
-// Verify that the JSON fragment can be loaded into a sarama.Config struct
-func TestMergeSaramaSettings(t *testing.T) {
-	// Setup Environment
-	commontesting.SetTestEnvironment(t)
-
-	// Get a default Sarama config for verification that we don't overwrite settings when we merge
-	defaultConfig := sarama.NewConfig()
-
-	// Verify a few settings in different parts of two separate sarama.Config structures
-	// Since it's a simple JSON merge we don't need to test every possible value.
-	config, err := MergeSaramaSettings(nil, commontesting.GetTestSaramaConfigMap(commontesting.OldSaramaConfig, commontesting.TestEKConfig))
-	assert.Nil(t, err)
-	assert.NotNil(t, config)
-	assert.Equal(t, commontesting.OldUsername, config.Net.SASL.User)
-	assert.Equal(t, defaultConfig.Producer.Timeout, config.Producer.Timeout)
-	assert.Equal(t, defaultConfig.Consumer.MaxProcessingTime, config.Consumer.MaxProcessingTime)
-
-	config, err = MergeSaramaSettings(config, commontesting.GetTestSaramaConfigMap(commontesting.NewSaramaConfig, commontesting.TestEKConfig))
-	assert.Nil(t, err)
-	assert.NotNil(t, config)
-	assert.Equal(t, sarama.V2_3_0_0, config.Version)
-	assert.Equal(t, commontesting.NewUsername, config.Net.SASL.User)
-	assert.Equal(t, defaultConfig.Producer.Timeout, config.Producer.Timeout)
-	assert.Equal(t, defaultConfig.Consumer.MaxProcessingTime, config.Consumer.MaxProcessingTime)
-
-	// Verify error when no Data section is provided
-	configEmpty := commontesting.GetTestSaramaConfigMap(commontesting.NewSaramaConfig, commontesting.TestEKConfig)
-	configEmpty.Data = nil
-	config, err = MergeSaramaSettings(config, configEmpty)
-	assert.NotNil(t, err)
-
-	// Verify error when an invalid Version is provided
-	configMap := commontesting.GetTestSaramaConfigMap(commontesting.NewSaramaConfig, commontesting.TestEKConfig)
-	regexVersion := regexp.MustCompile(`Version:\s*\d*\.[\d.]*`) // Must have at least one period or it will match the "Version: 1" in Net.SASL
-	configMap.Data[commontesting.SaramaSettingsConfigKey] =
-		regexVersion.ReplaceAllString(configMap.Data[commontesting.SaramaSettingsConfigKey], "Version: INVALID")
-	config, err = MergeSaramaSettings(config, configMap)
-	assert.NotNil(t, err)
-
-	// Verify error when an invalid RootPEMs is provided
-	configMap = commontesting.GetTestSaramaConfigMap(EKDefaultSaramaConfigWithRootCert, commontesting.TestEKConfig)
-	regexPEMs := regexp.MustCompile(`-----BEGIN CERTIFICATE-----`)
-	configMap.Data[commontesting.SaramaSettingsConfigKey] =
-		regexPEMs.ReplaceAllString(configMap.Data[commontesting.SaramaSettingsConfigKey], "INVALID CERT DATA")
-	config, err = MergeSaramaSettings(config, configMap)
-	assert.NotNil(t, err)
-
-	// Verify that the RootPEMs section is merged properly
-	configMap = commontesting.GetTestSaramaConfigMap(EKDefaultSaramaConfigWithRootCert, commontesting.TestEKConfig)
-	config, err = MergeSaramaSettings(config, configMap)
-	assert.Nil(t, err)
-	assert.NotNil(t, config.Net.TLS.Config.RootCAs)
-
-	// Verify that the InsecureSkipVerify flag can be set properly
-	configMap = commontesting.GetTestSaramaConfigMap(EKDefaultSaramaConfigWithInsecureSkipVerify, commontesting.TestEKConfig)
-	config, err = MergeSaramaSettings(config, configMap)
-	assert.Nil(t, err)
-	assert.True(t, config.Net.TLS.Config.InsecureSkipVerify)
 }
 
 // Verify that comparisons of sarama config structs function as expected
@@ -339,9 +240,9 @@ func TestSaramaConfigEqual(t *testing.T) {
 	assert.True(t, ConfigEqual(config1, config2))
 
 	// Test config with TLS struct
-	config1, err := MergeSaramaSettings(nil, commontesting.GetTestSaramaConfigMap(EKDefaultSaramaConfigWithRootCert, commontesting.TestEKConfig))
+	config1, err := client.MergeSaramaSettings(nil, EKDefaultSaramaConfigWithRootCert)
 	assert.Nil(t, err)
-	config2, err = MergeSaramaSettings(nil, commontesting.GetTestSaramaConfigMap(EKDefaultSaramaConfigWithRootCert, commontesting.TestEKConfig))
+	config2, err = client.MergeSaramaSettings(nil, EKDefaultSaramaConfigWithRootCert)
 	assert.Nil(t, err)
 	assert.True(t, ConfigEqual(config1, config2))
 }

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler.go
@@ -243,8 +243,6 @@ func (r *Reconciler) configMapObserver(configMap *corev1.ConfigMap) {
 	// env.GetEnvironment is not necessary now.  If	those settings are needed in the future, the
 	// environment will also need to be re-parsed here.
 
-	// Load the Sarama settings from our configmap, ignoring the eventing-kafka result.
-
 	// Validate The ConfigMap Data
 	if configMap.Data == nil {
 		r.logger.Fatal("Attempted to merge sarama settings with empty configmap")
@@ -254,6 +252,7 @@ func (r *Reconciler) configMapObserver(configMap *corev1.ConfigMap) {
 	// Merge The ConfigMap Settings Into The Provided Config
 	saramaSettingsYamlString := configMap.Data[testing.SaramaSettingsConfigKey]
 
+	// Load the Sarama settings from our configmap, ignoring the eventing-kafka result.
 	saramaConfig, err := client.MergeSaramaSettings(nil, saramaSettingsYamlString)
 	if err != nil {
 		r.logger.Fatal("Failed To Load Eventing-Kafka Settings", zap.Error(err))

--- a/pkg/common/client/config.go
+++ b/pkg/common/client/config.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/pkg/common/client/config.go
+++ b/pkg/common/client/config.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"github.com/Shopify/sarama"
+	"github.com/ghodss/yaml"
+	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
+)
+
+// Merge existing Sarama config with provided YAML string.
+// Values in YAML string will override the values in the config.
+// If config Is nil, A New sarama.Config Struct Will Be Created With Default Values
+func MergeSaramaSettings(config *sarama.Config, saramaSettingsYamlString string) (*sarama.Config, error) {
+	// Merging To A Nil Config Requires Creating An Default One First
+	if config == nil {
+		// Start With Base Sarama Defaults
+		config = sarama.NewConfig()
+
+		// Use Our Default Minimum Version
+		config.Version = constants.ConfigKafkaVersionDefault
+
+		// Add Any Required Settings
+		UpdateSaramaConfig(config, config.ClientID, "", "")
+	}
+
+	// Extract (Remove) The KafkaVersion From The Sarama Config YAML
+	saramaSettingsYamlString, kafkaVersion, err := extractKafkaVersion(saramaSettingsYamlString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract KafkaVersion from Sarama Config YAML: err=%s : config=%+v", err, saramaSettingsYamlString)
+	}
+
+	// Extract (Remove) Any TLS.Config RootCAs & Set In Sarama.Config
+	saramaSettingsYamlString, certPool, err := extractRootCerts(saramaSettingsYamlString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract RootPEMs from Sarama Config YAML: err=%s : config=%+v", err, saramaSettingsYamlString)
+	}
+
+	// Unmarshall The Sarama Config Yaml Into The Provided Sarama.Config Object
+	err = yaml.Unmarshal([]byte(saramaSettingsYamlString), &config)
+	if err != nil {
+		return nil, fmt.Errorf("ConfigMap's sarama value could not be converted to a Sarama.Config struct: %s : %v", err, saramaSettingsYamlString)
+	}
+
+	// Override The Custom Parsed KafkaVersion
+	config.Version = kafkaVersion
+
+	// Override Any Custom Parsed TLS.Config.RootCAs
+	if certPool != nil && len(certPool.Subjects()) > 0 {
+		config.Net.TLS.Config = &tls.Config{RootCAs: certPool}
+	}
+
+	// Return Success
+	return config, nil
+}
+
+// Utility Function For Configuring Common Settings For Admin/Producer/Consumer
+func UpdateSaramaConfig(config *sarama.Config, clientId string, username string, password string) {
+
+	// Set The ClientID For Logging
+	config.ClientID = clientId
+
+	// Set The SASL Username / Password
+	config.Net.SASL.User = username
+	config.Net.SASL.Password = password
+
+	// We Always Want To Know About Consumer Errors
+	config.Consumer.Return.Errors = true
+
+	// We Always Want Success Messages From Producer
+	config.Producer.Return.Successes = true
+}

--- a/pkg/common/client/config_test.go
+++ b/pkg/common/client/config_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/pkg/common/client/config_test.go
+++ b/pkg/common/client/config_test.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/assert"
+	commontesting "knative.dev/eventing-kafka/pkg/channel/distributed/common/testing"
+)
+
+const (
+	EKDefaultSaramaConfigWithInsecureSkipVerify = `
+Net:
+  TLS:
+    Enable: true
+    Config:
+      InsecureSkipVerify: true
+  SASL:
+    Mechanism: PLAIN
+    Version: 1
+Metadata:
+  RefreshFrequency: 300000000000
+Consumer:
+  Offsets:
+    AutoCommit:
+        Interval: 5000000000
+    Retention: 604800000000000
+  Return:
+    Errors: true
+`
+)
+
+// Verify that the JSON fragment can be loaded into a sarama.Config struct
+func TestMergeSaramaSettings(t *testing.T) {
+	// Setup Environment
+	commontesting.SetTestEnvironment(t)
+
+	// Get a default Sarama config for verification that we don't overwrite settings when we merge
+	defaultConfig := sarama.NewConfig()
+
+	// Verify a few settings in different parts of two separate sarama.Config structures
+	// Since it's a simple JSON merge we don't need to test every possible value.
+	config, err := MergeSaramaSettings(nil, commontesting.OldSaramaConfig)
+	assert.Nil(t, err)
+	assert.NotNil(t, config)
+	assert.Equal(t, commontesting.OldUsername, config.Net.SASL.User)
+	assert.Equal(t, defaultConfig.Producer.Timeout, config.Producer.Timeout)
+	assert.Equal(t, defaultConfig.Consumer.MaxProcessingTime, config.Consumer.MaxProcessingTime)
+
+	config, err = MergeSaramaSettings(config, commontesting.NewSaramaConfig)
+	assert.Nil(t, err)
+	assert.NotNil(t, config)
+	assert.Equal(t, sarama.V2_3_0_0, config.Version)
+	assert.Equal(t, commontesting.NewUsername, config.Net.SASL.User)
+	assert.Equal(t, defaultConfig.Producer.Timeout, config.Producer.Timeout)
+	assert.Equal(t, defaultConfig.Consumer.MaxProcessingTime, config.Consumer.MaxProcessingTime)
+
+	// Verify error when an invalid Version is provided
+	regexVersion := regexp.MustCompile(`Version:\s*\d*\.[\d.]*`) // Must have at least one period or it will match the "Version: 1" in Net.SASL
+	config, err = MergeSaramaSettings(config, regexVersion.ReplaceAllString(commontesting.NewSaramaConfig, "Version: INVALID"))
+	assert.NotNil(t, err)
+
+	// Verify error when an invalid RootPEMs is provided
+	config, err = MergeSaramaSettings(config, strings.Replace(EKDefaultSaramaConfigWithRootCert, "-----BEGIN CERTIFICATE-----", "INVALID CERT DATA", -1))
+	assert.NotNil(t, err)
+
+	// Verify that the RootPEMs section is merged properly
+	config, err = MergeSaramaSettings(config, EKDefaultSaramaConfigWithRootCert)
+	assert.Nil(t, err)
+	assert.NotNil(t, config.Net.TLS.Config.RootCAs)
+
+	// Verify that the InsecureSkipVerify flag can be set properly
+	config, err = MergeSaramaSettings(config, EKDefaultSaramaConfigWithInsecureSkipVerify)
+	assert.Nil(t, err)
+	assert.True(t, config.Net.TLS.Config.InsecureSkipVerify)
+}
+
+// Test The UpdateSaramaConfig() Functionality
+func TestUpdateSaramaConfig(t *testing.T) {
+
+	// Test Data
+	clientId := "TestClientId"
+	username := "TestUsername"
+	password := "TestPassword"
+
+	// Perform The Test
+	config := sarama.NewConfig()
+	UpdateSaramaConfig(config, clientId, username, password)
+
+	// Verify The Results
+	assert.Equal(t, clientId, config.ClientID)
+	assert.Equal(t, username, config.Net.SASL.User)
+	assert.Equal(t, password, config.Net.SASL.Password)
+	assert.Equal(t, sarama.V1_0_0_0, config.Version)
+	assert.Nil(t, config.Net.TLS.Config)
+}

--- a/pkg/common/client/sarama.go
+++ b/pkg/common/client/sarama.go
@@ -1,0 +1,147 @@
+package client
+
+import (
+	"crypto/x509"
+	"fmt"
+	"regexp"
+
+	"github.com/Shopify/sarama"
+	"github.com/ghodss/yaml"
+	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
+)
+
+// Regular Expression To Find All Certificates In Net.TLS.Config.RootPEMs Field
+var regexRootPEMs = regexp.MustCompile(`(?s)\s*RootPEMs:.*-----END CERTIFICATE-----`)
+
+//
+// Extract (Parse & Remove) Top Level Kafka Version From Specified Sarama Confirm YAML String
+//
+// The Sarama.Config struct contains a top-level 'Version' field of type sarama.KafkaVersion.
+// This type contains a package scoped [4]uint field called 'version' which we cannot unmarshal
+// the yaml into.  Therefore, we instead support the user providing a 'Version' string of the
+// format "major.minor.patch" (e.g. "2.3.0") which we will "extract" out of the YAML string
+// and return as an actual sarama.KafkaVersion.  In the case where the user has NOT specified
+// a Version string we will return a default version.
+//
+func ExtractKafkaVersion(saramaConfigYamlString string) (string, sarama.KafkaVersion, error) {
+
+	// Define Inline Struct To Marshall The Top Level Sarama Config "Kafka" Version Into
+	type saramaConfigShell struct {
+		Version string
+	}
+
+	// Unmarshal The Sarama Config Into The Shell
+	shell := &saramaConfigShell{}
+	err := yaml.Unmarshal([]byte(saramaConfigYamlString), shell)
+	if err != nil {
+		return saramaConfigYamlString, constants.ConfigKafkaVersionDefault, err
+	}
+
+	// Return Default Kafka Version If Not Specified
+	if len(shell.Version) <= 0 {
+		return saramaConfigYamlString, constants.ConfigKafkaVersionDefault, nil
+	}
+
+	// Attempt To Parse The Version String Into A Sarama.KafkaVersion
+	kafkaVersion, err := sarama.ParseKafkaVersion(shell.Version)
+	if err != nil {
+		return saramaConfigYamlString, constants.ConfigKafkaVersionDefault, err
+	}
+
+	// Remove The Version From The Sarama Config YAML String
+	regex, err := regexp.Compile("\\s*Version:\\s*" + shell.Version + "\\s*")
+	if err != nil {
+		return saramaConfigYamlString, constants.ConfigKafkaVersionDefault, err
+	} else {
+		updatedSaramaConfigYamlBytes := regex.ReplaceAll([]byte(saramaConfigYamlString), []byte{})
+		return string(updatedSaramaConfigYamlBytes), kafkaVersion, nil
+	}
+}
+
+/* Extract (Parse & Remove) TLS.Config Level RootPEMs From Specified Sarama Confirm YAML String
+
+The Sarama.Config struct contains Net.TLS.Config which is a *tls.Config which cannot be parsed.
+due to it being from another package and containing lots of func()s.  We do need the ability
+however to provide Root Certificates in order to avoid having to disable verification via the
+InsecureSkipVerify field.  Therefore, we support a custom 'RootPEMs' field which is an array
+of strings containing the PEM file content.  This function will "extract" that content out
+of the YAML string and return as a populated *x509.CertPool which can be assigned to the
+Sarama.Config.Net.TLS.Config.RootCAs field.  In the case where the user has NOT specified
+any PEM files we will return nil.
+
+In order for the PEM file content to pass cleanly from the YAML string, which is itself
+already a YAML string inside the K8S ConfigMap, it must be formatted and spaced correctly.
+The following shows an example of the expected usage...
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-kafka
+  namespace: knative-eventing
+data:
+  sarama: |
+    Admin:
+      Timeout: 10000000000
+    Net:
+      KeepAlive: 30000000000
+      TLS:
+        Enable: true
+        Config:
+          RootCaPems:
+          - |-
+            -----BEGIN CERTIFICATE-----
+            MIIGBDCCA+ygAwIBAgIJAKi1aEV58cQ1MA0GCSqGSIb3DQEBCwUAMIGOMQswCQYD
+            ...
+            2wk9rLRZaQnhspt6MhlmU0qkaEZpYND3emR2XZ07m51jXqDUgTjXYCSggImUsARs
+            NAehp9bMeco=
+            -----END CERTIFICATE-----
+      SASL:
+        Enable: true
+
+...where you should make sure to use the YAML string syntax of "|-" in order to
+prevent trailing linefeed. The indentation of the PEM content is also important
+and must be aligned as shown.
+*/
+func ExtractRootCerts(saramaConfigYamlString string) (string, *x509.CertPool, error) {
+
+	// Define Inline Struct To Marshall The TLS Config 'RootPEMs' Into
+	type tlsConfigShell struct {
+		Net struct {
+			TLS struct {
+				Config struct {
+					RootPEMs []string
+				}
+			}
+		}
+	}
+
+	// Unmarshal The TLS Config Into The Shell
+	shell := &tlsConfigShell{}
+	err := yaml.Unmarshal([]byte(saramaConfigYamlString), shell)
+	if err != nil {
+		return saramaConfigYamlString, nil, err
+	}
+
+	// Convenience Variable For The RootPEMs
+	rootPEMs := shell.Net.TLS.Config.RootPEMs
+
+	// Exit Early If No RootCert PEMs
+	if rootPEMs == nil || len(rootPEMs) < 1 {
+		return saramaConfigYamlString, nil, nil
+	}
+
+	// Create A New CertPool To Contain The Root PEMs
+	certPool := x509.NewCertPool()
+
+	// Populate The CertPool With The PEMs
+	for _, rootPEM := range rootPEMs {
+		ok := certPool.AppendCertsFromPEM([]byte(rootPEM))
+		if !ok {
+			return saramaConfigYamlString, nil, fmt.Errorf("failed to parse root certificate PEM: %s", rootPEM)
+		}
+	}
+
+	// Remove The RootPEMs From The Sarama YAML String (Multi-Line / Greedy To Collect All PEMs)
+	updatedSaramaConfigYamlBytes := regexRootPEMs.ReplaceAll([]byte(saramaConfigYamlString), []byte{})
+	return string(updatedSaramaConfigYamlBytes), certPool, nil
+}

--- a/pkg/common/client/sarama.go
+++ b/pkg/common/client/sarama.go
@@ -23,7 +23,7 @@ var regexRootPEMs = regexp.MustCompile(`(?s)\s*RootPEMs:.*-----END CERTIFICATE--
 // and return as an actual sarama.KafkaVersion.  In the case where the user has NOT specified
 // a Version string we will return a default version.
 //
-func ExtractKafkaVersion(saramaConfigYamlString string) (string, sarama.KafkaVersion, error) {
+func extractKafkaVersion(saramaConfigYamlString string) (string, sarama.KafkaVersion, error) {
 
 	// Define Inline Struct To Marshall The Top Level Sarama Config "Kafka" Version Into
 	type saramaConfigShell struct {
@@ -102,7 +102,7 @@ data:
 prevent trailing linefeed. The indentation of the PEM content is also important
 and must be aligned as shown.
 */
-func ExtractRootCerts(saramaConfigYamlString string) (string, *x509.CertPool, error) {
+func extractRootCerts(saramaConfigYamlString string) (string, *x509.CertPool, error) {
 
 	// Define Inline Struct To Marshall The TLS Config 'RootPEMs' Into
 	type tlsConfigShell struct {

--- a/pkg/common/client/sarama.go
+++ b/pkg/common/client/sarama.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/pkg/common/client/sarama_test.go
+++ b/pkg/common/client/sarama_test.go
@@ -70,7 +70,7 @@ func TestExtractRootCerts(t *testing.T) {
 	beforeSaramaConfigYaml := EKDefaultSaramaConfigWithRootCert
 
 	// Perform The Test (Extract The RootCert)
-	afterSaramaConfigYaml, certPool, err := ExtractRootCerts(beforeSaramaConfigYaml)
+	afterSaramaConfigYaml, certPool, err := extractRootCerts(beforeSaramaConfigYaml)
 
 	// Verify The RootCert Was Extracted Successfully & Returned In CertPool
 	assert.NotNil(t, afterSaramaConfigYaml)
@@ -85,7 +85,7 @@ func TestExtractRootCerts(t *testing.T) {
 	assert.Len(t, subjects, 1)
 
 	// Attempt To Extract Again (Now That There Arent' Any RootPEMs)
-	finalSaramaConfigYaml, certPool, err := ExtractRootCerts(afterSaramaConfigYaml)
+	finalSaramaConfigYaml, certPool, err := extractRootCerts(afterSaramaConfigYaml)
 
 	// Verify The YAML String Is Unchanged And CertPool Is Nil
 	assert.NotNil(t, finalSaramaConfigYaml)

--- a/pkg/common/client/sarama_test.go
+++ b/pkg/common/client/sarama_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/pkg/common/client/sarama_test.go
+++ b/pkg/common/client/sarama_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const EKDefaultSaramaConfigWithRootCert = `
+Net:
+  TLS:
+    Enable: true
+    Config:
+      RootPEMs: # Array of Root Certificate PEM Files As Strings (Mind indentation and use '|-' Syntax To Avoid Terminating \n)
+      - |-
+        -----BEGIN CERTIFICATE-----
+        MIIGBDCCA+ygAwIBAgIJAKi1aEV58cQ1MA0GCSqGSIb3DQEBCwUAMIGOMQswCQYD
+        VQQGEwJERTEbMBkGA1UECAwSQmFkZW4tV3VlcnR0ZW1iZXJnMREwDwYDVQQHDAhX
+        YWxsZG9yZjEPMA0GA1UECgwGU0FQIFNFMR8wHQYDVQQLDBZTQVAgQ1AgRGF0YSBN
+        YW5hZ2VtZW50MR0wGwYDVQQDDBRTQVAgQ1AgS2Fma2EgUm9vdCBDQTAeFw0xNzEy
+        MDQxMzUxMjZaFw0yMTAzMTgxMzUxMjZaMIGOMQswCQYDVQQGEwJERTEbMBkGA1UE
+        CAwSQmFkZW4tV3VlcnR0ZW1iZXJnMREwDwYDVQQHDAhXYWxsZG9yZjEPMA0GA1UE
+        CgwGU0FQIFNFMR8wHQYDVQQLDBZTQVAgQ1AgRGF0YSBNYW5hZ2VtZW50MR0wGwYD
+        VQQDDBRTQVAgQ1AgS2Fma2EgUm9vdCBDQTCCAiIwDQYJKoZIhvcNAQEBBQADggIP
+        ADCCAgoCggIBAKCx+et7E53Znvy+bFB/y4IDjubIEZOg+nmCYmID2RV/6PGtHXLY
+        DEwSue+JDwGXp4sLziFFHhoSjPx6OKLvwd1ww//FraDiGbeJY0BsnkpWVRbQiNyK
+        fxDY+YCLhYTujdtPZqcPcCII4QnQk1PoOrmgHuONGqgjIVTuSOeGx6eIUh8JC3TW
+        Z7EY0qKbnxCsVmyZudsO5Sh8AcDXNHAHJImoJ3uhWwU5YheCv24Jn0UcD/X843Jo
+        J6PhhoCmrLTZCVYeirv9jQqTiks0IhjQEAL6m2W6UCJArePzyjY+HOaY20Umo8Lf
+        CVjR0SfZric9g2+2XHkBex/73AMJbvyCvwER8oHwO9iGNeuHbkDdaicotQ5D7Nap
+        uXLgPFm3y/CkqiBXoiqCJxy+duM3itmLeW/PbEtNMnbS0mG64tZHd9THFAh3I+ug
+        w1+cQWzYO24EcdPQzaX8CpVJ8Au7aYc9QyyaayfTr4YxGYtMO0zay9tchEyChhtK
+        koHmyISz1kxuudItoRDNnRdbfUX1QeKnYWsUtfeK5MED2dpUPO+IVp7qomdy+F4T
+        KdQDvOlKBRFsngmyBbGeGB5wjXwTjuLfC0j6VIlfW0yMKhuePbqSPbVjGTFVefRo
+        rgODPaIre72GtXjcaVISlqagFQgOurRE5Z9OLpgCrMsLdOqVJ9LnSNTrAgMBAAGj
+        YzBhMB0GA1UdDgQWBBRkTG0qgjz9anjV94RGJ+GAApaf3DAfBgNVHSMEGDAWgBRk
+        TG0qgjz9anjV94RGJ+GAApaf3DAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
+        AwIBhjANBgkqhkiG9w0BAQsFAAOCAgEAjL3wUM+Kgzbii2F76/qK2C1asFJkVQRd
+        CMiOhlZDEJYaBPzucF2vhOygkMMuw4SojkbzWGEdaRrc4IR6wVe0CezVeBrVRtAQ
+        DmCzdxO0xEZkWNMmMnzPBiB6k4l5Y9WiOGWiCrzLcMi8fiXr4pJoaUirUsvGf7xf
+        rwR6preFeLIZAgUesxy1RV2p9JHYm+iHiQskovkGt5Xr2sKJ+za3vtQ7Tf52rqAI
+        LPdhZXrMsqcza7yVfiJtS0orn3Su489bj6j+/MKjYjS6DvrSnw1VfzW1eA0U9nYt
+        vP8PVeWGsNxyg3YSwTaPi9cZ5lhGCoUSf2pq1g+VLvR1bIV++UL9wUHl4D7m5V4f
+        jqve5XlMMxYPk9l0YcA4nMF4CxpPsFqzx2MYfbWb1/RiR1BaHqgx7dFWJt980vHp
+        wM4tudQei+uUPYjLte09jKGLpZot0DGLIVJhT4RXnDV1VFmalRjJhJKBBIj7JPba
+        NKWCBaob148p5gwZ4dr4N/yaaUhesdYPJjZn+uvO29/pvv+u80nkEEWW2KYOCd44
+        SMTAhWkj5lx3X8xj40GSCxCMP+Jq2VLasoJSNminWVJuUaTk3veHsQ1mkoRDAbr1
+        2wk9rLRZaQnhspt6MhlmU0qkaEZpYND3emR2XZ07m51jXqDUgTjXYCSggImUsARs
+        NAehp9bMeco=
+        -----END CERTIFICATE-----
+  SASL:
+    Mechanism: PLAIN
+    Version: 1
+Metadata:
+  RefreshFrequency: 300000000000
+Consumer:
+  Offsets:
+    AutoCommit:
+        Interval: 5000000000
+    Retention: 604800000000000
+  Return:
+    Errors: true
+`
+
+// Test The ExtractRoots() Functionality
+func TestExtractRootCerts(t *testing.T) {
+
+	// The Sarama Config YAML String To Test
+	beforeSaramaConfigYaml := EKDefaultSaramaConfigWithRootCert
+
+	// Perform The Test (Extract The RootCert)
+	afterSaramaConfigYaml, certPool, err := ExtractRootCerts(beforeSaramaConfigYaml)
+
+	// Verify The RootCert Was Extracted Successfully & Returned In CertPool
+	assert.NotNil(t, afterSaramaConfigYaml)
+	assert.NotEqual(t, beforeSaramaConfigYaml, afterSaramaConfigYaml)
+	assert.False(t, strings.Contains(afterSaramaConfigYaml, "RootPEMs"))
+	assert.False(t, strings.Contains(afterSaramaConfigYaml, "-----BEGIN CERTIFICATE-----"))
+	assert.False(t, strings.Contains(afterSaramaConfigYaml, "-----END CERTIFICATE-----"))
+	assert.NotNil(t, certPool)
+	assert.Nil(t, err)
+	subjects := certPool.Subjects()
+	assert.NotNil(t, subjects)
+	assert.Len(t, subjects, 1)
+
+	// Attempt To Extract Again (Now That There Arent' Any RootPEMs)
+	finalSaramaConfigYaml, certPool, err := ExtractRootCerts(afterSaramaConfigYaml)
+
+	// Verify The YAML String Is Unchanged And CertPool Is Nil
+	assert.NotNil(t, finalSaramaConfigYaml)
+	assert.Equal(t, afterSaramaConfigYaml, finalSaramaConfigYaml)
+	assert.Nil(t, certPool)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Related to #268

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Move some Sarama config related functions to a common package
- Make the `MergeSaramaSettings` function work with YAML-string instead of configmap
- Will follow up with more PRs that unify the behavior on both channels and the source around Sarama config by modifying `MergeSaramaSettings` as necessary and using it as the central place for Sarama config building

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
