### PR TITLE
Use CE connection args available, instead of hardcoded values

### DIFF
--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -157,11 +157,8 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 		return nil, fmt.Errorf("unable to create kafka producer against Kafka bootstrap servers %v : %v", args.Brokers, err)
 	}
 
-	// Configured with the same connection arguments of IMC
-	kncloudevents.ConfigureConnectionArgs(&kncloudevents.ConnectionArgs{
-		MaxIdleConns:        1000,
-		MaxIdleConnsPerHost: 100,
-	})
+	// Configure connection arguments
+	kncloudevents.ConfigureConnectionArgs(args.KnCEConnectionArgs)
 
 	dispatcher := &KafkaDispatcher{
 		dispatcher:           eventingchannels.NewMessageDispatcher(args.Logger.Desugar()),

--- a/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
@@ -65,11 +65,14 @@ func TestDispatcher(t *testing.T) {
 	})
 
 	dispatcherArgs := KafkaDispatcherArgs{
-		KnCEConnectionArgs: nil,
-		ClientID:           "testing",
-		Brokers:            []string{"localhost:9092"},
-		TopicFunc:          utils.TopicName,
-		Logger:             logger.Sugar(),
+		KnCEConnectionArgs: &kncloudevents.ConnectionArgs{
+			MaxIdleConns:        1000,
+			MaxIdleConnsPerHost: 100,
+		},
+		ClientID:  "testing",
+		Brokers:   []string{"localhost:9092"},
+		TopicFunc: utils.TopicName,
+		Logger:    logger.Sugar(),
 	}
 
 	// Create the dispatcher. At this point, if Kafka is not up, this thing fails


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use CE connection args available, instead of hardcoded values
- These values default to `DefaultMaxIdleConns` and `DefaultMaxIdleConnsPerHost` constants in `util.go`
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
