### PR TITLE
Add http endpoint to communicate dispatcher readySubscriber status

### DIFF
--- a/config/channel/consolidated/deployments/dispatcher.yaml
+++ b/config/channel/consolidated/deployments/dispatcher.yaml
@@ -60,6 +60,9 @@ spec:
         - containerPort: 9090
           name: metrics
           protocol: TCP
+        - containerPort: 8081
+          name: sub-status
+          protocol: TCP
         volumeMounts:
         - name: config-kafka
           mountPath: /etc/config-kafka
@@ -85,6 +88,10 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 8080
+  - name: http-sub-status
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
   selector:
     messaging.knative.dev/channel: kafka-channel
     messaging.knative.dev/role: dispatcher

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -52,8 +52,7 @@ const (
 )
 
 type KafkaSubscription struct {
-	channelRef eventingchannels.ChannelReference
-	subs       []types.UID
+	subs []types.UID
 
 	// readySubscriptionsLock must be used to synchronize access to channelReadySubscriptions
 	readySubscriptionsLock    sync.RWMutex
@@ -336,7 +335,6 @@ func (d *KafkaDispatcher) UpdateKafkaConsumers(config *Config) (map[types.UID]er
 				}
 			} else { //ensure the pointer is populated or things go boom
 				d.channelSubscriptions[channelRef] = &KafkaSubscription{
-					channelRef:                channelRef,
 					subs:                      []types.UID{},
 					channelReadySubscriptions: sets.String{},
 				}

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -113,9 +113,10 @@ func (d *KafkaDispatcher) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request
 		w.WriteHeader(nethttp.StatusNotFound)
 		return
 	}
+	channelRefNamespace, channelRefName := uriSplit[1], uriSplit[2]
 	channelRef := eventingchannels.ChannelReference{
-		Name:      uriSplit[2],
-		Namespace: uriSplit[1],
+		Name:      channelRefName,
+		Namespace: channelRefNamespace,
 	}
 	if _, ok := d.channelSubscriptions[channelRef]; !ok {
 		w.WriteHeader(nethttp.StatusNotFound)
@@ -125,7 +126,7 @@ func (d *KafkaDispatcher) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request
 	defer d.channelSubscriptions[channelRef].readySubscriptionsLock.RUnlock()
 	var subscriptions = make(map[string][]string)
 	w.Header().Set(dispatcherReadySubHeader, uriSplit[2])
-	subscriptions[uriSplit[1]+"/"+uriSplit[2]] = d.channelSubscriptions[channelRef].channelReadySubscriptions.List()
+	subscriptions[channelRefNamespace+"/"+channelRefName] = d.channelSubscriptions[channelRef].channelReadySubscriptions.List()
 	jsonResult, err := json.Marshal(subscriptions)
 	if err != nil {
 		return // we should probably log instead, pass logger via context?

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -456,6 +456,9 @@ func (d *KafkaDispatcher) subscribe(channelRef eventingchannels.ChannelReference
 func (d *KafkaDispatcher) unsubscribe(channel eventingchannels.ChannelReference, sub Subscription) error {
 	d.logger.Infow("Unsubscribing from channel", zap.Any("channel", channel), zap.String("subscription", sub.String()))
 	delete(d.subscriptions, sub.UID)
+	if _, ok := d.channelSubscriptions[channel]; !ok {
+		return nil
+	}
 	if subsSlice := d.channelSubscriptions[channel].subs; subsSlice != nil {
 		var newSlice []types.UID
 		for _, oldSub := range subsSlice {

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -118,7 +118,7 @@ func (d *KafkaDispatcher) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request
 		Namespace: uriSplit[1],
 	}
 	if _, ok := d.channelSubscriptions[channelRef]; !ok {
-		w.WriteHeader(nethttp.StatusBadRequest)
+		w.WriteHeader(nethttp.StatusNotFound)
 		return
 	}
 	d.channelSubscriptions[channelRef].readySubscriptionsLock.RLock()

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -170,7 +170,7 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 	}
 
 	go func() {
-		dispatcher.logger.Fatal(nethttp.ListenAndServe(":", dispatcher))
+		dispatcher.logger.Fatal(nethttp.ListenAndServe(":8081", dispatcher))
 	}()
 
 	podName, err := env.GetRequiredConfigValue(args.Logger.Desugar(), env.PodNameEnvVarKey)

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -127,7 +127,7 @@ func (d *KafkaDispatcher) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request
 	d.channelSubscriptions[channelRef].readySubscriptionsLock.RLock()
 	defer d.channelSubscriptions[channelRef].readySubscriptionsLock.RUnlock()
 	var subscriptions = make(map[string][]string)
-	w.Header().Set(dispatcherReadySubHeader, uriSplit[2])
+	w.Header().Set(dispatcherReadySubHeader, channelRefName)
 	subscriptions[channelRefNamespace+"/"+channelRefName] = d.channelSubscriptions[channelRef].channelReadySubscriptions.List()
 	jsonResult, err := json.Marshal(subscriptions)
 	if err != nil {

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -134,8 +134,10 @@ func (d *KafkaDispatcher) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request
 		d.logger.Errorf("Error marshalling json for sub-status channelref: %s/%s, %w", channelRefNamespace, channelRefName, err)
 		return
 	}
-	fmt.Fprintf(w, string(jsonResult))
-	w.WriteHeader(nethttp.StatusOK)
+	_, err = w.Write(jsonResult)
+	if err != nil {
+		d.logger.Errorf("Error writing jsonResult to serveHTTP writer: %w", err)
+	}
 }
 
 func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispatcher, error) {

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -155,7 +155,7 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 		dispatcher.channelSubscriptions[channelRef].readySubscriptionsLock.RLock()
 		defer dispatcher.channelSubscriptions[channelRef].readySubscriptionsLock.RUnlock()
 		var subscriptions = make(map[string][]string)
-		w.Header().Set("K-Subscriber-Status", uriSPlit[2])
+		w.Header().Set("K-Subscriber-Status", uriSplit[2])
 		subscriptions[uriSplit[2]] = dispatcher.channelSubscriptions[channelRef].channelReadySubscriptions.List()
 		jsonResult, err := json.Marshal(subscriptions)
 		if err != nil {

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -125,7 +125,7 @@ func (d *KafkaDispatcher) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request
 	defer d.channelSubscriptions[channelRef].readySubscriptionsLock.RUnlock()
 	var subscriptions = make(map[string][]string)
 	w.Header().Set(dispatcherReadySubHeader, uriSplit[2])
-	subscriptions[uriSplit[2]] = d.channelSubscriptions[channelRef].channelReadySubscriptions.List()
+	subscriptions[uriSplit[1]+"/"+uriSplit[2]] = d.channelSubscriptions[channelRef].channelReadySubscriptions.List()
 	jsonResult, err := json.Marshal(subscriptions)
 	if err != nil {
 		return // we should probably log instead, pass logger via context?

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -47,8 +47,6 @@ import (
 	"knative.dev/eventing-kafka/pkg/common/consumer"
 )
 
-type ConsumerCallback func()
-
 type KafkaSubscription struct {
 	channelRef eventingchannels.ChannelReference
 	subs       []types.UID
@@ -56,10 +54,6 @@ type KafkaSubscription struct {
 	// readySubscriptionsLock must be used to synchronize access to channelReadySubscriptions
 	readySubscriptionsLock    sync.RWMutex
 	channelReadySubscriptions sets.String
-
-	// watchersLock must be used to synchronize access to consumerWatchers
-	watchersLock     sync.RWMutex
-	consumerWatchers []ConsumerCallback
 }
 
 type KafkaDispatcher struct {
@@ -327,7 +321,6 @@ func (d *KafkaDispatcher) UpdateKafkaConsumers(config *Config) (map[types.UID]er
 					channelRef:                channelRef,
 					subs:                      []types.UID{},
 					channelReadySubscriptions: sets.String{},
-					consumerWatchers:          []ConsumerCallback{},
 				}
 				go func() {
 					nethttp.HandleFunc(fmt.Sprintf("/%s/%s", cc.Namespace, cc.Name), d.channelSubscriptions[channelRef].HandleReadySubsStatusRequest)

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -47,6 +47,10 @@ import (
 	"knative.dev/eventing-kafka/pkg/common/consumer"
 )
 
+const (
+	dispatcherReadySubHeader = "K-Subscriber-Status"
+)
+
 type KafkaSubscription struct {
 	channelRef eventingchannels.ChannelReference
 	subs       []types.UID
@@ -155,7 +159,7 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 		dispatcher.channelSubscriptions[channelRef].readySubscriptionsLock.RLock()
 		defer dispatcher.channelSubscriptions[channelRef].readySubscriptionsLock.RUnlock()
 		var subscriptions = make(map[string][]string)
-		w.Header().Set("K-Subscriber-Status", uriSplit[2])
+		w.Header().Set(dispatcherReadySubHeader, uriSplit[2])
 		subscriptions[uriSplit[2]] = dispatcher.channelSubscriptions[channelRef].channelReadySubscriptions.List()
 		jsonResult, err := json.Marshal(subscriptions)
 		if err != nil {

--- a/pkg/channel/consolidated/dispatcher/dispatcher_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/channel/consolidated/dispatcher/dispatcher_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -320,7 +320,7 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 			t.Logf("Running %s", t.Name())
 			d := &KafkaDispatcher{
 				kafkaConsumerFactory: &mockKafkaConsumerFactory{},
-				channelSubscriptions: make(map[eventingchannels.ChannelReference][]types.UID),
+				channelSubscriptions: make(map[eventingchannels.ChannelReference]*KafkaSubscription),
 				subsConsumerGroups:   make(map[types.UID]sarama.ConsumerGroup),
 				subscriptions:        make(map[types.UID]Subscription),
 				topicFunc:            utils.TopicName,

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -151,11 +151,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 	return r.syncDispatcher(ctx)
 }
 
-func (r *Reconciler) ObserveKind(ctx context.Context, kc *v1beta1.KafkaChannel) pkgreconciler.Event {
-	logging.FromContext(ctx).Debugw("ObserveKind for channel", zap.String("channel", kc.Name))
-	return r.syncDispatcher(ctx)
-}
-
 func (r *Reconciler) syncDispatcher(ctx context.Context) pkgreconciler.Event {
 	channels, err := r.kafkachannelLister.List(labels.Everything())
 	if err != nil {

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -151,6 +151,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 	return r.syncDispatcher(ctx)
 }
 
+func (r *Reconciler) ObserveKind(ctx context.Context, kc *v1beta1.KafkaChannel) pkgreconciler.Event {
+	logging.FromContext(ctx).Debugw("ObserveKind for channel", zap.String("channel", kc.Name))
+	return r.syncDispatcher(ctx)
+}
+
 func (r *Reconciler) syncDispatcher(ctx context.Context) pkgreconciler.Event {
 	channels, err := r.kafkachannelLister.List(labels.Everything())
 	if err != nil {

--- a/pkg/common/consumer/consumer_handler.go
+++ b/pkg/common/consumer/consumer_handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/consumer/consumer_handler_test.go
+++ b/pkg/common/consumer/consumer_handler_test.go
@@ -115,7 +115,6 @@ func (m mockMessageHandler) Handle(ctx context.Context, message *sarama.Consumer
 }
 
 func (m mockMessageHandler) SetReady(ready bool) {
-	return
 }
 
 //------ Tests

--- a/pkg/common/consumer/consumer_handler_test.go
+++ b/pkg/common/consumer/consumer_handler_test.go
@@ -114,6 +114,10 @@ func (m mockMessageHandler) Handle(ctx context.Context, message *sarama.Consumer
 	}
 }
 
+func (m mockMessageHandler) SetReady(ready bool) {
+	return
+}
+
 //------ Tests
 
 func Test(t *testing.T) {

--- a/pkg/source/adapter/adapter.go
+++ b/pkg/source/adapter/adapter.go
@@ -121,6 +121,8 @@ func (a *Adapter) start(stopCh <-chan struct{}) error {
 	return nil
 }
 
+func (a *Adapter) SetReady(_ bool) {}
+
 func (a *Adapter) Handle(ctx context.Context, msg *sarama.ConsumerMessage) (bool, error) {
 	if a.rateLimiter != nil {
 		a.rateLimiter.Wait(ctx)


### PR DESCRIPTION
this is a WIP/PoC for one half of a more immediate fix for the
'readySubscriber' issues in the kafkachannel.  This will need some of
the work that @devguyio is working on with lifting the network prober
to knative/pkg.  However, I'm about as far as I think I can get until
I know more about that implementation.

/hold