### PR TITLE
[mtsource] don't kill pods with placed vpods

### DIFF
--- a/config/source/multi/201-adapter-clusterrole.yaml
+++ b/config/source/multi/201-adapter-clusterrole.yaml
@@ -56,14 +56,27 @@ rules:
   - watch
 
 - apiGroups:
-    - ""
+  - apps
   resources:
-    - secrets
+  - deployments
   verbs:
-    - get
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 
 - apiGroups:
-   - ""
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+
+- apiGroups:
+  - ""
   resources:
   - events
   verbs:

--- a/pkg/common/scheduler/statefulset/autoscaler.go
+++ b/pkg/common/scheduler/statefulset/autoscaler.go
@@ -46,7 +46,8 @@ func (s *StatefulSetScheduler) autoscale(ctx context.Context) {
 				zap.Int32("free", s.freeCapacity(snapshot)),
 				zap.Int32("used", s.usedCapacity(snapshot)),
 				zap.Int32("pending", s.pendingVReplicas()),
-				zap.Int32("replicas", s.replicas))
+				zap.Int32("replicas", s.replicas),
+				zap.Int32("last ordinal", snapshot.lastOrdinal))
 
 			var ratio float64
 			if s.replicas == 0 {
@@ -72,13 +73,21 @@ func (s *StatefulSetScheduler) autoscale(ctx context.Context) {
 				}
 
 				// Desired ratio is 0.5 (TODO: configurable)
-				scale.Spec.Replicas = int32(math.Ceil(float64(s.usedCapacity(snapshot)+s.pendingVReplicas()) / (float64(s.capacity) * 0.5)))
+				new := int32(math.Ceil(float64(s.usedCapacity(snapshot)+s.pendingVReplicas()) / (float64(s.capacity) * 0.5)))
 
-				s.logger.Infow("updating adapter replicas", zap.Int32("replicas", scale.Spec.Replicas))
+				// Make sure not to scale down past the last pod with placed vpods
+				if new < snapshot.lastOrdinal+1 {
+					new = snapshot.lastOrdinal + 1
+				}
 
-				_, err = s.statefulSetClient.UpdateScale(ctx, s.statefulSetName, scale, metav1.UpdateOptions{})
-				if err != nil {
-					s.logger.Errorw("updating scale subresource failed", zap.Error(err))
+				if new != scale.Spec.Replicas {
+					scale.Spec.Replicas = new
+					s.logger.Infow("updating adapter replicas", zap.Int32("replicas", scale.Spec.Replicas))
+
+					_, err = s.statefulSetClient.UpdateScale(ctx, s.statefulSetName, scale, metav1.UpdateOptions{})
+					if err != nil {
+						s.logger.Errorw("updating scale subresource failed", zap.Error(err))
+					}
 				}
 			}
 		}()

--- a/pkg/common/scheduler/statefulset/snapshot_test.go
+++ b/pkg/common/scheduler/statefulset/snapshot_test.go
@@ -45,19 +45,19 @@ func TestSnapshot(t *testing.T) {
 			name:     "no vpods, no replicas",
 			vpods:    [][]duckv1alpha1.Placement{},
 			replicas: int32(0),
-			expected: Snapshot{free: map[string]int32{}},
+			expected: Snapshot{free: map[string]int32{}, lastOrdinal: 0},
 		},
 		{
 			name:     "no vpods, one replica",
 			vpods:    [][]duckv1alpha1.Placement{},
 			replicas: int32(1),
-			expected: Snapshot{free: map[string]int32{"statefulset-name-0": int32(10)}},
+			expected: Snapshot{free: map[string]int32{"statefulset-name-0": int32(10)}, lastOrdinal: 0},
 		},
 		{
 			name:     "one vpods, one replica",
 			vpods:    [][]duckv1alpha1.Placement{{{PodName: "statefulset-name-0", VReplicas: 1}}},
 			replicas: int32(1),
-			expected: Snapshot{free: map[string]int32{"statefulset-name-0": int32(9)}},
+			expected: Snapshot{free: map[string]int32{"statefulset-name-0": int32(9)}, lastOrdinal: 0},
 		},
 		{
 			name: "many vpods, many replicas",
@@ -71,7 +71,7 @@ func TestSnapshot(t *testing.T) {
 				"statefulset-name-0": int32(8),
 				"statefulset-name-1": int32(5),
 				"statefulset-name-2": int32(5),
-				"statefulset-name-3": int32(10)}},
+				"statefulset-name-3": int32(10)}, lastOrdinal: 2},
 		},
 	}
 

--- a/pkg/source/mtadapter/adapter.go
+++ b/pkg/source/mtadapter/adapter.go
@@ -90,16 +90,19 @@ func (a *Adapter) Start(ctx context.Context) error {
 // Implements MTAdapter
 
 func (a *Adapter) Update(ctx context.Context, obj *v1beta1.KafkaSource) {
+	a.sourcesMu.Lock()
+	defer a.sourcesMu.Unlock()
+
 	key := obj.Namespace + "/" + obj.Name
 
-	a.sourcesMu.RLock()
-	cancel, ok := a.sources[key]
-	a.sourcesMu.RUnlock()
+	_, ok := a.sources[key]
 
 	if ok {
+		// TODO: see https://github.com/knative-sandbox/eventing-kafka/issues/382
+		return
 		// TODO: do not stop if the only thing that changes is the number of vreplicas
-		a.logger.Info("stopping adapter", zap.String("key", key))
-		cancel()
+		//a.logger.Info("stopping adapter", zap.String("key", key))
+		//cancel()
 	}
 
 	placement := scheduler.GetPlacementForPod(obj.GetPlacements(), a.config.PodName)
@@ -166,17 +169,16 @@ func (a *Adapter) Update(ctx context.Context, obj *v1beta1.KafkaSource) {
 
 	}(ctx)
 
-	a.sourcesMu.Lock()
 	a.sources[key] = cancelFn
-	a.sourcesMu.Unlock()
 }
 
 func (a *Adapter) Remove(ctx context.Context, obj *v1beta1.KafkaSource) {
+	a.sourcesMu.Lock()
+	defer a.sourcesMu.Unlock()
+
 	key := obj.Namespace + "/" + obj.Name
 
-	a.sourcesMu.RLock()
 	cancel, ok := a.sources[key]
-	a.sourcesMu.RUnlock()
 
 	if !ok {
 		return
@@ -184,9 +186,7 @@ func (a *Adapter) Remove(ctx context.Context, obj *v1beta1.KafkaSource) {
 
 	cancel()
 
-	a.sourcesMu.Lock()
 	delete(a.sources, key)
-	a.sourcesMu.Unlock()
 }
 
 // ResolveSecret resolves the secret reference

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -456,7 +456,7 @@ function test_mt_source() {
   echo "Testing the multi-tenant source"
   install_mt_source || return 1
 
-  go_test_e2e -tags=source,mtsource -timeout=5m -test.parallel=${TEST_PARALLEL} ./test/...  || fail_test
+  go_test_e2e -tags=source,mtsource -timeout=20m -test.parallel=${TEST_PARALLEL} ./test/e2e/...  || fail_test
 
   uninstall_mt_source || return 1
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Limit scaling down the adapter to the last pod with placed "vpods" 
- Temporarily disable cancelling single-tenant adapters. See https://github.com/knative-sandbox/eventing-kafka/issues/382
- 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

source e2e tests are passing ... locally. Let's see if Prow is happy.