### PR TITLE
Consolidated channel watch config kafka

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/consumer_group_watcher.go
+++ b/pkg/channel/consolidated/reconciler/controller/consumer_group_watcher.go
@@ -145,7 +145,9 @@ func (w *WatcherImpl) Terminate() {
 
 	w.watchers = nil
 	w.cachedConsumerGroups = nil
-	w.done <- struct{}{}
+	if w.done != nil {
+		w.done <- struct{}{}
+	}
 }
 
 // TODO explore returning a channel instead of a taking callback

--- a/pkg/channel/consolidated/reconciler/controller/controller.go
+++ b/pkg/channel/consolidated/reconciler/controller/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/kelseyhightower/envconfig"
+	"knative.dev/eventing-kafka/pkg/common/constants"
 
 	"go.uber.org/zap"
 
@@ -87,12 +88,12 @@ func NewController(
 	impl := kafkaChannelReconciler.NewImpl(ctx, r)
 
 	// Get and Watch the Kakfa config map and dynamically update Kafka configuration.
-	if _, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(ctx, "config-kafka", metav1.GetOptions{}); err == nil {
-		cmw.Watch("config-kafka", func(configMap *v1.ConfigMap) {
+	if _, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(ctx, constants.SettingsConfigMapName, metav1.GetOptions{}); err == nil {
+		cmw.Watch(constants.SettingsConfigMapName, func(configMap *v1.ConfigMap) {
 			r.updateKafkaConfig(ctx, configMap)
 		})
 	} else if !apierrors.IsNotFound(err) {
-		logging.FromContext(ctx).With(zap.Error(err)).Fatal("Error reading ConfigMap 'config-kafka'")
+		logging.FromContext(ctx).With(zap.Error(err)).Fatalf("Error reading ConfigMap '%s'", constants.SettingsConfigMapName)
 	}
 
 	logging.FromContext(ctx).Info("Setting up event handlers")

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -25,6 +25,7 @@ import (
 
 	"knative.dev/eventing-kafka/pkg/channel/consolidated/kafka"
 	"knative.dev/eventing-kafka/pkg/common/client"
+	"knative.dev/eventing-kafka/pkg/common/constants"
 
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
@@ -158,7 +159,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 
 	if r.kafkaConfig == nil {
 		if r.kafkaConfigError == nil {
-			r.kafkaConfigError = errors.New("The config map 'config-kafka' does not exist")
+			r.kafkaConfigError = errors.New(fmt.Sprintf("The config map '%s' does not exist", constants.SettingsConfigMapName))
 		}
 		kc.Status.MarkConfigFailed("MissingConfiguration", "%v", r.kafkaConfigError)
 		return r.kafkaConfigError

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -600,9 +600,9 @@ func (r *Reconciler) updateKafkaConfig(ctx context.Context, configMap *corev1.Co
 	}
 
 	if r.consumerGroupWatcher != nil {
-		logger.Info("Terminating consumer group watcher")
+		logger.Info("terminating consumer group watcher")
 		r.consumerGroupWatcher.Terminate()
-		logger.Info("Terminated consumer group watcher")
+		logger.Info("terminated consumer group watcher")
 	}
 
 	r.consumerGroupWatcher = NewConsumerGroupWatcher(ctx, ac, pollInterval)

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -617,6 +617,8 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, kc *v1beta1.KafkaChannel)
 			return err
 		}
 	}
-	r.consumerGroupWatcher.Forget(string(kc.ObjectMeta.UID))
+	if r.consumerGroupWatcher != nil {
+		r.consumerGroupWatcher.Forget(string(kc.ObjectMeta.UID))
+	}
 	return newReconciledNormal(kc.Namespace, kc.Name) //ok to remove finalizer
 }

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -601,7 +601,9 @@ func (r *Reconciler) updateKafkaConfig(ctx context.Context, configMap *corev1.Co
 	}
 
 	if r.consumerGroupWatcher != nil {
+		logger.Info("Terminating consumer group watcher")
 		r.consumerGroupWatcher.Terminate()
+		logger.Info("Terminated consumer group watcher")
 	}
 
 	r.consumerGroupWatcher = NewConsumerGroupWatcher(ctx, ac, pollInterval)

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -159,7 +158,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 
 	if r.kafkaConfig == nil {
 		if r.kafkaConfigError == nil {
-			r.kafkaConfigError = errors.New(fmt.Sprintf("The config map '%s' does not exist", constants.SettingsConfigMapName))
+			r.kafkaConfigError = fmt.Errorf("the config map '%s' does not exist", constants.SettingsConfigMapName)
 		}
 		kc.Status.MarkConfigFailed("MissingConfiguration", "%v", r.kafkaConfigError)
 		return r.kafkaConfigError

--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing-kafka/pkg/common/constants"
 	"knative.dev/pkg/system"
 )
 
@@ -77,7 +78,7 @@ func MakeDispatcher(args DispatcherArgs) *v1.Deployment {
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "config-kafka",
-									MountPath: "/etc/config-kafka",
+									MountPath: constants.SettingsConfigMapMountPath,
 								},
 							},
 						},
@@ -88,7 +89,7 @@ func MakeDispatcher(args DispatcherArgs) *v1.Deployment {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "config-kafka",
+										Name: constants.SettingsConfigMapName,
 									},
 								},
 							},

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/eventing-kafka/pkg/common/constants"
 
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/pkg/channel/fanout"
@@ -76,7 +77,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		logger.Fatalw("unable to setup tracing", zap.Error(err))
 	}
 
-	configMap, err := configmap.Load("/etc/config-kafka")
+	configMap, err := configmap.Load(constants.SettingsConfigMapMountPath)
 	if err != nil {
 		logger.Fatalw("error loading configuration", zap.Error(err))
 	}

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -26,7 +26,7 @@ const (
 	SettingsConfigMapName = "config-kafka"
 
 	// Mount path of the configmap used to hold eventing-kafka settings
-	SettingsConfigMapMountPath = "/etc/config-kafka"
+	SettingsConfigMapMountPath = "/etc/" + SettingsConfigMapName
 
 	// Config key of the config in the configmap used to hold eventing-kafka settings
 	EventingKafkaSettingsConfigKey = "eventing-kafka"

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -23,8 +23,14 @@ const (
 	DefaultReplicationFactor = 1
 
 	// The name of the configmap used to hold eventing-kafka settings
-	SettingsConfigMapName          = "config-kafka"
+	SettingsConfigMapName = "config-kafka"
+
+	// Mount path of the configmap used to hold eventing-kafka settings
+	SettingsConfigMapMountPath = "/etc/config-kafka"
+
+	// Config key of the config in the configmap used to hold eventing-kafka settings
 	EventingKafkaSettingsConfigKey = "eventing-kafka"
+
 	// The name of the keys in the Data section of the eventing-kafka configmap that holds Sarama and Eventing-Kafka configuration YAML
 	SaramaSettingsConfigKey = "sarama"
 )


### PR DESCRIPTION
Fixes #393

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Replace hardcoded `config-kafka` string with proper constant
- Fix a panic: null check `consumerGroupWatcher`
- Fix a block: `consumerGroupWatcher.terminate()` doesn't block forever anymore

Please review commit by commit.
<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
