### PR TITLE
[Consolidated Channel] Update target pod IPs when dispatcher pods scale before the subscription is marked ready 

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/controller.go
+++ b/pkg/channel/consolidated/reconciler/controller/controller.go
@@ -157,9 +157,18 @@ func NewController(
 			DeleteFunc: func(obj interface{}) {
 				pod, ok := obj.(*corev1.Pod)
 				if ok && pod != nil {
-					logger.Debugw("Dispatcher pod deleted. Canceling pod probing.",
+					logger.Debugw("Dispatcher pod deleted. Refreshing pod probing.",
 						zap.String("pod", pod.GetName()))
-					statusProber.CancelPodProbing(*pod)
+					statusProber.RefreshPodProbing(ctx)
+					impl.GlobalResync(kafkaChannelInformer.Informer())
+				}
+			},
+			AddFunc: func(obj interface{}) {
+				pod, ok := obj.(*corev1.Pod)
+				if ok && pod != nil {
+					logger.Debugw("Dispatcher pod added. Refreshing pod probing.",
+						zap.String("pod", pod.GetName()))
+					statusProber.RefreshPodProbing(ctx)
 					impl.GlobalResync(kafkaChannelInformer.Informer())
 				}
 			},

--- a/pkg/channel/consolidated/reconciler/controller/controller.go
+++ b/pkg/channel/consolidated/reconciler/controller/controller.go
@@ -27,7 +27,7 @@ import (
 
 	"knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 	"knative.dev/eventing-kafka/pkg/channel/consolidated/status"
-	kafkavmessaging1beta1 "knative.dev/eventing-kafka/pkg/client/informers/externalversions/messaging/v1beta1"
+	kafkamessagingv1beta1 "knative.dev/eventing-kafka/pkg/client/informers/externalversions/messaging/v1beta1"
 	kafkaChannelClient "knative.dev/eventing-kafka/pkg/client/injection/client"
 	"knative.dev/eventing-kafka/pkg/client/injection/informers/messaging/v1beta1/kafkachannel"
 	kafkaChannelReconciler "knative.dev/eventing-kafka/pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel"
@@ -162,11 +162,11 @@ func NewController(
 	return impl
 }
 
-func getPodInformerEventHandler(ctx context.Context, logger *zap.SugaredLogger, statusProber *status.Prober, impl *controller.Impl, kafkaChannelInformer kafkavmessaging1beta1.KafkaChannelInformer, handlerType string) func(obj interface{}) {
+func getPodInformerEventHandler(ctx context.Context, logger *zap.SugaredLogger, statusProber *status.Prober, impl *controller.Impl, kafkaChannelInformer kafkamessagingv1beta1.KafkaChannelInformer, handlerType string) func(obj interface{}) {
 	return func(obj interface{}) {
 		pod, ok := obj.(*corev1.Pod)
 		if ok && pod != nil {
-			logger.Debugw("%s rods. Refreshing pod probing.", handlerType,
+			logger.Debugw("%s pods. Refreshing pod probing.", handlerType,
 				zap.String("pod", pod.GetName()))
 			statusProber.RefreshPodProbing(ctx)
 			impl.GlobalResync(kafkaChannelInformer.Informer())

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -230,7 +230,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 	// Reconcile the k8s service representing the actual Channel. It points to the Dispatcher service via ExternalName
 	svc, err := r.reconcileChannelService(ctx, dispatcherNamespace, kc)
 	if err != nil {
-
 		return err
 	}
 	kc.Status.MarkChannelServiceTrue()
@@ -243,7 +242,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 		return fmt.Errorf("error reconciling subscribers %v", err)
 	}
 	if !reconciled {
-		return newSubscribersNotReadyWarn()
+		return fmt.Errorf("SubscribersNotReady")
 	}
 
 	// Ok, so now the Dispatcher Deployment & Service have been created, we're golden since the
@@ -275,7 +274,7 @@ func (r *Reconciler) reconcileSubscribers(ctx context.Context, ch *v1beta1.Kafka
 	// If there is nothing to patch, we are good, just return.
 	// Empty patch is [], hence we check for that.
 	if len(jsonPatch) == 0 {
-		return true, nil
+		return reconciled, nil
 	}
 	patch, err := jsonPatch.MarshalJSON()
 	if err != nil {

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -242,7 +242,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 		return fmt.Errorf("error reconciling subscribers %v", err)
 	}
 	if !reconciled {
-		return fmt.Errorf("SubscribersNotReady")
+		return newSubscribersNotReadyWarn()
 	}
 
 	// Ok, so now the Dispatcher Deployment & Service have been created, we're golden since the

--- a/pkg/channel/consolidated/reconciler/controller/lister.go
+++ b/pkg/channel/consolidated/reconciler/controller/lister.go
@@ -70,7 +70,6 @@ func (t *DispatcherPodsLister) ListProbeTargets(ctx context.Context, kc v1beta1.
 	return &status.ProbeTarget{
 		PodIPs:  sets.NewString(readyIPs...),
 		PodPort: "8081",
-		Port:    "8081",
 		URL:     u,
 	}, nil
 }

--- a/pkg/channel/consolidated/status/status.go
+++ b/pkg/channel/consolidated/status/status.go
@@ -202,7 +202,9 @@ func (m *Prober) IsReady(ctx context.Context, ch messagingv1beta1.KafkaChannel, 
 						return false, true
 					} else {
 						// the dispatcher pods changed, we need to cancel old probing and start again
+						m.mu.Unlock()
 						m.CancelProbing(state.sub)
+						m.mu.Lock()
 						return false, false
 					}
 				}

--- a/pkg/channel/consolidated/status/status.go
+++ b/pkg/channel/consolidated/status/status.go
@@ -362,7 +362,7 @@ func (m *Prober) RefreshPodProbing(ctx context.Context) {
 				return
 			}
 			if !state.probedPods.Equal(target.PodIPs) {
-				m.forgetState(state.sub)
+				m.forgetState(sub)
 				func() {
 					// probeTarget requires an unlocked mutex.
 					m.mu.Unlock()
@@ -511,11 +511,10 @@ func (m *Prober) probeVerifier(item *workItem) prober.Verifier {
 
 // A target state is outdated if the generation is different or if the target IPs change before it becomes
 // ready.
-func isOutdatedTargetState(s *targetState, sub eventingduckv1.SubscriberSpec, podIPs sets.String) bool {
-	s.readyLock.RLock()
-	defer s.readyLock.RUnlock()
-	r := s.ready
-	return s.sub.Generation != sub.Generation || (!r && !s.probedPods.Equal(podIPs))
+func isOutdatedTargetState(state *targetState, sub eventingduckv1.SubscriberSpec, podIPs sets.String) bool {
+	state.readyLock.RLock()
+	defer state.readyLock.RUnlock()
+	return state.sub.Generation != sub.Generation || (!state.ready && !state.probedPods.Equal(podIPs))
 }
 
 // deepCopy copies a URL into a new one

--- a/pkg/channel/consolidated/status/status.go
+++ b/pkg/channel/consolidated/status/status.go
@@ -201,6 +201,8 @@ func (m *Prober) IsReady(ctx context.Context, ch messagingv1beta1.KafkaChannel, 
 					if target.PodIPs.Len() == state.probedPods.Len() && target.PodIPs.HasAll(state.probedPods.List()...) {
 						return false, true
 					} else {
+						logger.Debugw("Dispatcher pods changed. Canceling old probes and restarting",
+							zap.Any("subscription", sub.UID))
 						// the dispatcher pods changed, we need to cancel old probing and start again
 						m.mu.Unlock()
 						m.CancelProbing(state.sub)


### PR DESCRIPTION
## Background
The existing dispatcher pods Prober acts like this:
1. `IsReady(sub)` -> get list of target pods, cache the state (including the list of pods), and start probing those pods.
3. Probing collects ready partitions and stores them in the cached target state
4. After each dispatcher pod partitions are cached, check if we collected all partitions we are looking for and if so, mark the cached targetState as ready.  

There's a corner case the manifests itself as follows:
1. `IsReady(sub)` -> get list of target pods, cache the state (including the list of pods), and start probing those pods.
2.  Dispatcher pods scale up before the cached targetState becomes ready. 
3.  No new probes are created for the new pods.
4. The existing probing returns only a subset of the partitions, because not all dispatcher pods are probed for this targetState.

This is a fix for the behavior [described here](https://github.com/knative-sandbox/eventing-kafka/pull/476#issuecomment-809156584)

## Proposed Changes
### Kafka Controller 
1. Refresh prober pods when dispatcher pods are added or deleted.

### Prober
1. Refactor the code to be more readible by breaking down `IsReady` and getting rid of non-readable anonymous function and logic.
2. Consider an in-flight targetState outdated if the list of initial probed pods change from the current, forget the state and reprobe new pods.
3. Add `RefreshPodProbing()` that will eject outdated in-flight target states, and reprobe the new pods instead.

