### PR TITLE
[source] spec.consumers is now mutable

### DIFF
--- a/pkg/apis/sources/v1beta1/kafka_validation_test.go
+++ b/pkg/apis/sources/v1beta1/kafka_validation_test.go
@@ -123,6 +123,7 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 		"Topic changed": {
 			orig: &fullSpec,
 			updated: KafkaSourceSpec{
+				KafkaAuthSpec: fullSpec.KafkaAuthSpec,
 				Topics:        []string{"some-other-topic"},
 				ConsumerGroup: fullSpec.ConsumerGroup,
 				SourceSpec:    fullSpec.SourceSpec,
@@ -134,7 +135,9 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 			updated: KafkaSourceSpec{
 				KafkaAuthSpec: bindingsv1beta1.KafkaAuthSpec{
 					BootstrapServers: []string{"server1,server2"},
+					Net:              fullSpec.Net,
 				},
+				Topics:        []string{"some-other-topic"},
 				ConsumerGroup: fullSpec.ConsumerGroup,
 				SourceSpec:    fullSpec.SourceSpec,
 			},
@@ -143,6 +146,7 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 		"Sink.APIVersion changed": {
 			orig: &fullSpec,
 			updated: KafkaSourceSpec{
+				KafkaAuthSpec: fullSpec.KafkaAuthSpec,
 				Topics:        fullSpec.Topics,
 				ConsumerGroup: fullSpec.ConsumerGroup,
 				SourceSpec: duckv1.SourceSpec{
@@ -161,6 +165,7 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 		"Sink.Kind changed": {
 			orig: &fullSpec,
 			updated: KafkaSourceSpec{
+				KafkaAuthSpec: fullSpec.KafkaAuthSpec,
 				Topics:        fullSpec.Topics,
 				ConsumerGroup: fullSpec.ConsumerGroup,
 				SourceSpec: duckv1.SourceSpec{
@@ -179,6 +184,8 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 		"Sink.Namespace changed": {
 			orig: &fullSpec,
 			updated: KafkaSourceSpec{
+
+				KafkaAuthSpec: fullSpec.KafkaAuthSpec,
 				Topics:        fullSpec.Topics,
 				ConsumerGroup: fullSpec.ConsumerGroup,
 				SourceSpec: duckv1.SourceSpec{
@@ -197,6 +204,8 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 		"Sink.Name changed": {
 			orig: &fullSpec,
 			updated: KafkaSourceSpec{
+
+				KafkaAuthSpec: fullSpec.KafkaAuthSpec,
 				Topics:        fullSpec.Topics,
 				ConsumerGroup: fullSpec.ConsumerGroup,
 				SourceSpec: duckv1.SourceSpec{
@@ -212,23 +221,6 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 			},
 			allowed: true,
 		},
-		"ServiceAccountName changed": {
-			orig: &fullSpec,
-			updated: KafkaSourceSpec{
-				Topics: fullSpec.Topics,
-				SourceSpec: duckv1.SourceSpec{
-					Sink: duckv1.Destination{
-						Ref: &duckv1.KReference{
-							APIVersion: fullSpec.Sink.Ref.APIVersion,
-							Kind:       fullSpec.Sink.Ref.Kind,
-							Namespace:  fullSpec.Sink.Ref.Namespace,
-							Name:       "some-other-name",
-						},
-					},
-				},
-			},
-			allowed: false,
-		},
 		"no change": {
 			orig:    &fullSpec,
 			updated: fullSpec,
@@ -237,7 +229,10 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 		"consumerGroup changed": {
 			orig: &fullSpec,
 			updated: KafkaSourceSpec{
+				KafkaAuthSpec: fullSpec.KafkaAuthSpec,
+				Topics:        fullSpec.Topics,
 				ConsumerGroup: "no-way",
+				SourceSpec:    fullSpec.SourceSpec,
 			},
 			allowed: false,
 		},
@@ -248,6 +243,7 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 				SourceSpec:    fullSpec.SourceSpec,
 				Topics:        fullSpec.Topics,
 				KafkaAuthSpec: bindingsv1beta1.KafkaAuthSpec{
+					BootstrapServers: []string{"servers"},
 					Net: bindingsv1beta1.KafkaNetSpec{
 						TLS: bindingsv1beta1.KafkaTLSSpec{
 							Enable: true,
@@ -264,6 +260,7 @@ func TestKafkaSourceCheckImmutableFields(t *testing.T) {
 				SourceSpec:    fullSpec.SourceSpec,
 				Topics:        fullSpec.Topics,
 				KafkaAuthSpec: bindingsv1beta1.KafkaAuthSpec{
+					BootstrapServers: []string{"servers"},
 					Net: bindingsv1beta1.KafkaNetSpec{
 						SASL: bindingsv1beta1.KafkaSASLSpec{
 							Enable: true,


### PR DESCRIPTION
Fixes #442 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- spec.consumers is now mutable
- check for mandatory fields when updating a source
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛spec.consumers is now mutable. 
- 🐛bootstrapServers and topics fields cannot be unset anymore. 
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
