### PR TITLE
#331 Add sasltype as optional secret parameter for kafka user configuration

### DIFF
--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -79,6 +79,7 @@ func main() {
 			SASL: &client.KafkaSaslConfig{
 				User:     environment.KafkaUsername,
 				Password: environment.KafkaPassword,
+				SaslType: environment.KafkaSaslType,
 			},
 		}
 	}

--- a/cmd/channel/distributed/receiver/main.go
+++ b/cmd/channel/distributed/receiver/main.go
@@ -82,6 +82,7 @@ func main() {
 			SASL: &client.KafkaSaslConfig{
 				User:     environment.KafkaUsername,
 				Password: environment.KafkaPassword,
+				SaslType: environment.KafkaSaslType,
 			},
 		}
 	}

--- a/config/channel/distributed/300-eventing-kafka-configmap.yaml
+++ b/config/channel/distributed/300-eventing-kafka-configmap.yaml
@@ -25,7 +25,6 @@ data:
         Enable: true
       SASL:
         Enable: true
-        Mechanism: PLAIN
         Version: 1
     Metadata:
       RefreshFrequency: 300000000000  # 5 minutes

--- a/config/channel/distributed/300-kafka-secret.yaml
+++ b/config/channel/distributed/300-kafka-secret.yaml
@@ -19,6 +19,7 @@ data:
   namespace: ""
   password: ""
   username: ""
+  sasltype: ""
 kind: Secret
 metadata:
   name: kafka-cluster

--- a/config/channel/distributed/README.md
+++ b/config/channel/distributed/README.md
@@ -126,6 +126,10 @@ your Kafka cluster.
   - **Net.SASL.Password:** If you specify the password in the ConfigMap it will
     be overridden by the values from the
     [kafka-secret.yaml](300-kafka-secret.yaml) file!
+  - **Net.SASL.Mechanism:** If you specify the Mechanism in the ConfigMap it
+    will be overridden by the value of `sasltype` from the
+    [kafka-secret.yaml](300-kafka-secret.yaml) or default to `PLAIN`.
+    Optional values are `SCRAM-SHA-256` and `SCRAM-SHA-512`.
   - **Net.TLS.Enable** Enable (true) / disable (false) according to your
     authentication needs.
   - **Net.TLS.Config:** The Golang

--- a/pkg/channel/distributed/common/env/constants.go
+++ b/pkg/channel/distributed/common/env/constants.go
@@ -32,6 +32,7 @@ const (
 	KafkaBrokerEnvVarKey   = "KAFKA_BROKERS"
 	KafkaUsernameEnvVarKey = "KAFKA_USERNAME"
 	KafkaPasswordEnvVarKey = "KAFKA_PASSWORD"
+	KafkaSaslTypeEnvVarKey = "KAKFA_SASL_TYPE"
 
 	// Kafka Configuration
 	KafkaTopicEnvVarKey = "KAFKA_TOPIC"

--- a/pkg/channel/distributed/common/kafka/constants/constants.go
+++ b/pkg/channel/distributed/common/kafka/constants/constants.go
@@ -33,6 +33,7 @@ const (
 	KafkaSecretKeyNamespace = "namespace"
 	KafkaSecretKeyUsername  = "username"
 	KafkaSecretKeyPassword  = "password"
+	KafkaSecretKeySaslType  = "sasltype"
 
 	// Kafka Admin/Consumer/Producer Config Values
 	ConfigNetSaslVersion = sarama.SASLHandshakeV1 // Latest version, seems to work with EventHubs as well.

--- a/pkg/channel/distributed/controller/constants/constants.go
+++ b/pkg/channel/distributed/controller/constants/constants.go
@@ -51,6 +51,7 @@ const (
 	KafkaSecretDataKeyBrokers  = "brokers"
 	KafkaSecretDataKeyUsername = "username"
 	KafkaSecretDataKeyPassword = "password"
+	KafkaSecretDataKeySaslType = "sasltype"
 
 	// Prometheus MetricsPort
 	MetricsPortName = "metrics"

--- a/pkg/channel/distributed/controller/kafkachannel/controller.go
+++ b/pkg/channel/distributed/controller/kafkachannel/controller.go
@@ -83,6 +83,7 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 	kafkaBrokers := string(kafkaSecret.Data[clientconstants.KafkaSecretKeyBrokers])
 	kafkaUsername := string(kafkaSecret.Data[clientconstants.KafkaSecretKeyUsername])
 	kafkaPassword := string(kafkaSecret.Data[clientconstants.KafkaSecretKeyPassword])
+	kafkaSaslType := string(kafkaSecret.Data[clientconstants.KafkaSecretKeySaslType])
 
 	// Create A Kafka Auth Config From Current Credentials (Secret Data Takes Precedence Over ConfigMap)
 	var kafkaAuthCfg *commonclient.KafkaAuthConfig
@@ -91,6 +92,7 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 			SASL: &commonclient.KafkaSaslConfig{
 				User:     kafkaUsername,
 				Password: kafkaPassword,
+				SaslType: kafkaSaslType,
 			},
 		}
 	}
@@ -137,6 +139,7 @@ func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 		kafkaBrokers:         kafkaBrokers,
 		kafkaUsername:        kafkaUsername,
 		kafkaPassword:        kafkaPassword,
+		kafkaSaslType:        kafkaSaslType,
 	}
 
 	// Watch The Settings ConfigMap For Changes

--- a/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
+++ b/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
@@ -581,6 +581,19 @@ func (r *Reconciler) dispatcherDeploymentEnvVars(channel *kafkav1beta1.KafkaChan
 				},
 			},
 		})
+
+		// Append The Kafka SaslType As Env Var
+		optional := true
+		envVars = append(envVars, corev1.EnvVar{
+			Name: commonenv.KafkaSaslTypeEnvVarKey,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: kafkaSecret},
+					Key:                  constants.KafkaSecretDataKeySaslType,
+					Optional:             &optional,
+				},
+			},
+		})
 	}
 
 	// Return The Dispatcher Deployment EnvVars Array

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler.go
@@ -67,6 +67,7 @@ type Reconciler struct {
 	kafkaBrokers         string
 	kafkaUsername        string
 	kafkaPassword        string
+	kafkaSaslType        string
 }
 
 var (
@@ -275,6 +276,7 @@ func (r *Reconciler) configMapObserver(ctx context.Context, configMap *corev1.Co
 			SASL: &client.KafkaSaslConfig{
 				User:     r.kafkaUsername,
 				Password: r.kafkaPassword,
+				SaslType: r.kafkaSaslType,
 			},
 		}
 	}

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
@@ -676,6 +676,7 @@ func TestReconcile(t *testing.T) {
 			kafkaSecret:          controllertesting.KafkaSecretName,
 			kafkaUsername:        controllertesting.KafkaSecretDataValueUsername,
 			kafkaPassword:        controllertesting.KafkaSecretDataValuePassword,
+			kafkaSaslType:        controllertesting.KafkaSecretDataValueSaslType,
 		}
 		return kafkachannelreconciler.NewReconciler(ctx, logger, r.kafkaClientSet, listers.GetKafkaChannelLister(), controller.GetEventRecorder(ctx), r)
 	}, logger.Desugar()))

--- a/pkg/channel/distributed/controller/kafkasecret/receiver.go
+++ b/pkg/channel/distributed/controller/kafkasecret/receiver.go
@@ -442,6 +442,18 @@ func (r *Reconciler) receiverDeploymentEnvVars(secret *corev1.Secret) ([]corev1.
 		},
 	})
 
+	optional := true
+	envVars = append(envVars, corev1.EnvVar{
+		Name: commonenv.KafkaSaslTypeEnvVarKey,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secret.Name},
+				Key:                  constants.KafkaSecretDataKeySaslType,
+				Optional:             &optional,
+			},
+		},
+	})
+
 	// Return The Receiver Deployment EnvVars Array
 	return envVars, nil
 }

--- a/pkg/channel/distributed/controller/testing/data.go
+++ b/pkg/channel/distributed/controller/testing/data.go
@@ -80,6 +80,7 @@ const (
 	KafkaSecretDataValueBrokers  = "TestKafkaSecretDataBrokers"
 	KafkaSecretDataValueUsername = "TestKafkaSecretDataUsername"
 	KafkaSecretDataValuePassword = "TestKafkaSecretDataPassword"
+	KafkaSecretDataValueSaslType = "PLAIN"
 
 	// ChannelSpec Test Data
 	NumPartitions     = 123
@@ -289,6 +290,7 @@ func NewKafkaSecret(options ...KafkaSecretOption) *corev1.Secret {
 			constants.KafkaSecretDataKeyBrokers:  []byte(KafkaSecretDataValueBrokers),
 			constants.KafkaSecretDataKeyUsername: []byte(KafkaSecretDataValueUsername),
 			constants.KafkaSecretDataKeyPassword: []byte(KafkaSecretDataValuePassword),
+			constants.KafkaSecretDataKeySaslType: []byte(KafkaSecretDataValueSaslType),
 		},
 		Type: "opaque",
 	}
@@ -577,6 +579,9 @@ func NewKafkaChannelReceiverDeployment(options ...DeploymentOption) *appsv1.Depl
 	// Replicas Int Reference
 	replicas := int32(ReceiverReplicas)
 
+	// Optional EnvVar
+	optional := true
+
 	// Create The Receiver Deployment
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -707,6 +712,16 @@ func NewKafkaChannelReceiverDeployment(options ...DeploymentOption) *appsv1.Depl
 										},
 									},
 								},
+								{
+									Name: commonenv.KafkaSaslTypeEnvVarKey,
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{Name: KafkaSecretName},
+											Key:                  constants.KafkaSecretDataKeySaslType,
+											Optional:             &optional,
+										},
+									},
+								},
 							},
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: corev1.ResourceRequirements{
@@ -791,6 +806,7 @@ func NewKafkaChannelDispatcherDeployment(options ...DeploymentOption) *appsv1.De
 	dispatcherName := util.DispatcherDnsSafeName(sparseKafkaChannel)
 	topicName := util.TopicName(sparseKafkaChannel)
 	systemNamespace := system.Namespace()
+	optional := true
 
 	// Replicas Int Reference
 	replicas := int32(DispatcherReplicas)
@@ -923,6 +939,16 @@ func NewKafkaChannelDispatcherDeployment(options ...DeploymentOption) *appsv1.De
 										SecretKeyRef: &corev1.SecretKeySelector{
 											LocalObjectReference: corev1.LocalObjectReference{Name: KafkaSecretName},
 											Key:                  constants.KafkaSecretDataKeyPassword,
+										},
+									},
+								},
+								{
+									Name: commonenv.KafkaSaslTypeEnvVarKey,
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{Name: KafkaSecretName},
+											Key:                  constants.KafkaSecretDataKeySaslType,
+											Optional:             &optional,
 										},
 									},
 								},

--- a/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
@@ -297,6 +297,7 @@ func (d *DispatcherImpl) ConfigChanged(ctx context.Context, configMap *corev1.Co
 				SASL: &client.KafkaSaslConfig{
 					User:     d.SaramaConfig.Net.SASL.User,
 					Password: d.SaramaConfig.Net.SASL.Password,
+					SaslType: string(d.SaramaConfig.Net.SASL.Mechanism),
 				},
 			}
 			configBuilder = configBuilder.WithAuth(kafkaAuthCfg)

--- a/pkg/channel/distributed/dispatcher/env/environment.go
+++ b/pkg/channel/distributed/dispatcher/env/environment.go
@@ -54,6 +54,7 @@ type Environment struct {
 	// Kafka Authorization
 	KafkaUsername string // Optional
 	KafkaPassword string // Optional
+	KafkaSaslType string // Optional
 }
 
 // Get The Environment
@@ -141,6 +142,9 @@ func GetEnvironment(logger *zap.Logger) (*Environment, error) {
 
 	// Get The Optional KafkaPassword Config Value
 	environment.KafkaPassword = env.GetOptionalConfigValue(logger, env.KafkaPasswordEnvVarKey, "")
+
+	// Get The Optional KafkaSaslType Config Value
+	environment.KafkaSaslType = env.GetOptionalConfigValue(logger, env.KafkaSaslTypeEnvVarKey, "")
 
 	// Clone The Environment & Mask The Password For Safe Logging
 	safeEnvironment := *environment

--- a/pkg/channel/distributed/dispatcher/env/environment_test.go
+++ b/pkg/channel/distributed/dispatcher/env/environment_test.go
@@ -44,6 +44,7 @@ const (
 	serviceName     = "TestServiceName"
 	kafkaUsername   = "TestKafkaUsername"
 	kafkaPassword   = "TestKafkaPassword"
+	kafkaSaslType   = "SCRAM-SHA-512"
 	podName         = "TestPod"
 	containerName   = "TestContainer"
 )
@@ -62,6 +63,7 @@ type TestCase struct {
 	serviceName          string
 	kafkaUsername        string
 	kafkaPassword        string
+	kafkaSaslType        string
 	podName              string
 	containerName        string
 	expectedError        error
@@ -166,6 +168,7 @@ func TestGetEnvironment(t *testing.T) {
 			assertSetenv(t, commonenv.ServiceNameEnvVarKey, testCase.serviceName)
 			assertSetenv(t, commonenv.KafkaUsernameEnvVarKey, testCase.kafkaUsername)
 			assertSetenv(t, commonenv.KafkaPasswordEnvVarKey, testCase.kafkaPassword)
+			assertSetenv(t, commonenv.KafkaSaslTypeEnvVarKey, testCase.kafkaSaslType)
 			assertSetenv(t, commonenv.PodNameEnvVarKey, testCase.podName)
 			assertSetenv(t, commonenv.ContainerNameEnvVarKey, testCase.containerName)
 
@@ -186,6 +189,7 @@ func TestGetEnvironment(t *testing.T) {
 				assert.Equal(t, testCase.serviceName, environment.ServiceName)
 				assert.Equal(t, testCase.kafkaUsername, environment.KafkaUsername)
 				assert.Equal(t, testCase.kafkaPassword, environment.KafkaPassword)
+				assert.Equal(t, testCase.kafkaSaslType, environment.KafkaSaslType)
 				assert.Equal(t, testCase.podName, environment.PodName)
 				assert.Equal(t, testCase.containerName, environment.ContainerName)
 				assert.Equal(t, testCase.expectedResyncPeriod, strconv.Itoa(int(environment.ResyncPeriod/time.Minute)))
@@ -223,6 +227,7 @@ func getValidTestCase(name string) TestCase {
 		serviceName:          serviceName,
 		kafkaUsername:        kafkaUsername,
 		kafkaPassword:        kafkaPassword,
+		kafkaSaslType:        kafkaSaslType,
 		podName:              podName,
 		containerName:        containerName,
 		expectedError:        nil,

--- a/pkg/channel/distributed/receiver/env/environment.go
+++ b/pkg/channel/distributed/receiver/env/environment.go
@@ -52,6 +52,7 @@ type Environment struct {
 	// Kafka Authorization
 	KafkaUsername string // Optional
 	KafkaPassword string // Optional
+	KafkaSaslType string // Optional
 }
 
 // Get The Environment
@@ -127,6 +128,9 @@ func GetEnvironment(logger *zap.Logger) (*Environment, error) {
 
 	// Get The Optional KafkaPassword Config Value
 	environment.KafkaPassword = env.GetOptionalConfigValue(logger, env.KafkaPasswordEnvVarKey, "")
+
+	// Get the Optional KafkaSaslType Config value
+	environment.KafkaSaslType = env.GetOptionalConfigValue(logger, env.KafkaSaslTypeEnvVarKey, "")
 
 	// Clone The Environment & Mask The Password For Safe Logging
 	safeEnvironment := *environment

--- a/pkg/channel/distributed/receiver/producer/producer.go
+++ b/pkg/channel/distributed/receiver/producer/producer.go
@@ -198,6 +198,7 @@ func (p *Producer) ConfigChanged(ctx context.Context, configMap *corev1.ConfigMa
 				SASL: &client.KafkaSaslConfig{
 					User:     p.configuration.Net.SASL.User,
 					Password: p.configuration.Net.SASL.Password,
+					SaslType: string(p.configuration.Net.SASL.Mechanism),
 				},
 			}
 			configBuilder = configBuilder.WithAuth(kafkaAuthCfg)


### PR DESCRIPTION
Fixes #331

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add `sasltype` to kafka secret to configure optional sasltype as `SCRAM-SHA-256` or `SCRAM-SHA-512`.

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Adding new optional field named `sasltype` to default kafka-secret to enable other Kafka SASL Methods than `PLAIN`. Supports `SCRAM-SHA-256` or `SCRAM-SHA-512`.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
