### PR TITLE
Adding check that requires us to just enable TLS, no need for custom certs

### DIFF
--- a/pkg/channel/consolidated/utils/util.go
+++ b/pkg/channel/consolidated/utils/util.go
@@ -42,7 +42,7 @@ const (
 	MaxIdleConnectionsKey        = "maxIdleConns"
 	MaxIdleConnectionsPerHostKey = "maxIdleConnsPerHost"
 
-	TlsEnabled  = "tls.enabled"
+	TlsEnabled   = "tls.enabled"
 	TlsCacert    = "ca.crt"
 	TlsUsercert  = "user.crt"
 	TlsUserkey   = "user.key"
@@ -81,7 +81,7 @@ func parseTls(secret *corev1.Secret, kafkaAuthConfig *client.KafkaAuthConfig) {
 	} else {
 		// Public CERTS from a proper CA do not need this,
 		// we can just say `tls.enabled: true`
-		tlsEnabled, err :=  strconv.ParseBool(string(secret.Data[TlsEnabled]))
+		tlsEnabled, err := strconv.ParseBool(string(secret.Data[TlsEnabled]))
 		if err != nil {
 			tlsEnabled = false
 		}

--- a/pkg/common/client/config.go
+++ b/pkg/common/client/config.go
@@ -186,14 +186,18 @@ func (b *configBuilder) Build(ctx context.Context) (*sarama.Config, error) {
 
 	// then apply auth settings
 	if b.auth != nil {
-		// tls
+		// TLS
 		if b.auth.TLS != nil {
 			config.Net.TLS.Enable = true
-			tlsConfig, err := newTLSConfig(b.auth.TLS.Usercert, b.auth.TLS.Userkey, b.auth.TLS.Cacert)
-			if err != nil {
-				return nil, fmt.Errorf("Error creating TLS config: %w", err)
+
+			// if we have TLS, we might want to use the certs for self-signed CERTs
+			if b.auth.TLS.Cacert != "" {
+				tlsConfig, err := newTLSConfig(b.auth.TLS.Usercert, b.auth.TLS.Userkey, b.auth.TLS.Cacert)
+				if err != nil {
+					return nil, fmt.Errorf("Error creating TLS config: %w", err)
+				}
+				config.Net.TLS.Config = tlsConfig
 			}
-			config.Net.TLS.Config = tlsConfig
 		}
 		// SASL
 		if b.auth.SASL != nil {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #356

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- with public CA Certs we just need to "enable" TLS .... and we don't have to bother with the certs like for self-signed ones

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Adding tls.enabled flag for public cert usage and allowing skipping CA/User certs and key
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
