### PR TITLE
[mtsource] remove finalizer in mtadapter

### DIFF
--- a/pkg/common/scheduler/statefulset/autoscaler.go
+++ b/pkg/common/scheduler/statefulset/autoscaler.go
@@ -76,11 +76,11 @@ func (s *StatefulSetScheduler) autoscale(ctx context.Context) {
 				new := int32(math.Ceil(float64(s.usedCapacity(snapshot)+s.pendingVReplicas()) / (float64(s.capacity) * 0.5)))
 
 				// Make sure not to scale down past the last pod with placed vpods
-				//if new < snapshot.lastOrdinal+1 {
-				//	new = snapshot.lastOrdinal + 1
-				//}
+				if new < snapshot.lastOrdinal+1 {
+					new = snapshot.lastOrdinal + 1
+				}
 
-				if new > scale.Spec.Replicas {
+				if new != scale.Spec.Replicas {
 					scale.Spec.Replicas = new
 					s.logger.Infow("updating adapter replicas", zap.Int32("replicas", scale.Spec.Replicas))
 

--- a/pkg/common/scheduler/statefulset/autoscaler.go
+++ b/pkg/common/scheduler/statefulset/autoscaler.go
@@ -75,12 +75,10 @@ func (s *StatefulSetScheduler) autoscale(ctx context.Context) {
 				// Desired ratio is 0.5 (TODO: configurable)
 				new := int32(math.Ceil(float64(s.usedCapacity(snapshot)+s.pendingVReplicas()) / (float64(s.capacity) * 0.5)))
 
-				//// Make sure not to scale down past the last pod with placed vpods
+				// Make sure not to scale down past the last pod with placed vpods
 				//if new < snapshot.lastOrdinal+1 {
 				//	new = snapshot.lastOrdinal + 1
 				//}
-				// Disable scaling down until we have a better story with finalizers
-				// See https://github.com/knative-sandbox/eventing-kafka/issues/412
 
 				if new > scale.Spec.Replicas {
 					scale.Spec.Replicas = new

--- a/pkg/source/mtadapter/adapter.go
+++ b/pkg/source/mtadapter/adapter.go
@@ -171,7 +171,7 @@ func (a *Adapter) Update(ctx context.Context, obj *v1beta1.KafkaSource) {
 	a.logger.Infow("source added", "name", obj.Name)
 }
 
-func (a *Adapter) Remove(ctx context.Context, obj *v1beta1.KafkaSource) {
+func (a *Adapter) Remove(obj *v1beta1.KafkaSource) {
 	a.sourcesMu.Lock()
 	defer a.sourcesMu.Unlock()
 	a.logger.Infow("removing source", "name", obj.Name)

--- a/pkg/source/mtadapter/adapter_test.go
+++ b/pkg/source/mtadapter/adapter_test.go
@@ -90,7 +90,7 @@ func TestUpdateRemoveSources(t *testing.T) {
 		t.Error("sub-adapter failed to start after 100 ms")
 	}
 
-	adapter.Remove(ctx, &sourcesv1beta1.KafkaSource{
+	adapter.Remove(&sourcesv1beta1.KafkaSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-name",
 			Namespace: "test-ns",


### PR DESCRIPTION
Similar to https://github.com/knative/eventing/pull/4511

Fixes https://github.com/knative-sandbox/eventing-kafka/issues/412

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- The mt source adapter doesn't set any finalizers anymore, since updating the internal state never fails.
- Reenable scaling down
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 The mt source adapter does not set the finalizers anymore
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
