### PR TITLE
Increase idle connection limits from 100/2 to 1000/100

### DIFF
--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -19,9 +19,10 @@ package main
 import (
 	"context"
 	"flag"
-	"knative.dev/eventing/pkg/kncloudevents"
 	"strconv"
 	"strings"
+
+	"knative.dev/eventing/pkg/kncloudevents"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"

--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"knative.dev/eventing/pkg/kncloudevents"
 	"strconv"
 	"strings"
 
@@ -113,6 +114,12 @@ func main() {
 	}
 
 	statsReporter := metrics.NewStatsReporter(logger)
+
+	// Increase The Idle Connection Limits From Transport Defaults (see net/http/DefaultTransport)
+	kncloudevents.ConfigureConnectionArgs(&kncloudevents.ConnectionArgs{
+		MaxIdleConns:        constants.DefaultMaxIdleConns,
+		MaxIdleConnsPerHost: constants.DefaultMaxIdleConnsPerHost,
+	})
 
 	// Create The Dispatcher With Specified Configuration
 	dispatcherConfig := dispatch.DispatcherConfig{

--- a/pkg/channel/distributed/dispatcher/constants/constants.go
+++ b/pkg/channel/distributed/dispatcher/constants/constants.go
@@ -18,5 +18,9 @@ package constants
 
 // Global Constants
 const (
+	// Values Used When Creating A New Dispatcher
+	DefaultMaxIdleConns        = 1000
+	DefaultMaxIdleConnsPerHost = 100
+
 	Component = "eventing-kafka-channel-dispatcher"
 )


### PR DESCRIPTION
## Proposed Changes

-🧽 Increase the idle connection limits to the values used by the consolidated and in-memory channels

