### PR TITLE
No retry on 400 response

### DIFF
--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -173,12 +173,12 @@ func (h *Handler) checkRetry(_ context.Context, response *http.Response, err err
 	logger := h.Logger.With(zap.Int("StatusCode", statusCode))
 
 	//
-	// Note - Normally we would NOT want to retry 400 responses, BUT the knative-eventing
+	// Note - Normally we would NOT want to retry 4xx responses, BUT the knative-eventing
 	//        filter handler (due to CloudEvents SDK V1 usage) is swallowing the actual
-	//        status codes from the subscriber and returning 400s instead.  Once this has,
-	//        been resolved we can remove 400 from the list of codes to retry.
+	//        status codes from the subscriber and returning 4xx instead.  Once this has,
+	//        been resolved we can remove 4xx from the list of codes to retry.
 	//
-	if statusCode >= 500 || statusCode == 400 || statusCode == 404 || statusCode == 429 || statusCode == 409 {
+	if statusCode >= 500 || statusCode == 404 || statusCode == 429 || statusCode == 409 {
 		logger.Warn("Failed To Send Message To Subscriber Service - Retrying")
 		return true, nil
 	} else if statusCode >= 300 && statusCode <= 399 {

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -172,12 +172,18 @@ func (h *Handler) checkRetry(_ context.Context, response *http.Response, err err
 	statusCode := response.StatusCode
 	logger := h.Logger.With(zap.Int("StatusCode", statusCode))
 
+	// Note - Normally we would NOT want to retry 4xx responses, BUT there are a few
+	//        known areas of knative-eventing that return codes in this range which
+	//        require retries.  Reasons for particular codes are as follows:
 	//
-	// Note - Normally we would NOT want to retry 4xx responses, BUT the knative-eventing
-	//        filter handler (due to CloudEvents SDK V1 usage) is swallowing the actual
-	//        status codes from the subscriber and returning 4xx instead.  Once this has,
-	//        been resolved we can remove 4xx from the list of codes to retry.
-	//
+	// 404  Although we would ideally not want to retry a permanent "Not Found"
+	//      response, a 404 can be returned when a pod is in the process of becoming
+	//      ready, so a retry can be a useful thing in this situation.
+	// 409  Returned by the E2E tests, so we must retry when "Conflict" is received, or the
+	//      tests will fail (see knative.dev/eventing/test/lib/recordevents/receiver/receiver.go)
+	// 429  Since retry typically involves a delay (usually an exponential backoff),
+	//      retrying after receiving a "Too Many Requests" response is useful.
+
 	if statusCode >= 500 || statusCode == 404 || statusCode == 429 || statusCode == 409 {
 		logger.Warn("Failed To Send Message To Subscriber Service - Retrying")
 		return true, nil

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
@@ -294,7 +294,7 @@ func TestCheckRetry(t *testing.T) {
 		{
 			name:     "Http StatusCode 400",
 			response: &http.Response{StatusCode: http.StatusBadRequest},
-			result:   true,
+			result:   false,
 		},
 		{
 			name:     "Http StatusCode 401",


### PR DESCRIPTION
## Proposed Changes

- 🧽 Removed 400 ("Bad Request") from the list of responses in the distributed channel dispatcher's handler that indicate retries.

**Reasoning**

Retrying on a 400 response was a legacy behavior that was required due to the way the filter handler was consuming 5xx responses and returning 400 in their place.  This is no longer the case and "Bad Request" responses are not generally conditions that warrant retries, so that code has been removed.

Note that there are still several 4xx responses that do cause checkRetry to return true (namely 404, 409, and 429).  409 is required unless the e2e tests are changed, and 404/429 are left for their original reasons (noted in the comments for the checkRetry function).
