### PR TITLE
capacity and refreshPeriod are now configurable via env vars

### DIFF
--- a/config/source/multi/deployments/adapter.yaml
+++ b/config/source/multi/deployments/adapter.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: devel
 spec:
-  replicas: 1 # TODO: set to 0
+  replicas: 1
   selector:
     matchLabels: &labels
       control-plane: kafkasource-mt-adapter
@@ -56,11 +56,11 @@ spec:
 
         resources:
           requests:
-            cpu: 50m
-            memory: 1Gi
+            cpu: 100m
+            memory: 100Mi
           limits:
-            cpu: 50m
-            memory: 1Gi
+            cpu: 200m
+            memory: 150Mi
 
         ports:
         - name: metrics

--- a/config/source/multi/deployments/controller.yaml
+++ b/config/source/multi/deployments/controller.yaml
@@ -44,7 +44,15 @@ spec:
           value: config-observability
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
-        volumeMounts:
+
+        # how often (in seconds) the autoscaler tries to scale down the statefulset
+        - name: AUTOSCALER_REFRESH_PERIOD
+          value: '10'
+
+        # the number of virtual replicas this pod can handle
+        - name: POD_CAPACITY
+          value: '100'
+
         resources:
           requests:
             cpu: 20m

--- a/pkg/common/scheduler/statefulset/autoscaler_test.go
+++ b/pkg/common/scheduler/statefulset/autoscaler_test.go
@@ -196,7 +196,7 @@ func TestAutoscaler(t *testing.T) {
 				t.Fatal("unexpected error", err)
 			}
 
-			autoscaler := NewAutoscaler(ctx, testNs, sfsName, stateAccessor, 10*time.Second).(*autoscaler)
+			autoscaler := NewAutoscaler(ctx, testNs, sfsName, stateAccessor, 10*time.Second, int32(10)).(*autoscaler)
 
 			for _, vpod := range tc.vpods {
 				vpodClient.Append(vpod)
@@ -239,7 +239,7 @@ func TestAutoscalerScaleDownToZero(t *testing.T) {
 		t.Fatal("unexpected error", err)
 	}
 
-	autoscaler := NewAutoscaler(ctx, testNs, sfsName, stateAccessor, 2*time.Second).(*autoscaler)
+	autoscaler := NewAutoscaler(ctx, testNs, sfsName, stateAccessor, 2*time.Second, int32(10)).(*autoscaler)
 
 	done := make(chan bool)
 	go func() {

--- a/pkg/common/scheduler/statefulset/scheduler.go
+++ b/pkg/common/scheduler/statefulset/scheduler.go
@@ -38,11 +38,14 @@ import (
 )
 
 // NewScheduler creates a new scheduler with pod autoscaling enabled.
-func NewScheduler(ctx context.Context, namespace, name string, lister scheduler.VPodLister) scheduler.Scheduler {
-	capacity := int32(10) // TODO: config
+func NewScheduler(ctx context.Context,
+	namespace, name string,
+	lister scheduler.VPodLister,
+	refreshPeriod time.Duration,
+	capacity int32) scheduler.Scheduler {
 
 	stateAccessor := newStateBuilder(logging.FromContext(ctx), lister, capacity)
-	autoscaler := NewAutoscaler(ctx, namespace, name, stateAccessor, 10*time.Second) // TODO: config
+	autoscaler := NewAutoscaler(ctx, namespace, name, stateAccessor, refreshPeriod, capacity)
 
 	go autoscaler.Start(ctx)
 
@@ -67,7 +70,12 @@ type StatefulSetScheduler struct {
 	pending map[types.NamespacedName]int32
 }
 
-func NewStatefulSetScheduler(ctx context.Context, namespace, name string, lister scheduler.VPodLister, stateAccessor stateAccessor, autoscaler Autoscaler) scheduler.Scheduler {
+func NewStatefulSetScheduler(ctx context.Context,
+	namespace, name string,
+	lister scheduler.VPodLister,
+	stateAccessor stateAccessor,
+	autoscaler Autoscaler) scheduler.Scheduler {
+
 	scheduler := &StatefulSetScheduler{
 		logger:            logging.FromContext(ctx),
 		statefulSetName:   name,

--- a/pkg/common/scheduler/statefulset/state.go
+++ b/pkg/common/scheduler/statefulset/state.go
@@ -36,7 +36,7 @@ type state struct {
 	// with placed vpods.
 	lastOrdinal int32
 
-	// Pod capacity. Used
+	// Pod capacity.
 	capacity int32
 }
 


### PR DESCRIPTION
Fixes https://github.com/knative-sandbox/eventing-kafka/issues/324

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add two new env variables on the mt source controller to configure pod capacity and autoscaler refresh period
- Change adapter resource request to accommodate 100 vreplicas consuming max 2MB (not enforced yet) 
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
