### PR TITLE
Expand number of kafkasource fields that are now mutable, add e2e tests

### DIFF
--- a/pkg/apis/sources/v1beta1/kafka_validation.go
+++ b/pkg/apis/sources/v1beta1/kafka_validation.go
@@ -61,7 +61,7 @@ func (ks *KafkaSource) CheckImmutableFields(ctx context.Context, original *Kafka
 	var errs *apis.FieldError
 
 	// Ignore diffs in bootstrapServers and topics
-	ignoreArgs := cmpopts.IgnoreFields(KafkaSourceSpec{}, "Topics", "BootstrapServers", "Sink")
+	ignoreArgs := cmpopts.IgnoreFields(KafkaSourceSpec{}, "Topics", "BootstrapServers", "Sink", "Net")
 	if diff, err := kmp.ShortDiff(original.Spec, ks.Spec, ignoreArgs); err != nil {
 		errs = errs.Also(&apis.FieldError{
 			Message: "Failed to diff KafkaSource",

--- a/pkg/apis/sources/v1beta1/kafka_validation.go
+++ b/pkg/apis/sources/v1beta1/kafka_validation.go
@@ -61,7 +61,7 @@ func (ks *KafkaSource) CheckImmutableFields(ctx context.Context, original *Kafka
 	var errs *apis.FieldError
 
 	// Ignore diffs in bootstrapServers and topics
-	ignoreArgs := cmpopts.IgnoreFields(KafkaSourceSpec{}, "Topics", "BootstrapServers", "Sink", "Net")
+	ignoreArgs := cmpopts.IgnoreFields(KafkaSourceSpec{}, "Topics", "BootstrapServers", "Sink", "Net", "CloudEventOverrides")
 	if diff, err := kmp.ShortDiff(original.Spec, ks.Spec, ignoreArgs); err != nil {
 		errs = errs.Also(&apis.FieldError{
 			Message: "Failed to diff KafkaSource",

--- a/pkg/apis/sources/v1beta1/kafka_validation.go
+++ b/pkg/apis/sources/v1beta1/kafka_validation.go
@@ -26,25 +26,58 @@ import (
 )
 
 // Validate ensures KafkaSource is properly configured.
-func (r *KafkaSource) Validate(ctx context.Context) *apis.FieldError {
+func (ks *KafkaSource) Validate(ctx context.Context) *apis.FieldError {
+	errs := ks.Spec.Validate(ctx).ViaField("spec")
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*KafkaSource)
-		// Ignore diffs in bootstrapServers and topics
-		ignoreArgs := cmpopts.IgnoreFields(KafkaSourceSpec{}, "Topics", "BootstrapServers")
-		if diff, err := kmp.ShortDiff(original.Spec, r.Spec, ignoreArgs); err != nil {
-			return &apis.FieldError{
-				Message: "Failed to diff KafkaSource",
-				Paths:   []string{"spec"},
-				Details: err.Error(),
-			}
-		} else if diff != "" {
-			return &apis.FieldError{
-				Message: "Immutable fields changed (-old +new)",
-				Paths:   []string{"spec"},
-				Details: diff,
-			}
+		errs = errs.Also(ks.CheckImmutableFields(ctx, original))
+	}
+	return errs
+}
+
+func (kss *KafkaSourceSpec) Validate(ctx context.Context) *apis.FieldError {
+	var errs *apis.FieldError
+
+	// Validate sink
+	errs = errs.Also(kss.Sink.Validate(ctx).ViaField("sink"))
+
+	// We want to ensure we have a bootstrapServer & Topics for creation
+	if apis.IsInCreate(ctx) {
+		if len(kss.Topics) <= 0 {
+			errs = errs.Also(apis.ErrMissingField("Topics"))
+		}
+		if len(kss.BootstrapServers) <= 0 {
+			errs = errs.Also(apis.ErrMissingField("bootstrapServer"))
 		}
 	}
 
-	return nil
+	return errs
+}
+
+func (ks *KafkaSource) CheckImmutableFields(ctx context.Context, original *KafkaSource) *apis.FieldError {
+	if original == nil {
+		return nil
+	}
+	var errs *apis.FieldError
+
+	// Ignore diffs in bootstrapServers and topics
+	ignoreArgs := cmpopts.IgnoreFields(KafkaSourceSpec{}, "Topics", "BootstrapServers", "Sink")
+	if diff, err := kmp.ShortDiff(original.Spec, ks.Spec, ignoreArgs); err != nil {
+		errs = errs.Also(&apis.FieldError{
+			Message: "Failed to diff KafkaSource",
+			Paths:   []string{"spec"},
+			Details: err.Error(),
+		})
+		return errs
+	} else if diff != "" {
+		errs = errs.Also(
+			&apis.FieldError{
+				Message: "Immutable fields changed (-old +new)",
+				Paths:   []string{"spec"},
+				Details: diff,
+			})
+		return errs
+	}
+
+	return errs
 }

--- a/pkg/apis/sources/v1beta1/kafka_validation_test.go
+++ b/pkg/apis/sources/v1beta1/kafka_validation_test.go
@@ -29,6 +29,14 @@ var (
 	fullSpec = KafkaSourceSpec{
 		KafkaAuthSpec: bindingsv1beta1.KafkaAuthSpec{
 			BootstrapServers: []string{"servers"},
+			Net: bindingsv1beta1.KafkaNetSpec{
+				SASL: bindingsv1beta1.KafkaSASLSpec{
+					Enable: false,
+				},
+				TLS: bindingsv1beta1.KafkaTLSSpec{
+					Enable: false,
+				},
+			},
 		},
 		Topics:        []string{"topics"},
 		ConsumerGroup: "group",
@@ -224,6 +232,45 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 		"no change": {
 			orig:    &fullSpec,
 			updated: fullSpec,
+			allowed: true,
+		},
+		"consumerGroup changed": {
+			orig: &fullSpec,
+			updated: KafkaSourceSpec{
+				ConsumerGroup: "no-way",
+			},
+			allowed: false,
+		},
+		"Kafka TLS Spec changed": {
+			orig: &fullSpec,
+			updated: KafkaSourceSpec{
+				ConsumerGroup: fullSpec.ConsumerGroup,
+				SourceSpec:    fullSpec.SourceSpec,
+				Topics:        fullSpec.Topics,
+				KafkaAuthSpec: bindingsv1beta1.KafkaAuthSpec{
+					Net: bindingsv1beta1.KafkaNetSpec{
+						TLS: bindingsv1beta1.KafkaTLSSpec{
+							Enable: true,
+						},
+					},
+				},
+			},
+			allowed: true,
+		},
+		"Kafka SASL Spec changed": {
+			orig: &fullSpec,
+			updated: KafkaSourceSpec{
+				ConsumerGroup: fullSpec.ConsumerGroup,
+				SourceSpec:    fullSpec.SourceSpec,
+				Topics:        fullSpec.Topics,
+				KafkaAuthSpec: bindingsv1beta1.KafkaAuthSpec{
+					Net: bindingsv1beta1.KafkaNetSpec{
+						SASL: bindingsv1beta1.KafkaSASLSpec{
+							Enable: true,
+						},
+					},
+				},
+			},
 			allowed: true,
 		},
 	}

--- a/test/e2e/kafka_source_test.go
+++ b/test/e2e/kafka_source_test.go
@@ -535,7 +535,7 @@ func testKafkaSourceUpdate(t *testing.T, name string, test updateTest) {
 	client.WaitForAllTestResourcesReadyOrFail(context.Background())
 
 	t.Logf("Send update event to kafkatopic")
-	helpers.MustPublishKafkaMessage(client, defaultKafkaSource.auth.bootStrapServer,
+	helpers.MustPublishKafkaMessage(client, kafkaBootstrapUrlPlain,
 		defaultKafkaSource.topicName+name,
 		originalMessage.key, originalMessage.headers, string(originalMessage.payload))
 	eventSourceName := sourcesv1beta1.KafkaEventSource(client.Namespace, kafkaSourceName, defaultKafkaSource.topicName+name)
@@ -571,7 +571,7 @@ func testKafkaSourceUpdate(t *testing.T, name string, test updateTest) {
 	client.WaitForAllTestResourcesReadyOrFail(context.Background())
 
 	t.Logf("Send update event to kafkatopic")
-	helpers.MustPublishKafkaMessage(client, test.auth.bootStrapServer,
+	helpers.MustPublishKafkaMessage(client, kafkaBootstrapUrlPlain,
 		test.topicName+name,
 		updateMessage.key, updateMessage.headers, string(updateMessage.payload))
 

--- a/test/e2e/kafka_source_test.go
+++ b/test/e2e/kafka_source_test.go
@@ -422,3 +422,163 @@ func mustJsonMarshal(t *testing.T, val interface{}) string {
 	}
 	return string(data)
 }
+
+type message struct {
+	cloudEventType string
+	payload        []byte
+	headers        map[string]string
+	key            string
+}
+
+type updateTest struct {
+	auth      authSetup
+	topicName string
+	sinkName  string
+}
+
+var (
+	defaultKafkaSource = updateTest{
+		auth: authSetup{
+			bootStrapServer: kafkaBootstrapUrlTLS,
+			SASLEnabled:     false,
+			TLSEnabled:      true,
+		},
+		topicName: "initial-topic",
+		sinkName:  "default-event-recorder",
+	}
+)
+
+func TestKafkaSourceUpdate(t *testing.T) {
+
+	testCases := map[string]updateTest{
+		"no-change": defaultKafkaSource,
+		"change-sink": {
+			auth:      defaultKafkaSource.auth,
+			topicName: defaultKafkaSource.topicName,
+			sinkName:  "update-event-recorder",
+		},
+		"change-topic": {
+			auth:      defaultKafkaSource.auth,
+			topicName: "update-topic",
+			sinkName:  defaultKafkaSource.sinkName,
+		},
+		"change-bootstrap-server": {
+			auth: authSetup{
+				bootStrapServer: kafkaBootstrapUrlPlain,
+				TLSEnabled:      false,
+				SASLEnabled:     false,
+			},
+			topicName: defaultKafkaSource.topicName,
+			sinkName:  defaultKafkaSource.sinkName,
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			testKafkaSourceUpdate(t, name, test)
+		})
+	}
+}
+
+func testKafkaSourceUpdate(t *testing.T, name string, test updateTest) {
+
+	messagePayload := []byte(`{"value":5}`)
+	matcherGen := func(cloudEventsSourceName, originalOrUpdate string) EventMatcher {
+		return AllOf(
+			HasSource(cloudEventsSourceName),
+			HasData(messagePayload),
+			HasExtension("kafkaheaderceoriginalorupdate", originalOrUpdate))
+	}
+
+	originalMessage := message{
+		payload: messagePayload,
+		headers: map[string]string{
+			"ce_originalorupdate": "original",
+		},
+		key: "0",
+	}
+	updateMessage := message{
+		payload: messagePayload,
+		headers: map[string]string{
+			"ce_originalorupdate": "update",
+		},
+		key: "0",
+	}
+
+	client := testlib.Setup(t, true)
+	defer testlib.TearDown(client)
+
+	t.Logf("Creating topic: %s\n", defaultKafkaSource.topicName+name)
+	helpers.MustCreateTopic(client, kafkaClusterName, kafkaClusterNamespace, defaultKafkaSource.topicName+name)
+
+	t.Logf("Copying secrets: %s\n", defaultKafkaSource.topicName+name)
+	_, err := utils.CopySecret(client.Kube.CoreV1(), "knative-eventing", kafkaTLSSecret, client.Namespace, "default")
+	if err != nil {
+		t.Fatalf("could not copy secret(%s): %v", kafkaTLSSecret, err)
+	}
+
+	t.Logf("Creating default eventrecorder pod: %s\n", defaultKafkaSource.sinkName)
+	originalEventTracker, _ := recordevents.StartEventRecordOrFail(context.Background(), client, defaultKafkaSource.sinkName)
+	client.WaitForAllTestResourcesReadyOrFail(context.Background())
+
+	kafkaSourceName := "e2e-kafka-source-" + name
+
+	t.Logf("Creating kafkasource: %s\n", kafkaSourceName)
+	contribtestlib.CreateKafkaSourceV1Beta1OrFail(client, contribresources.KafkaSourceV1Beta1(
+		defaultKafkaSource.auth.bootStrapServer,
+		defaultKafkaSource.topicName+name,
+		resources.ServiceRef(defaultKafkaSource.sinkName),
+		contribresources.WithNameV1Beta1(kafkaSourceName),
+		withAuthEnablementV1Beta1(defaultKafkaSource.auth),
+	))
+	client.WaitForAllTestResourcesReadyOrFail(context.Background())
+
+	t.Logf("Send update event to kafkatopic")
+	helpers.MustPublishKafkaMessage(client, defaultKafkaSource.auth.bootStrapServer,
+		defaultKafkaSource.topicName+name,
+		originalMessage.key, originalMessage.headers, string(originalMessage.payload))
+	eventSourceName := sourcesv1beta1.KafkaEventSource(client.Namespace, kafkaSourceName, defaultKafkaSource.topicName+name)
+	originalEventTracker.AssertExact(1, recordevents.MatchEvent(matcherGen(eventSourceName, "original")))
+	t.Logf("Properly received original event for %s\n", eventSourceName)
+
+	var (
+		ksObj               *sourcesv1beta1.KafkaSource
+		newSinkEventTracker *recordevents.EventInfoStore
+	)
+	ksObj = contribtestlib.GetKafkaSourceV1Beta1OrFail(client, kafkaSourceName)
+	if ksObj == nil {
+		t.Fatalf("Unabled to Get kafkasource: %s/%s\n", client.Namespace, kafkaSourceName)
+	}
+	if test.topicName != defaultKafkaSource.topicName {
+		helpers.MustCreateTopic(client, kafkaClusterName, kafkaClusterNamespace, test.topicName+name)
+		ksObj.Spec.Topics = []string{test.topicName + name}
+		eventSourceName = sourcesv1beta1.KafkaEventSource(client.Namespace, kafkaSourceName, test.topicName+name)
+	}
+	if test.sinkName != defaultKafkaSource.sinkName {
+		kSinkRef := resources.ServiceKRef(test.sinkName)
+		ksObj.Spec.Sink.Ref = kSinkRef
+
+		newSinkEventTracker, _ = recordevents.StartEventRecordOrFail(context.Background(), client, test.sinkName)
+	}
+	if test.auth.bootStrapServer != defaultKafkaSource.auth.bootStrapServer {
+		ksObj.Spec.KafkaAuthSpec.BootstrapServers = []string{test.auth.bootStrapServer}
+		ksObj.Spec.KafkaAuthSpec.Net.TLS.Enable = test.auth.TLSEnabled
+		ksObj.Spec.KafkaAuthSpec.Net.SASL.Enable = test.auth.SASLEnabled
+	}
+
+	contribtestlib.UpdateKafkaSourceV1Beta1OrFail(client, ksObj)
+	client.WaitForAllTestResourcesReadyOrFail(context.Background())
+
+	t.Logf("Send update event to kafkatopic")
+	helpers.MustPublishKafkaMessage(client, test.auth.bootStrapServer,
+		test.topicName+name,
+		updateMessage.key, updateMessage.headers, string(updateMessage.payload))
+
+	if test.sinkName != defaultKafkaSource.sinkName {
+		newSinkEventTracker.AssertExact(1, recordevents.MatchEvent(matcherGen(eventSourceName, "update")))
+	} else {
+		originalEventTracker.AssertExact(1, recordevents.MatchEvent(matcherGen(eventSourceName, "update")))
+	}
+
+}

--- a/test/lib/creation.go
+++ b/test/lib/creation.go
@@ -58,6 +58,33 @@ func CreateKafkaSourceV1Beta1OrFail(c *testlib.Client, kafkaSource *sourcesv1bet
 	}
 }
 
+func GetKafkaSourceV1Beta1OrFail(c *testlib.Client, kafkaSource string) *sourcesv1beta1.KafkaSource {
+	kafkaSourceClientSet, err := kafkaclientset.NewForConfig(c.Config)
+	if err != nil {
+		c.T.Fatalf("Failed to create v1beta1 KafkaSource client: %v", err)
+	}
+
+	kSources := kafkaSourceClientSet.SourcesV1beta1().KafkaSources(c.Namespace)
+	if ksObj, err := kSources.Get(context.Background(), kafkaSource, metav1.GetOptions{}); err != nil {
+		c.T.Fatalf("Failed to get v1beta1 KafkaSource %q: %v", kafkaSource, err)
+	} else {
+		return ksObj
+	}
+	return nil
+}
+
+func UpdateKafkaSourceV1Beta1OrFail(c *testlib.Client, kafkaSource *sourcesv1beta1.KafkaSource) {
+	kafkaSourceClientSet, err := kafkaclientset.NewForConfig(c.Config)
+	if err != nil {
+		c.T.Fatalf("Failed to create v1beta1 KafkaSource client: %v", err)
+	}
+
+	kSources := kafkaSourceClientSet.SourcesV1beta1().KafkaSources(c.Namespace)
+	if _, err := kSources.Update(context.Background(), kafkaSource, metav1.UpdateOptions{}); err != nil {
+		c.T.Fatalf("Failed to update v1beta1 KafkaSource %q: %v", kafkaSource.Name, err)
+	}
+}
+
 func CreateKafkaBindingV1Alpha1OrFail(c *testlib.Client, kafkaBinding *bindingsv1alpha1.KafkaBinding) {
 	kafkaBindingClientSet, err := kafkaclientset.NewForConfig(c.Config)
 	if err != nil {


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- 🧽 Update or clean up current behavior


**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The kafkasource now allows for mutable fields for:
- Topics 
- BootstrapServers 
- Sink
- Net
- CloudEventOverrides
Previously, after creation, all fields were immutable.
```
