### PR TITLE
[source] Set default number of consumers

### DIFF
--- a/pkg/apis/sources/v1beta1/kafka_defaults.go
+++ b/pkg/apis/sources/v1beta1/kafka_defaults.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -28,7 +29,11 @@ const (
 
 // SetDefaults ensures KafkaSource reflects the default values.
 func (k *KafkaSource) SetDefaults(ctx context.Context) {
-	if k != nil && k.Spec.ConsumerGroup == "" {
+	if k.Spec.ConsumerGroup == "" {
 		k.Spec.ConsumerGroup = uuidPrefix + uuid.New().String()
+	}
+
+	if k.Spec.Consumers == nil {
+		k.Spec.Consumers = pointer.Int32Ptr(1)
 	}
 }


### PR DESCRIPTION
 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set the default number of consumers to 1. A default value is needed for KEDA.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛The default number of KafkaSource consumers is now set to 1. 
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
