### PR TITLE
[mtsource] Enable stopping underlying st adapters when source is modified/removed.

### DIFF
--- a/pkg/common/scheduler/statefulset/autoscaler.go
+++ b/pkg/common/scheduler/statefulset/autoscaler.go
@@ -75,12 +75,14 @@ func (s *StatefulSetScheduler) autoscale(ctx context.Context) {
 				// Desired ratio is 0.5 (TODO: configurable)
 				new := int32(math.Ceil(float64(s.usedCapacity(snapshot)+s.pendingVReplicas()) / (float64(s.capacity) * 0.5)))
 
-				// Make sure not to scale down past the last pod with placed vpods
-				if new < snapshot.lastOrdinal+1 {
-					new = snapshot.lastOrdinal + 1
-				}
+				//// Make sure not to scale down past the last pod with placed vpods
+				//if new < snapshot.lastOrdinal+1 {
+				//	new = snapshot.lastOrdinal + 1
+				//}
+				// Disable scaling down until we have a better story with finalizers
+				// See https://github.com/knative-sandbox/eventing-kafka/issues/412
 
-				if new != scale.Spec.Replicas {
+				if new > scale.Spec.Replicas {
 					scale.Spec.Replicas = new
 					s.logger.Infow("updating adapter replicas", zap.Int32("replicas", scale.Spec.Replicas))
 

--- a/test/e2e/kafka_source_test.go
+++ b/test/e2e/kafka_source_test.go
@@ -23,8 +23,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	. "github.com/cloudevents/sdk-go/v2/test"
@@ -62,6 +64,10 @@ type authSetup struct {
 	SASLEnabled     bool
 	TLSEnabled      bool
 }
+
+var (
+	test_mt_source = os.Getenv("TEST_MT_SOURCE")
+)
 
 func withAuthEnablementV1Beta1(auth authSetup) contribresources.KafkaSourceV1Beta1Option {
 	// We test with sasl512 and enable tls with it, so check tls first
@@ -243,6 +249,11 @@ func testKafkaSource(t *testing.T, name string, version string, messageKey strin
 	}
 
 	client.WaitForAllTestResourcesReadyOrFail(context.Background())
+
+	// See https://github.com/knative-sandbox/eventing-kafka/issues/411
+	if test_mt_source == "1" {
+		time.Sleep(20 * time.Second)
+	}
 
 	helpers.MustPublishKafkaMessage(client, kafkaBootstrapUrlPlain, kafkaTopicName, messageKey, messageHeaders, messagePayload)
 
@@ -534,6 +545,11 @@ func testKafkaSourceUpdate(t *testing.T, name string, test updateTest) {
 	))
 	client.WaitForAllTestResourcesReadyOrFail(context.Background())
 
+	// See https://github.com/knative-sandbox/eventing-kafka/issues/411
+	if test_mt_source == "1" {
+		time.Sleep(20 * time.Second)
+	}
+
 	t.Logf("Send update event to kafkatopic")
 	helpers.MustPublishKafkaMessage(client, kafkaBootstrapUrlPlain,
 		defaultKafkaSource.topicName+name,
@@ -569,6 +585,11 @@ func testKafkaSourceUpdate(t *testing.T, name string, test updateTest) {
 
 	contribtestlib.UpdateKafkaSourceV1Beta1OrFail(client, ksObj)
 	client.WaitForAllTestResourcesReadyOrFail(context.Background())
+
+	// See https://github.com/knative-sandbox/eventing-kafka/issues/411
+	if test_mt_source == "1" {
+		time.Sleep(20 * time.Second)
+	}
 
 	t.Logf("Send update event to kafkatopic")
 	helpers.MustPublishKafkaMessage(client, kafkaBootstrapUrlPlain,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
The e2e source tests are now passing when run on top of the mt source adapter. 
I opened several GH issues to track the various features that are missing/disabled to make this happened. 

## Proposed Changes

- Single-tenant adapters are now properly shut down by the multi-tenant adapter
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
