### PR TITLE
Fix race on error channel in consumer factory

### DIFF
--- a/pkg/common/consumer/consumer_factory.go
+++ b/pkg/common/consumer/consumer_factory.go
@@ -47,11 +47,8 @@ func (c *customConsumerGroup) Errors() <-chan error {
 }
 
 func (c *customConsumerGroup) Close() error {
-	err := c.ConsumerGroup.Close()
-	// Canceling the context after the close of consumer group makes sure we cleanup the error channel
-	// after the consumer group is stopped
 	c.cancel()
-	return err
+	return c.ConsumerGroup.Close()
 }
 
 var _ sarama.ConsumerGroup = (*customConsumerGroup)(nil)


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

In #263 the error channel is closed in a separate context of where it is created and it might cause race conditions during the teardown (one closes the error channel, but the consumer group is still running and tries to push to that channel).
This fix makes sure that we close the error channel effectively after `Consume` returns (when consume returns, sarama guarantees us that no consumer handler is running)

```
{"level":"info","ts":"2021-02-02T02:10:00.620Z","logger":"kafkachannel-dispatcher","caller":"consumer/consumer_handler.go:83","msg":"Failure while handling a message","knative.dev/pod":"kafka-ch-dispatcher-66776c4967-7lbpw","topic":"knative-messaging-kafka.kafka-stable-kn-retry-1.channel-0","partition":2,"offset":9732,"error":"unable to complete request to http://receiver-0.kafka-stable-kn-retry-1.svc.cluster.local: Post \"http://receiver-0.kafka-stable-kn-retry-1.svc.cluster.local\": dial tcp: lookup receiver-0.kafka-stable-kn-retry-1.svc.cluster.local: no such host"}
{"level":"info","ts":"2021-02-02T02:10:00.620Z","logger":"kafkachannel-dispatcher","caller":"consumer/consumer_handler.go:61","msg":"cleanup handler","knative.dev/pod":"kafka-ch-dispatcher-66776c4967-7lbpw"}
panic: send on closed channel

goroutine 1075 [running]:
knative.dev/eventing-kafka/pkg/common/consumer.(*SaramaConsumerHandler).ConsumeClaim(0xc00093a1a0, 0x2317b20, 0xc0007c9a80, 0x2308d60, 0xc0006629c0, 0x39, 0x2)
	/opt/app-root/src/go/src/knative.dev/eventing/pkg/common/consumer/consumer_handler.go:84 +0xbdd
github.com/Shopify/sarama.(*consumerGroupSession).consume(0xc0007c9a80, 0xc0007cce40, 0x39, 0x726f6f6300000002)
	/opt/app-root/src/go/src/knative.dev/eventing/vendor/github.com/Shopify/sarama/consumer_group.go:690 +0x27f
github.com/Shopify/sarama.newConsumerGroupSession.func2(0xc0007c9a80, 0xc0007cce40, 0x39, 0xc000000002)
	/opt/app-root/src/go/src/knative.dev/eventing/vendor/github.com/Shopify/sarama/consumer_group.go:615 +0x87
created by github.com/Shopify/sarama.newConsumerGroupSession
	/opt/app-root/src/go/src/knative.dev/eventing/vendor/github.com/Shopify/sarama/consumer_group.go:607 +0x526
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Fix race on error channel in consumer factory

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Fix race on error channel in consumer factory
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
