### PR TITLE
Do not mark messages as consumed if the context was canceled

### DIFF
--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"strings"
 
 	kafkasarama "knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/sarama"
 
@@ -108,11 +109,18 @@ func (h *Handler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama
 	// Pull Any Available Messages From The ConsumerGroupClaim (Until The Channel Closes)
 	for message := range claim.Messages() {
 
-		// Consume The Message (Ignore Errors - Will have already been retried and we're moving on so as not to block further Topic processing.)
-		_ = h.consumeMessage(session.Context(), message, destinationURL, replyURL, deadLetterURL, &retryConfig)
+		// Consume The Message (Ignore any errors other than "context canceled" - Will have already been retried
+		// and we're moving on so as not to block further Topic processing.)
+		err := h.consumeMessage(session.Context(), message, destinationURL, replyURL, deadLetterURL, &retryConfig)
 
-		// Mark The Message As Having Been Consumed (Does Not Imply Successful Delivery - Only Full Retry Attempts Made)
-		session.MarkMessage(message, "")
+		// If the system is shutting down, it's possible to get a "unable to complete request to [destination]: context canceled" error
+		// This is different than other types of failure in that it is the dispatcher's "fault" and so marking the message as delivered
+		// would be a violation of the "at least once" guarantee (because the next dispatcher that starts would see it as marked and not
+		// try to deliver it again).
+		if err == nil || !strings.Contains(err.Error(), context.Canceled.Error()) {
+			// Mark The Message As Having Been Consumed (Does Not Imply Successful Delivery - Only Full Retry Attempts Made)
+			session.MarkMessage(message, "")
+		}
 	}
 
 	// Return Success


### PR DESCRIPTION
## Proposed Changes

- 🐛 During blue/green upgrade testing of the distributed channel, we found that when a continuous stream of messages is being sent during a rollout restart, the dispatcher would often miss a single message when the new pod became ready.  This was tracked down to MarkMessage being called when consumeMessage() returns a "context was canceled" error, which is not appropriate.  This change skips the MarkMessage call when that particular error is returned, and adds a new unit test to verify that.  
