### PR TITLE
Refactor distributed component mains to handle Kubernetes config better

### DIFF
--- a/pkg/channel/distributed/common/k8s/context.go
+++ b/pkg/channel/distributed/common/k8s/context.go
@@ -24,26 +24,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	k8sclientcmd "k8s.io/client-go/tools/clientcmd"
-	injectionclient "knative.dev/pkg/client/injection/kube/client"
 	configmap "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 )
-
-// K8sClientWrapper Used To Facilitate Unit Testing
-var K8sClientWrapper = func(serverUrl string, kubeconfigPath string) kubernetes.Interface {
-
-	// Create The K8S Configuration (In-Cluster By Default / Cmd Line Flags For Out-Of-Cluster Usage)
-	k8sConfig, err := k8sclientcmd.BuildConfigFromFlags(serverUrl, kubeconfigPath)
-	if err != nil {
-		log.Fatalf("Failed To Build Kubernetes Config: %v", err)
-	}
-
-	// Create A New Kubernetes Client From The K8S Configuration
-	return kubernetes.NewForConfigOrDie(k8sConfig)
-}
 
 //
 // Initialize The Specified Context With A K8S Client & Logger (ConfigMap Watcher)
@@ -54,14 +39,7 @@ var K8sClientWrapper = func(serverUrl string, kubeconfigPath string) kubernetes.
 //        knative-eventing logging configuration and dynamic updating.  To that end, we are setting up a basic context ourselves
 //        that mirrors what the injection framework would have created.
 //
-func LoggingContext(ctx context.Context, component string, serverUrl string, kubeconfigPath string) context.Context {
-
-	// Get The K8S Client
-	k8sClient := K8sClientWrapper(serverUrl, kubeconfigPath)
-
-	// Put The Kubernetes Client Into The Context Where The Injection Framework Expects It
-	ctx = context.WithValue(ctx, injectionclient.Key{}, k8sClient)
-
+func LoggingContext(ctx context.Context, component string, k8sClient kubernetes.Interface) context.Context {
 	// Get The Logging Config From Knative SharedMain
 	loggingConfig, err := sharedmain.GetLoggingConfig(ctx)
 	if err != nil {

--- a/pkg/channel/distributed/common/k8s/context_test.go
+++ b/pkg/channel/distributed/common/k8s/context_test.go
@@ -21,13 +21,11 @@ import (
 	"testing"
 	"time"
 
-	commontesting "knative.dev/eventing-kafka/pkg/channel/distributed/common/testing"
-
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	commontesting "knative.dev/eventing-kafka/pkg/channel/distributed/common/testing"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
@@ -58,17 +56,10 @@ func TestLoggingContext(t *testing.T) {
 	// Create The Fake K8S Client
 	fakeK8sClient := fake.NewSimpleClientset(loggingConfigMap)
 
-	// Temporarily Swap The K8S Client Wrapper For Testing
-	k8sClientWrapperRef := K8sClientWrapper
-	K8sClientWrapper = func(serverUrlArg string, kubeconfigPathArg string) kubernetes.Interface {
-		assert.Empty(t, serverUrlArg)
-		assert.Empty(t, kubeconfigPathArg)
-		return fakeK8sClient
-	}
-	defer func() { K8sClientWrapper = k8sClientWrapperRef }()
+	ctx = context.WithValue(ctx, kubeclient.Key{}, fakeK8sClient)
 
 	// Perform The Test (Initialize The Logging Context)
-	resultContext := LoggingContext(ctx, component, "", "")
+	resultContext := LoggingContext(ctx, component, fakeK8sClient)
 
 	// Verify The Results
 	assert.NotNil(t, resultContext)

--- a/pkg/channel/distributed/receiver/channel/channel.go
+++ b/pkg/channel/distributed/receiver/channel/channel.go
@@ -23,7 +23,6 @@ import (
 
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	k8sclientcmd "k8s.io/client-go/tools/clientcmd"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/receiver/health"
 	kafkaclientset "knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 	kafkainformers "knative.dev/eventing-kafka/pkg/client/informers/externalversions"
@@ -39,32 +38,10 @@ var (
 	stopChan           chan struct{}
 )
 
-// Wrapper Around Kafka Client Creation To Facilitate Unit Testing
-var getKafkaClient = func(ctx context.Context, serverUrl string, kubeconfigPath string) (kafkaclientset.Interface, error) {
-
-	// Create The K8S Configuration (In-Cluster With Cmd Line Flags For Out-Of-Cluster Usage)
-	k8sConfig, err := k8sclientcmd.BuildConfigFromFlags(serverUrl, kubeconfigPath)
-	if err != nil {
-		logging.FromContext(ctx).Error("Failed To Build Kubernetes Config", zap.Error(err))
-		return nil, err
-	}
-
-	// Create A New Kafka Client From The K8S Config & Return The Result
-	return kafkaclientset.NewForConfigOrDie(k8sConfig), nil
-}
-
 // Initialize The KafkaChannel Lister Singleton
-func InitializeKafkaChannelLister(ctx context.Context, serverUrl string, kubeconfigPath string, healthServer *health.Server, resyncDuration time.Duration) error {
-
+func InitializeKafkaChannelLister(ctx context.Context, client kafkaclientset.Interface, healthServer *health.Server, resyncDuration time.Duration) error {
 	// Get The Logger From The Provided Context
 	logger = logging.FromContext(ctx).Desugar()
-
-	// Get The K8S Kafka Client For KafkaChannels
-	client, err := getKafkaClient(ctx, serverUrl, kubeconfigPath)
-	if err != nil {
-		logger.Error("Failed To Create Kafka Client", zap.Error(err))
-		return err
-	}
 
 	// Create A New KafkaChannel SharedInformerFactory For ALL Namespaces (Default Resync Is 10 Hrs)
 	sharedInformerFactory := kafkainformers.NewSharedInformerFactory(client, resyncDuration)

--- a/pkg/channel/distributed/receiver/channel/channel_test.go
+++ b/pkg/channel/distributed/receiver/channel/channel_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	channelhealth "knative.dev/eventing-kafka/pkg/channel/distributed/receiver/health"
 	receivertesting "knative.dev/eventing-kafka/pkg/channel/distributed/receiver/testing"
-	kafkaclientset "knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 	fakeclientset "knative.dev/eventing-kafka/pkg/client/clientset/versioned/fake"
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -33,18 +32,14 @@ import (
 
 // Test The InitializeKafkaChannelLister() Functionality
 func TestInitializeKafkaChannelLister(t *testing.T) {
-
-	// Stub The K8S Client Creation Wrapper With Test Version Returning The Fake KafkaClient Clientset
-	getKafkaClient = func(ctx context.Context, serverUrl string, kubeconfigPath string) (kafkaclientset.Interface, error) {
-		return fakeclientset.NewSimpleClientset(), nil
-	}
-
 	// Create A Context With Test Logger
 	ctx := logging.WithLogger(context.TODO(), logtesting.TestLogger(t))
 
+	kafkaClient := fakeclientset.NewSimpleClientset()
+
 	// Perform The Test
 	healthServer := channelhealth.NewChannelHealthServer("12345")
-	err := InitializeKafkaChannelLister(ctx, "", "", healthServer, 600*time.Minute)
+	err := InitializeKafkaChannelLister(ctx, kafkaClient, healthServer, 600*time.Minute)
 
 	// Verify The Results
 	assert.Nil(t, err)


### PR DESCRIPTION
Refactoring distributed component `main`s to make them use more of the functionality in sharedmain.

I wasn't able to [debug](https://github.com/knative/eventing/blob/master/DEVELOPMENT.md#debugging-knative-controllers-and-friends-locally-with-intellij-idea) the receiver and dispatcher locally because they required me to provide additional stuff like Kube URL etc. Once I provided these, this time the debugging failed because of missing service account token.

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use `ParseAndGetRESTConfigOrDie` of `knative/pkg` which handles in-cluster or out-of-cluster situations better than `BuildConfigFromFlags` of the same package
- Change above also made these `main`s more similar to other Knative controllers with injection (more effort needed in this area)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
