### PR TITLE
Get rid of maybeAppendVar func

### DIFF
--- a/pkg/source/reconciler/source/config_watcher.go
+++ b/pkg/source/reconciler/source/config_watcher.go
@@ -50,18 +50,11 @@ type KafkaSourceConfigAccessor interface {
 func (cw *KafkaSourceConfigWatcher) ToEnvVars() []corev1.EnvVar {
 	envs := cw.ConfigWatcher.ToEnvVars()
 
-	envs = maybeAppendEnvVar(envs, cw.kafkaConfigEnvVar(), cw.KafkaConfig() != nil)
-
-	return envs
-}
-
-// maybeAppendEnvVar appends an EnvVar only if the condition boolean is true.
-func maybeAppendEnvVar(envs []corev1.EnvVar, env corev1.EnvVar, cond bool) []corev1.EnvVar {
-	if !cond {
-		return envs
+	if cw.KafkaConfig() != nil {
+		envs = append(envs, cw.kafkaConfigEnvVar())
 	}
 
-	return append(envs, env)
+	return envs
 }
 
 // KafkaConfig returns the logging configuration from the ConfigWatcher.


### PR DESCRIPTION
Address the comment by @eric-sap in https://github.com/knative-sandbox/eventing-kafka/pull/337#discussion_r573926042

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Just get rid of maybeAppendVar func as it is too complex for a simple thing
- Didn't want to make the same function in knative/eventing public

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
