### PR TITLE
Propagate the auth config down to the st adapter

### DIFF
--- a/config/source/multi/201-adapter-clusterrole.yaml
+++ b/config/source/multi/201-adapter-clusterrole.yaml
@@ -56,6 +56,13 @@ rules:
   - watch
 
 - apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+
+- apiGroups:
    - ""
   resources:
   - events

--- a/pkg/source/mtadapter/adapter_test.go
+++ b/pkg/source/mtadapter/adapter_test.go
@@ -25,6 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	_ "knative.dev/pkg/client/injection/kube/client/fake"
 	pkgtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/source"
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -456,7 +456,7 @@ function test_mt_source() {
   echo "Testing the multi-tenant source"
   install_mt_source || return 1
 
-  go_test_e2e -tags=mtsource -timeout=5m -test.parallel=${TEST_PARALLEL} ./test/...  || fail_test
+  go_test_e2e -tags=source,mtsource -timeout=5m -test.parallel=${TEST_PARALLEL} ./test/...  || fail_test
 
   uninstall_mt_source || return 1
 }

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -1,4 +1,4 @@
-//+build e2e mtsource
+//+build e2e
 //+build source
 
 /*


### PR DESCRIPTION
Fixes #358

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Propagate the auth config down to the single-tenant adapter
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

e2e tests are now passing (with https://github.com/knative-sandbox/eventing-kafka/pull/364). I'll enable PROW when both PR are merged.

/cc @steven0711dong 