### PR TITLE
[mtsource] Automatically adjust Sarama resource usage to fit within limits

### DIFF
--- a/config/source/multi/deployments/adapter.yaml
+++ b/config/source/multi/deployments/adapter.yaml
@@ -49,6 +49,7 @@ spec:
 
         # The memory limit, per vreplica. Must be a quantity.
         # see https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L31
+        # Should be pod requested memory / pod capacity (see controller.yaml)
         - name: VREPLICA_LIMITS_MEMORY
           value: '2Mi'
 

--- a/config/source/multi/deployments/adapter.yaml
+++ b/config/source/multi/deployments/adapter.yaml
@@ -43,6 +43,16 @@ spec:
             fieldRef:
               fieldPath: metadata.name
 
+        # The maximum number of messages per second, per vreplica
+        - name: VREPLICA_LIMITS_MPS
+          value: '50'
+
+        # The memory limit, per vreplica. Must be a quantity.
+        # see https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L31
+        - name: VREPLICA_LIMITS_MEMORY
+          value: '2Mi'
+
+
         # DO NOT MODIFY: The values below are being filled by the kafka source controller
         # See 500-controller.yaml
         - name: K_METRICS_CONFIG

--- a/config/source/multi/deployments/controller.yaml
+++ b/config/source/multi/deployments/controller.yaml
@@ -45,11 +45,11 @@ spec:
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
 
-        # how often (in seconds) the autoscaler tries to scale down the statefulset
+        # How often (in seconds) the autoscaler tries to scale down the statefulset.
         - name: AUTOSCALER_REFRESH_PERIOD
           value: '10'
 
-        # the number of virtual replicas this pod can handle
+        # The number of virtual replicas this pod can handle.
         - name: POD_CAPACITY
           value: '100'
 

--- a/pkg/common/scheduler/placement.go
+++ b/pkg/common/scheduler/placement.go
@@ -38,3 +38,18 @@ func GetPlacementForPod(placements []duckv1alpha1.Placement, podName string) *du
 	}
 	return nil
 }
+
+// GetPodCount returns the number of pods with the given placements
+func GetPodCount(placements []duckv1alpha1.Placement) int {
+	set := map[string]int{}
+	for _, p := range placements {
+		if p.VReplicas > 0 {
+			if _, ok := set[p.PodName]; !ok {
+				set[p.PodName] = 1
+				continue
+			}
+			set[p.PodName] += 1
+		}
+	}
+	return len(set)
+}

--- a/pkg/common/scheduler/placement.go
+++ b/pkg/common/scheduler/placement.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduler
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
 	duckv1alpha1 "knative.dev/eventing-kafka/pkg/apis/duck/v1alpha1"
 )
 
@@ -41,15 +42,11 @@ func GetPlacementForPod(placements []duckv1alpha1.Placement, podName string) *du
 
 // GetPodCount returns the number of pods with the given placements
 func GetPodCount(placements []duckv1alpha1.Placement) int {
-	set := map[string]int{}
+	set := sets.NewString()
 	for _, p := range placements {
 		if p.VReplicas > 0 {
-			if _, ok := set[p.PodName]; !ok {
-				set[p.PodName] = 1
-				continue
-			}
-			set[p.PodName] += 1
+			set.Insert(p.PodName)
 		}
 	}
-	return len(set)
+	return set.Len()
 }

--- a/pkg/common/scheduler/placement_test.go
+++ b/pkg/common/scheduler/placement_test.go
@@ -106,3 +106,51 @@ func TestGetPlacementForPod(t *testing.T) {
 		})
 	}
 }
+func TestPodCount(t *testing.T) {
+	testCases := []struct {
+		name       string
+		placements []duckv1alpha1.Placement
+		expected   int
+	}{
+		{
+			name:       "nil placements",
+			placements: nil,
+			expected:   0,
+		},
+		{
+			name:       "empty placements",
+			placements: []duckv1alpha1.Placement{},
+			expected:   0,
+		},
+		{
+			name:       "one pod",
+			placements: []duckv1alpha1.Placement{{PodName: "d", VReplicas: 2}},
+			expected:   1,
+		},
+		{
+			name: "two pods",
+			placements: []duckv1alpha1.Placement{
+				{PodName: "p1", VReplicas: 2},
+				{PodName: "p2", VReplicas: 6},
+				{PodName: "p1", VReplicas: 6}},
+			expected: 2,
+		},
+		{
+			name: "three pods, one with no vreplicas",
+			placements: []duckv1alpha1.Placement{
+				{PodName: "p1", VReplicas: 2},
+				{PodName: "p2", VReplicas: 6},
+				{PodName: "p1", VReplicas: 0}},
+			expected: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetPodCount(tc.placements)
+			if got != tc.expected {
+				t.Errorf("got %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/source/client/client.go
+++ b/pkg/source/client/client.go
@@ -119,3 +119,12 @@ func NewProducer(ctx context.Context) (sarama.Client, error) {
 
 	return sarama.NewClient(bs, cfg)
 }
+
+// NewProducer is a helper method for constructing an admin client
+func MakeAdminClient(ctx context.Context, env *KafkaEnvConfig) (sarama.ClusterAdmin, error) {
+	bs, cfg, err := NewConfigWithEnv(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	return sarama.NewClusterAdmin(bs, cfg)
+}

--- a/pkg/source/mtadapter/adapter.go
+++ b/pkg/source/mtadapter/adapter.go
@@ -18,12 +18,15 @@ package mtadapter
 
 import (
 	"context"
+	"math"
+	"strconv"
 	"sync"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -42,7 +45,9 @@ import (
 type AdapterConfig struct {
 	adapter.EnvConfig
 
-	PodName string `envconfig:"POD_NAME" required:"true"`
+	PodName     string `envconfig:"POD_NAME" required:"true"`
+	MPSLimit    int    `envconfig:"VREPLICA_LIMITS_MPS" required:"true"`
+	MemoryLimit string `envconfig:"VREPLICA_LIMITS_MEMORY" required:"true"`
 }
 
 func NewEnvConfig() adapter.EnvConfigAccessor {
@@ -55,6 +60,7 @@ type Adapter struct {
 	client      cloudevents.Client
 	adapterCtor adapter.MessageAdapterConstructor
 	kubeClient  kubernetes.Interface
+	memLimit    int64
 
 	sourcesMu sync.RWMutex
 	sources   map[string]context.CancelFunc
@@ -69,6 +75,7 @@ func NewAdapter(ctx context.Context, processed adapter.EnvConfigAccessor, ceClie
 func newAdapter(ctx context.Context, processed adapter.EnvConfigAccessor, ceClient cloudevents.Client, adapterCtor adapter.MessageAdapterConstructor) adapter.Adapter {
 	logger := logging.FromContext(ctx)
 	config := processed.(*AdapterConfig)
+	ml := resource.MustParse(config.MemoryLimit)
 
 	return &Adapter{
 		client:      ceClient,
@@ -76,6 +83,7 @@ func newAdapter(ctx context.Context, processed adapter.EnvConfigAccessor, ceClie
 		logger:      logger,
 		adapterCtor: adapterCtor,
 		kubeClient:  kubeclient.Get(ctx),
+		memLimit:    ml.Value(),
 		sourcesMu:   sync.RWMutex{},
 		sources:     make(map[string]context.CancelFunc),
 	}
@@ -87,52 +95,122 @@ func (a *Adapter) Start(ctx context.Context) error {
 	return nil
 }
 
+// bufferSize returns the maximum fetch buffer size (in bytes)
+// so that the st adapter memory consumption does not exceed
+// the allocated memory per vreplica (see MemoryLimit).
+// Account pod (consumer) partial outage.
+func (a *Adapter) bufferSize(ctx context.Context,
+	logger *zap.SugaredLogger,
+	kafkaEnvConfig *client.KafkaEnvConfig,
+	topics []string,
+	consumerCount int) (int, error) {
+
+	// Compute the number of partitions handled by this source
+	// TODO: periodically check for # of resources. Need control-protocol.
+	adminClient, err := client.MakeAdminClient(ctx, kafkaEnvConfig)
+	if err != nil {
+		logger.Errorw("cannot create admin client", zap.Error(err))
+		return 0, err
+	}
+
+	metas, err := adminClient.DescribeTopics(topics)
+	if err != nil {
+		logger.Errorw("cannot describe topics", zap.Error(err))
+		return 0, err
+	}
+
+	totalPartitions := 0
+	for _, meta := range metas {
+		totalPartitions += len(meta.Partitions)
+	}
+	adminClient.Close()
+
+	partitionsPerConsumer := int(math.Ceil(float64(totalPartitions) / float64(consumerCount)))
+
+	// Ideally, partitions are evenly spread across Kafka consumers.
+	// However, due to rebalancing or consumer (un)availability, a consumer
+	// might have to handle more partitions than expected.
+	// For now, account for 1 unavailable consumer.
+	handledPartitions := 2 * partitionsPerConsumer
+	if consumerCount < 3 {
+		handledPartitions = totalPartitions
+	}
+
+	logger.Infow("partition count",
+		zap.Int("total", totalPartitions),
+		zap.Int("perconsumer", partitionsPerConsumer),
+		zap.Int("handled", handledPartitions))
+
+	// A partition consumes about 2 * fetch buffer size.
+	return int(math.Floor(float64(a.memLimit) / float64(handledPartitions) / 2.0)), nil
+}
+
 // Implements MTAdapter
 
 func (a *Adapter) Update(ctx context.Context, obj *v1beta1.KafkaSource) {
 	a.sourcesMu.Lock()
 	defer a.sourcesMu.Unlock()
-	a.logger.Infow("adding source", "name", obj.Name)
 
 	key := obj.Namespace + "/" + obj.Name
+
+	logger := a.logger.With("key", key)
+	logger.Info("updating source")
 
 	cancel, ok := a.sources[key]
 
 	if ok {
 		// TODO: do not stop if the only thing that changes is the number of vreplicas
-		a.logger.Info("stopping adapter", zap.String("key", key))
+		logger.Info("stopping adapter")
 		cancel()
 	}
 
 	placement := scheduler.GetPlacementForPod(obj.GetPlacements(), a.config.PodName)
 	if placement == nil || placement.VReplicas == 0 {
 		// this pod does not handle this source. Skipping
-		a.logger.Infow("no replicas assigned to this source. skipping", zap.String("key", key))
+		logger.Info("no replicas assigned to this source. skipping")
 		return
 	}
+
+	kafkaEnvConfig := client.KafkaEnvConfig{
+		BootstrapServers: obj.Spec.BootstrapServers,
+		Net: client.AdapterNet{
+			SASL: client.AdapterSASL{
+				Enable:   obj.Spec.Net.SASL.Enable,
+				User:     a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.SASL.User.SecretKeyRef),
+				Password: a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.SASL.Password.SecretKeyRef),
+				Type:     a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.SASL.Type.SecretKeyRef),
+			},
+			TLS: client.AdapterTLS{
+				Enable: obj.Spec.Net.TLS.Enable,
+				Cert:   a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.TLS.Cert.SecretKeyRef),
+				Key:    a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.TLS.Key.SecretKeyRef),
+				CACert: a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.TLS.CACert.SecretKeyRef),
+			},
+		},
+	}
+
+	// Enforce memory limits
+	// TODO: periodically enforce limits as the number of partitions can dynamically change
+	bufferSizePerVReplica, err := a.bufferSize(ctx, logger, &kafkaEnvConfig, obj.Spec.Topics, scheduler.GetPodCount(obj.Status.Placement))
+	if err != nil {
+		return
+	}
+	bufferSize := bufferSizePerVReplica * int(placement.VReplicas)
+	a.logger.Infow("setting fetch buffer size", zap.Int("size", bufferSize))
+
+	// Nasty.
+	bufferSizeStr := strconv.Itoa(bufferSize)
+	min := `\n    Min: ` + bufferSizeStr
+	def := `\n    Default: ` + bufferSizeStr
+	max := `\n    Max: ` + bufferSizeStr
+	kafkaEnvConfig.KafkaConfigJson = `{"sarama": "Consumer:\n  Fetch:` + min + def + max + `"}`
 
 	config := stadapter.AdapterConfig{
 		EnvConfig: adapter.EnvConfig{
 			Component: "kafkasource",
 			Namespace: obj.Namespace,
 		},
-		KafkaEnvConfig: client.KafkaEnvConfig{
-			BootstrapServers: obj.Spec.BootstrapServers,
-			Net: client.AdapterNet{
-				SASL: client.AdapterSASL{
-					Enable:   obj.Spec.Net.SASL.Enable,
-					User:     a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.SASL.User.SecretKeyRef),
-					Password: a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.SASL.Password.SecretKeyRef),
-					Type:     a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.SASL.Type.SecretKeyRef),
-				},
-				TLS: client.AdapterTLS{
-					Enable: obj.Spec.Net.TLS.Enable,
-					Cert:   a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.TLS.Cert.SecretKeyRef),
-					Key:    a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.TLS.Key.SecretKeyRef),
-					CACert: a.ResolveSecret(ctx, obj.Namespace, obj.Spec.Net.TLS.CACert.SecretKeyRef),
-				},
-			},
-		},
+		KafkaEnvConfig:       kafkaEnvConfig,
 		Topics:               obj.Spec.Topics,
 		ConsumerGroup:        obj.Spec.ConsumerGroup,
 		Name:                 obj.Name,
@@ -155,9 +233,9 @@ func (a *Adapter) Update(ctx context.Context, obj *v1beta1.KafkaSource) {
 
 	adapter := a.adapterCtor(ctx, &config, httpBindingsSender, reporter)
 
-	if a, ok := adapter.(*stadapter.Adapter); ok {
-		// TODO: configurable
-		a.SetRateLimits(rate.Limit(10.0*placement.VReplicas), 20*int(placement.VReplicas))
+	// TODO: define Limit interface.
+	if sta, ok := adapter.(*stadapter.Adapter); ok {
+		sta.SetRateLimits(rate.Limit(a.config.MPSLimit*int(placement.VReplicas)), 2*a.config.MPSLimit*int(placement.VReplicas))
 	}
 
 	ctx, cancelFn := context.WithCancel(ctx)

--- a/pkg/source/mtadapter/adapter.go
+++ b/pkg/source/mtadapter/adapter.go
@@ -103,7 +103,7 @@ func (a *Adapter) bufferSize(ctx context.Context,
 	logger *zap.SugaredLogger,
 	kafkaEnvConfig *client.KafkaEnvConfig,
 	topics []string,
-	consumerCount int) (int, error) {
+	podCount int) (int, error) {
 
 	// Compute the number of partitions handled by this source
 	// TODO: periodically check for # of resources. Need control-protocol.
@@ -125,20 +125,20 @@ func (a *Adapter) bufferSize(ctx context.Context,
 	}
 	adminClient.Close()
 
-	partitionsPerConsumer := int(math.Ceil(float64(totalPartitions) / float64(consumerCount)))
+	partitionsPerPod := int(math.Ceil(float64(totalPartitions) / float64(podCount)))
 
 	// Ideally, partitions are evenly spread across Kafka consumers.
 	// However, due to rebalancing or consumer (un)availability, a consumer
 	// might have to handle more partitions than expected.
 	// For now, account for 1 unavailable consumer.
-	handledPartitions := 2 * partitionsPerConsumer
-	if consumerCount < 3 {
+	handledPartitions := 2 * partitionsPerPod
+	if podCount < 3 {
 		handledPartitions = totalPartitions
 	}
 
 	logger.Infow("partition count",
 		zap.Int("total", totalPartitions),
-		zap.Int("perconsumer", partitionsPerConsumer),
+		zap.Int("averagePerPod", partitionsPerPod),
 		zap.Int("handled", handledPartitions))
 
 	// A partition consumes about 2 * fetch buffer size.

--- a/pkg/source/mtadapter/adapter_test.go
+++ b/pkg/source/mtadapter/adapter_test.go
@@ -21,8 +21,6 @@ import (
 	"testing"
 	"time"
 
-	duckv1alpha1 "knative.dev/eventing-kafka/pkg/apis/duck/v1alpha1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	_ "knative.dev/pkg/client/injection/kube/client/fake"
@@ -34,6 +32,7 @@ import (
 	"knative.dev/eventing/pkg/kncloudevents"
 
 	bindingsv1beta1 "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
+	duckv1alpha1 "knative.dev/eventing-kafka/pkg/apis/duck/v1alpha1"
 	sourcesv1beta1 "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
 )
 
@@ -50,7 +49,7 @@ func TestUpdateRemoveSources(t *testing.T) {
 	ctx, _ := pkgtesting.SetupFakeContext(t)
 	ctx, cancelAdapter := context.WithCancel(ctx)
 
-	env := &AdapterConfig{PodName: podName}
+	env := &AdapterConfig{PodName: podName, MemoryLimit: "0"}
 	ceClient := adaptertest.NewTestClient()
 
 	adapter := newAdapter(ctx, env, ceClient, newSampleAdapter).(*Adapter)

--- a/pkg/source/reconciler/mtsource/controller.go
+++ b/pkg/source/reconciler/mtsource/controller.go
@@ -70,7 +70,6 @@ func NewController(
 	sourcesv1beta1.RegisterAlternateKafkaConditionSet(sourcesv1beta1.KafkaMTSourceCondSet)
 
 	rp := time.Duration(env.SchedulerRefreshPeriod) * time.Second
-
 	c.scheduler = scheduler.NewScheduler(ctx, system.Namespace(), mtadapterName, c.vpodLister, rp, env.PodCapacity)
 
 	logging.FromContext(ctx).Info("Setting up kafka event handlers")


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Compute the maximum fetch buffer size to not exceed the configured memory limit. Take into account the number of partitions handled by the sources and inevitable pod outages. 
-  Set default pod memory request to 100MB, capacity of 50, so each vreplica memory limit is 2MB. With these parameters, the maximum number of partitions a source can handle to process 64k messages is about 16.  
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
