### PR TITLE
Added post-install script to migrate KafkaChannel to v1beta1

### DIFF
--- a/config/post-install/clusterrole.yaml
+++ b/config/post-install/clusterrole.yaml
@@ -1,0 +1,46 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-kafka-eventing-post-install-job-role
+  labels:
+    eventing.knative.dev/release: devel
+rules:
+  # Storage version upgrader needs to be able to patch CRDs.
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+      - "customresourcedefinitions/status"
+    verbs:
+      - "get"
+      - "list"
+      - "update"
+      - "patch"
+      - "watch"
+  # Our own resources we care about.
+  - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "kafkachannels"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"

--- a/config/post-install/clusterrole.yaml
+++ b/config/post-install/clusterrole.yaml
@@ -17,7 +17,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-eventing-post-install-job-role
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:

--- a/config/post-install/placeholder.go
+++ b/config/post-install/placeholder.go
@@ -1,7 +1,5 @@
-// +build tools
-
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,19 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tools
-
-import (
-	_ "knative.dev/hack"
-	_ "knative.dev/pkg/hack"
-
-	// Test images from eventing
-	_ "knative.dev/eventing/test/test_images/event-sender"
-	_ "knative.dev/eventing/test/test_images/heartbeats"
-	_ "knative.dev/eventing/test/test_images/performance"
-	_ "knative.dev/eventing/test/test_images/print"
-	_ "knative.dev/eventing/test/test_images/recordevents"
-
-	// For migration
-	_ "knative.dev/pkg/apiextensions/storageversion/cmd/migrate"
-)
+// Package pre_install is a placeholder that allows us to pull in config files
+// via go mod vendor.
+package post_install

--- a/config/post-install/serviceaccount.yaml
+++ b/config/post-install/serviceaccount.yaml
@@ -18,7 +18,7 @@ metadata:
   name: knative-kafka-eventing-post-install-job
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 
 ---
 
@@ -27,7 +27,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-eventing-post-install-job-role-binding
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-eventing-post-install-job

--- a/config/post-install/serviceaccount.yaml
+++ b/config/post-install/serviceaccount.yaml
@@ -1,0 +1,38 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-kafka-eventing-post-install-job
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-kafka-eventing-post-install-job-role-binding
+  labels:
+    eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: knative-kafka-eventing-post-install-job
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-kafka-eventing-post-install-job-role
+  apiGroup: rbac.authorization.k8s.io

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -1,0 +1,45 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Adding a prefix to avoid naming conflict with previous version's post-install jobs,
+  # we cannot use `generateName` here as it's not supported by `kubectl apply -f`
+  #
+  # If `ttlSecondsAfterFinished` feature gate becomes generally available in the future,
+  # we can rely on that and keep using the same Job name.
+  name: v0.22-kafka-storage-version-migration
+  namespace: knative-eventing
+  labels:
+    app: "storage-version-migration"
+    eventing.knative.dev/release: devel
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: "storage-version-migration"
+        eventing.knative.dev/release: devel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: knative-kafka-eventing-post-install-job
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: ko://knative.dev/eventing-kafka/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+          args:
+            - "kafkachannels.messaging.knative.dev"

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -24,7 +24,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "storage-version-migration"
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -49,6 +49,15 @@ function build_release() {
     ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done
+
+  if [ -d "${YAML_REPO_ROOT}/config/post-install" ]; then
+    echo "Resolving post install manifests"
+
+    local yaml="post-install.yaml"
+    ko resolve ${KO_FLAGS} -f config/post-install/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    all_yamls+=(${yaml})
+  fi
+
   ARTIFACTS_TO_PUBLISH="${all_yamls[@]}"
 }
 

--- a/pkg/apis/messaging/v1alpha1/kafka_channel_defaults.go
+++ b/pkg/apis/messaging/v1alpha1/kafka_channel_defaults.go
@@ -33,7 +33,7 @@ func (c *KafkaChannel) SetDefaults(ctx context.Context) {
 		c.Annotations = make(map[string]string)
 	}
 	if _, ok := c.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
-		c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
+		c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
 	}
 
 	c.Spec.SetDefaults(ctx)

--- a/pkg/apis/messaging/v1alpha1/kafka_channel_defaults_test.go
+++ b/pkg/apis/messaging/v1alpha1/kafka_channel_defaults_test.go
@@ -36,7 +36,7 @@ func TestKafkaChannelDefaults(t *testing.T) {
 			initial: KafkaChannel{},
 			expected: KafkaChannel{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1beta1"},
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1alpha1"},
 				},
 				Spec: KafkaChannelSpec{
 					NumPartitions:     constants.DefaultNumPartitions,
@@ -52,7 +52,7 @@ func TestKafkaChannelDefaults(t *testing.T) {
 			},
 			expected: KafkaChannel{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1beta1"},
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1alpha1"},
 				},
 				Spec: KafkaChannelSpec{
 					NumPartitions:     constants.DefaultNumPartitions,
@@ -68,7 +68,7 @@ func TestKafkaChannelDefaults(t *testing.T) {
 			},
 			expected: KafkaChannel{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1beta1"},
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1alpha1"},
 				},
 				Spec: KafkaChannelSpec{
 					NumPartitions:     testNumPartitions,

--- a/pkg/apis/messaging/v1beta1/kafka_channel_defaults.go
+++ b/pkg/apis/messaging/v1beta1/kafka_channel_defaults.go
@@ -32,9 +32,14 @@ func (c *KafkaChannel) SetDefaults(ctx context.Context) {
 	if c.Annotations == nil {
 		c.Annotations = make(map[string]string)
 	}
-	if _, ok := c.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
-		c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
-	}
+
+	// TODO this should be wrapped in a if to avoid conversion of ducks and let some other duck controller do that?!
+	//   BUT we need this hack to properly update from v1alpha1 to v1beta1, so:
+	//   * KEEP THIS FOR THE WHOLE 0.22 LIFECYCLE
+	//   * REMOVE THIS BEFORE 0.23 RELEASE
+	//if _, ok := c.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
+	c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
+	//}
 
 	c.Spec.SetDefaults(ctx)
 }

--- a/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate/config.go
+++ b/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate/config.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// TODO - make a package that's reusable here and by sharedmain
+
+func configOrDie() *rest.Config {
+	var (
+		serverURL = flag.String("server", "",
+			"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+		kubeconfig = flag.String("kubeconfig", "",
+			"Path to a kubeconfig. Only required if out-of-cluster.")
+	)
+
+	flag.Parse()
+
+	cfg, err := getConfig(*serverURL, *kubeconfig)
+	if err != nil {
+		panic(fmt.Sprint("Error building kubeconfig:", err))
+	}
+
+	return cfg
+}
+
+// getConfig returns a rest.Config to be used for kubernetes client creation.
+// It does so in the following order:
+//   1. Use the passed kubeconfig/serverURL.
+//   2. Fallback to the KUBECONFIG environment variable.
+//   3. Fallback to in-cluster config.
+//   4. Fallback to the ~/.kube/config.
+func getConfig(serverURL, kubeconfig string) (*rest.Config, error) {
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+	}
+	// If we have an explicit indication of where the kubernetes config lives, read that.
+	if kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags(serverURL, kubeconfig)
+	}
+	// If not, try the in-cluster config.
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+	// If no in-cluster config, try the default location in the user's home directory.
+	if usr, err := user.Current(); err == nil {
+		if c, err := clientcmd.BuildConfigFromFlags("", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
+			return c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not create a valid kubeconfig")
+}

--- a/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate/main.go
+++ b/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate/main.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"go.uber.org/zap"
+	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"knative.dev/pkg/apiextensions/storageversion"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/signals"
+)
+
+func main() {
+	logger := setupLogger()
+	defer logger.Sync()
+
+	config := configOrDie()
+	grs, err := parseResources(flag.Args())
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	migrator := storageversion.NewMigrator(
+		dynamic.NewForConfigOrDie(config),
+		apixclient.NewForConfigOrDie(config),
+	)
+
+	ctx := signals.NewContext()
+
+	logger.Infof("Migrating %d group resources", len(grs))
+
+	for _, gr := range grs {
+		logger.Info("Migrating group resource ", gr)
+		if err := migrator.Migrate(ctx, gr); err != nil {
+			logger.Fatal("Failed to migrate: ", err)
+		}
+	}
+
+	logger.Info("Migration complete")
+}
+
+func parseResources(args []string) ([]schema.GroupResource, error) {
+	grs := make([]schema.GroupResource, 0, len(args))
+	for _, arg := range args {
+		gr := schema.ParseGroupResource(arg)
+		if gr.Empty() {
+			return nil, fmt.Errorf("unable to parse group version: %s", arg)
+		}
+		grs = append(grs, gr)
+	}
+	return grs, nil
+}
+
+func setupLogger() *zap.SugaredLogger {
+	const component = "storage-migrator"
+
+	config, err := logging.NewConfigFromMap(nil)
+	if err != nil {
+		log.Fatal("Failed to create logging config: ", err)
+	}
+
+	logger, _ := logging.NewLoggerFromConfig(config, component)
+	return logger
+}

--- a/vendor/knative.dev/pkg/apiextensions/storageversion/migrator.go
+++ b/vendor/knative.dev/pkg/apiextensions/storageversion/migrator.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+
+	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/pager"
+)
+
+// Migrator will read custom resource definitions and upgrade
+// the associated resources to the latest storage version
+type Migrator struct {
+	dynamicClient dynamic.Interface
+	apixClient    apixclient.Interface
+}
+
+// NewMigrator will return a new Migrator
+func NewMigrator(d dynamic.Interface, a apixclient.Interface) *Migrator {
+	return &Migrator{
+		dynamicClient: d,
+		apixClient:    a,
+	}
+}
+
+// Migrate takes a group resource (ie. resource.some.group.dev) and
+// updates instances of the resource to the latest storage version
+//
+// This is done by listing all the resources and performing an empty patch
+// which triggers a migration on the K8s API server
+//
+// Finally the migrator will update the CRD's status and drop older storage
+// versions
+func (m *Migrator) Migrate(ctx context.Context, gr schema.GroupResource) error {
+	crdClient := m.apixClient.ApiextensionsV1().CustomResourceDefinitions()
+
+	crd, err := crdClient.Get(ctx, gr.String(), metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to fetch crd %s - %w", gr, err)
+	}
+
+	version := storageVersion(crd)
+
+	if version == "" {
+		return fmt.Errorf("unable to determine storage version for %s", gr)
+	}
+
+	if err := m.migrateResources(ctx, gr.WithVersion(version)); err != nil {
+		return err
+	}
+
+	patch := `{"status":{"storedVersions":["` + version + `"]}}`
+	_, err = crdClient.Patch(ctx, crd.Name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "status")
+	if err != nil {
+		return fmt.Errorf("unable to drop storage version definition %s - %w", gr, err)
+	}
+
+	return nil
+}
+
+func (m *Migrator) migrateResources(ctx context.Context, gvr schema.GroupVersionResource) error {
+	client := m.dynamicClient.Resource(gvr)
+
+	listFunc := func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.Namespace(metav1.NamespaceAll).List(ctx, opts)
+	}
+
+	onEach := func(obj runtime.Object) error {
+		item := obj.(metav1.Object)
+
+		_, err := client.Namespace(item.GetNamespace()).
+			Patch(ctx, item.GetName(), types.MergePatchType, []byte("{}"), metav1.PatchOptions{})
+
+		if err != nil {
+			return fmt.Errorf("unable to patch resource %s/%s (gvr: %s) - %w",
+				item.GetNamespace(), item.GetName(),
+				gvr, err)
+		}
+
+		return nil
+	}
+
+	pager := pager.New(listFunc)
+	return pager.EachListItem(ctx, metav1.ListOptions{}, onEach)
+}
+
+func storageVersion(crd *apix.CustomResourceDefinition) string {
+	var version string
+
+	for _, v := range crd.Spec.Versions {
+		if v.Storage {
+			version = v.Name
+			break
+		}
+	}
+
+	return version
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1213,6 +1213,8 @@ knative.dev/eventing/test/test_images/recordevents
 knative.dev/hack
 # knative.dev/pkg v0.0.0-20210309024624-0f8d8de5949d
 ## explicit
+knative.dev/pkg/apiextensions/storageversion
+knative.dev/pkg/apiextensions/storageversion/cmd/migrate
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
 knative.dev/pkg/apis/duck/ducktypes


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Followup of #446

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🧽 Added a post-install migration job to migrate KafkaChannel to v1beta1

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🧽 Added a post-install migration job to migrate KafkaChannel to v1beta1. You must run it after installing eventing-kafka 0.22
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
