### PR TITLE
Allow v1beta1 stkafkasource topics & bootstrapservers to be mutable

### DIFF
--- a/pkg/apis/sources/v1beta1/kafka_validation.go
+++ b/pkg/apis/sources/v1beta1/kafka_validation.go
@@ -19,6 +19,8 @@ package v1beta1
 import (
 	"context"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 )
@@ -27,7 +29,9 @@ import (
 func (r *KafkaSource) Validate(ctx context.Context) *apis.FieldError {
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*KafkaSource)
-		if diff, err := kmp.ShortDiff(original.Spec, r.Spec); err != nil {
+		// Ignore diffs in bootstrapServers and topics
+		ignoreArgs := cmpopts.IgnoreFields(KafkaSourceSpec{}, "Topics", "BootstrapServers")
+		if diff, err := kmp.ShortDiff(original.Spec, r.Spec, ignoreArgs); err != nil {
 			return &apis.FieldError{
 				Message: "Failed to diff KafkaSource",
 				Paths:   []string{"spec"},

--- a/pkg/apis/sources/v1beta1/kafka_validation_test.go
+++ b/pkg/apis/sources/v1beta1/kafka_validation_test.go
@@ -57,10 +57,11 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 		"Topic changed": {
 			orig: &fullSpec,
 			updated: KafkaSourceSpec{
-				Topics:     []string{"some-other-topic"},
-				SourceSpec: fullSpec.SourceSpec,
+				Topics:        []string{"some-other-topic"},
+				ConsumerGroup: fullSpec.ConsumerGroup,
+				SourceSpec:    fullSpec.SourceSpec,
 			},
-			allowed: false,
+			allowed: true,
 		},
 		"Bootstrap servers changed": {
 			orig: &fullSpec,
@@ -68,9 +69,10 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 				KafkaAuthSpec: bindingsv1beta1.KafkaAuthSpec{
 					BootstrapServers: []string{"server1,server2"},
 				},
-				SourceSpec: fullSpec.SourceSpec,
+				ConsumerGroup: fullSpec.ConsumerGroup,
+				SourceSpec:    fullSpec.SourceSpec,
 			},
-			allowed: false,
+			allowed: true,
 		},
 		"Sink.APIVersion changed": {
 			orig: &fullSpec,


### PR DESCRIPTION
Change the validation of the kafkasource api to allow for changing the
topics/servers after creation