### PR TITLE
Do not test controller name from generated source which can change.

### DIFF
--- a/pkg/channel/distributed/controller/kafkachannel/controller_test.go
+++ b/pkg/channel/distributed/controller/kafkachannel/controller_test.go
@@ -75,7 +75,7 @@ func TestNewController(t *testing.T) {
 
 	// Verify The Results
 	assert.NotNil(t, controller)
-	assert.Equal(t, "knative.dev-eventing-kafka-pkg-channel-distributed-controller-kafkachannel.Reconciler", controller.Name)
+	assert.True(t, len(controller.Name) > 0)
 	assert.NotNil(t, controller.Reconciler)
 }
 

--- a/pkg/channel/distributed/controller/kafkasecret/controller_test.go
+++ b/pkg/channel/distributed/controller/kafkasecret/controller_test.go
@@ -71,7 +71,7 @@ func TestNewController(t *testing.T) {
 
 	// Verify The Results
 	assert.NotNil(t, controller)
-	assert.Equal(t, "knative.dev-eventing-kafka-pkg-channel-distributed-controller-kafkasecret.Reconciler", controller.Name)
+	assert.True(t, len(controller.Name) > 0)
 	assert.NotNil(t, controller.Reconciler)
 }
 


### PR DESCRIPTION
The distributed KafkaChannel contains two controllers which each have a test of their `NewController()` functionality.  These tests were asserting the Controller name matched an expected value.  That name is populated by the **generated** code in `pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel/controller.go` whose implementation can change.  This is causing problems with downstream builds related to knative-eventing [PR #4760](https://github.com/knative/eventing/pull/4760) where the logic for naming the controller is now using "." instead of "-" as a separator.  Therefore it's best for these tests not to expect any specific naming convention to account for the fact that the generated controller implementation might change.

## Proposed Changes
- Adjust test to not expect a specific controller name.

