### PR TITLE
Add more approvers as default owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,6 @@
 # Default owners are TOC, release leads and Eventing writers
-* @knative-sandbox/technical-oversight-committee
-* @knative-sandbox/knative-release-leads
-* @knative-sandbox/eventing-writers
-* @knative-sandbox/eventing-kafka-approvers
+* @knative-sandbox/eventing-kafka-approvers @knative-sandbox/eventing-writers @knative-sandbox/knative-release-leads @knative-sandbox/technical-oversight-committee
 
 # hack and test are owned by productivity
-/hack/* @knative-sandbox/productivity-wg-leads
-/test/* @knative-sandbox/productivity-wg-leads
+/hack/* @knative-sandbox/productivity-wg-leads @knative-sandbox/eventing-kafka-approvers @knative-sandbox/eventing-writers @knative-sandbox/knative-release-leads @knative-sandbox/technical-oversight-committee
+/test/* @knative-sandbox/productivity-wg-leads @knative-sandbox/eventing-kafka-approvers @knative-sandbox/eventing-writers @knative-sandbox/knative-release-leads @knative-sandbox/technical-oversight-committee


### PR DESCRIPTION
Add TOC, eventing approvers and release leads as default owners.

See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax