### PR TITLE
Use Oldest offset as the initial one when creating the consumer group

### DIFF
--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -141,7 +141,11 @@ func (d *KafkaDispatcher) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request
 }
 
 func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispatcher, error) {
+	confTemplate := sarama.NewConfig()
+	confTemplate.Consumer.Offsets.Initial = sarama.OffsetOldest
+
 	conf, err := client.NewConfigBuilder().
+		WithExisting(confTemplate).
 		WithClientId(args.ClientID).
 		WithDefaults().
 		FromYaml(args.SaramaSettingsYamlString).


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #420

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use OffsetOldest as default, but let user change this value through the config-kafka CM

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
