### PR TITLE
Move setting CE connection args setting one level above in consolidated dispatcher

### DIFF
--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	eventingchannels "knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
-	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/pkg/kmeta"
 
 	"knative.dev/eventing-kafka/pkg/channel/consolidated/utils"
@@ -157,9 +156,6 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 		return nil, fmt.Errorf("unable to create kafka producer against Kafka bootstrap servers %v : %v", args.Brokers, err)
 	}
 
-	// Configure connection arguments
-	kncloudevents.ConfigureConnectionArgs(args.KnCEConnectionArgs)
-
 	dispatcher := &KafkaDispatcher{
 		dispatcher:           eventingchannels.NewMessageDispatcher(args.Logger.Desugar()),
 		kafkaConsumerFactory: consumer.NewConsumerGroupFactory(args.Brokers, conf),
@@ -223,7 +219,6 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 type TopicFunc func(separator, namespace, name string) string
 
 type KafkaDispatcherArgs struct {
-	KnCEConnectionArgs       *kncloudevents.ConnectionArgs
 	ClientID                 string
 	Brokers                  []string
 	KafkaAuthConfig          *client.KafkaAuthConfig

--- a/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
@@ -64,11 +64,13 @@ func TestDispatcher(t *testing.T) {
 		ZipkinEndpoint: "http://localhost:9411/api/v2/spans",
 	})
 
+	// Configure connection arguments - to be done exactly once per process
+	kncloudevents.ConfigureConnectionArgs(&kncloudevents.ConnectionArgs{
+		MaxIdleConns:        utils.DefaultMaxIdleConns,
+		MaxIdleConnsPerHost: utils.DefaultMaxIdleConnsPerHost,
+	})
+
 	dispatcherArgs := KafkaDispatcherArgs{
-		KnCEConnectionArgs: &kncloudevents.ConnectionArgs{
-			MaxIdleConns:        1000,
-			MaxIdleConnsPerHost: 100,
-		},
 		ClientID:  "testing",
 		Brokers:   []string{"localhost:9092"},
 		TopicFunc: utils.TopicName,

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -89,14 +89,14 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	kafkaAuthCfg := utils.GetKafkaAuthData(ctx, kafkaConfig.AuthSecretName, kafkaConfig.AuthSecretNamespace)
 
-	connectionArgs := &kncloudevents.ConnectionArgs{
+	// Configure connection arguments - to be done exactly once per process
+	kncloudevents.ConfigureConnectionArgs(&kncloudevents.ConnectionArgs{
 		MaxIdleConns:        int(kafkaConfig.MaxIdleConns),
 		MaxIdleConnsPerHost: int(kafkaConfig.MaxIdleConnsPerHost),
-	}
+	})
 
 	kafkaChannelInformer := kafkachannel.Get(ctx)
 	args := &dispatcher.KafkaDispatcherArgs{
-		KnCEConnectionArgs:       connectionArgs,
 		ClientID:                 "kafka-ch-dispatcher",
 		Brokers:                  kafkaConfig.Brokers,
 		KafkaAuthConfig:          kafkaAuthCfg,


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Move setting CE connection args setting one level above in consolidated dispatcher so that it is more clear that this is to be done exactly once per process

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
