### PR TITLE
reduce apiserver requests for dispatcher

### DIFF
--- a/pkg/channel/distributed/dispatcher/controller/kafkachannel.go
+++ b/pkg/channel/distributed/dispatcher/controller/kafkachannel.go
@@ -114,6 +114,11 @@ func (r Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	r.logger.Info("Reconcile", zap.String("key", key))
 
+	// Only Reconcile KafkaChannel Associated With This Dispatcher
+	if r.channelKey != key {
+		return nil
+	}
+
 	// Convert the namespace/name string into a distinct namespace and name.
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -130,11 +135,6 @@ func (r Reconciler) Reconcile(ctx context.Context, key string) error {
 		}
 		r.logger.Error("Error Retrieving KafkaChannel", zap.Error(err), zap.String("namespace", namespace), zap.String("name", name))
 		return err
-	}
-
-	// Only Reconcile KafkaChannel Associated With This Dispatcher
-	if r.channelKey != key {
-		return nil
 	}
 
 	if !original.Status.IsReady() {


### PR DESCRIPTION
Signed-off-by: XinYang <xinydev@gmail.com>

The dispatcher now only gets information for the channel it cares about. reducing the GET requests to apiserver in a cluster with lots of channels.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-  return before GET requests for channels dispatcher doesn’t need to care about

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
