### PR TITLE
Move metrics shutdown channels out of dispatcher config

### DIFF
--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -144,8 +144,6 @@ func main() {
 		ChannelKey:         environment.ChannelKey,
 		StatsReporter:      statsReporter,
 		MetricsRegistry:    saramaConfig.MetricRegistry,
-		MetricsStopChan:    make(chan struct{}),
-		MetricsStoppedChan: make(chan struct{}),
 		SaramaConfig:       saramaConfig,
 	}
 	dispatcher = dispatch.NewDispatcher(dispatcherConfig)

--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -135,16 +135,16 @@ func main() {
 
 	// Create The Dispatcher With Specified Configuration
 	dispatcherConfig := dispatch.DispatcherConfig{
-		Logger:             logger,
-		ClientId:           constants.Component,
-		Brokers:            strings.Split(ekConfig.Kafka.Brokers, ","),
-		Topic:              environment.KafkaTopic,
-		Username:           kafkaAuthCfg.SASL.User,
-		Password:           kafkaAuthCfg.SASL.Password,
-		ChannelKey:         environment.ChannelKey,
-		StatsReporter:      statsReporter,
-		MetricsRegistry:    saramaConfig.MetricRegistry,
-		SaramaConfig:       saramaConfig,
+		Logger:          logger,
+		ClientId:        constants.Component,
+		Brokers:         strings.Split(ekConfig.Kafka.Brokers, ","),
+		Topic:           environment.KafkaTopic,
+		Username:        kafkaAuthCfg.SASL.User,
+		Password:        kafkaAuthCfg.SASL.Password,
+		ChannelKey:      environment.ChannelKey,
+		StatsReporter:   statsReporter,
+		MetricsRegistry: saramaConfig.MetricRegistry,
+		SaramaConfig:    saramaConfig,
 	}
 	dispatcher = dispatch.NewDispatcher(dispatcherConfig)
 

--- a/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
@@ -45,17 +45,17 @@ import (
 
 // Define A Dispatcher Config Struct To Hold Configuration
 type DispatcherConfig struct {
-	Logger             *zap.Logger
-	ClientId           string
-	Brokers            []string
-	Topic              string
-	Username           string
-	Password           string
-	ChannelKey         string
-	StatsReporter      metrics.StatsReporter
-	MetricsRegistry    gometrics.Registry
-	SaramaConfig       *sarama.Config
-	SubscriberSpecs    []eventingduck.SubscriberSpec
+	Logger          *zap.Logger
+	ClientId        string
+	Brokers         []string
+	Topic           string
+	Username        string
+	Password        string
+	ChannelKey      string
+	StatsReporter   metrics.StatsReporter
+	MetricsRegistry gometrics.Registry
+	SaramaConfig    *sarama.Config
+	SubscriberSpecs []eventingduck.SubscriberSpec
 }
 
 // Knative Eventing SubscriberSpec Wrapper Enhanced With Sarama ConsumerGroup

--- a/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
@@ -391,7 +391,6 @@ func (d *DispatcherImpl) reconfigure(newConfig *sarama.Config, ekConfig *commonc
 		// Currently the only thing that a new dispatcher might care about in the EventingKafkaConfig is the Brokers
 		d.DispatcherConfig.Brokers = strings.Split(ekConfig.Kafka.Brokers, ",")
 	}
-
 	newDispatcher := NewDispatcher(d.DispatcherConfig)
 	failedSubscriptions := newDispatcher.UpdateSubscriptions(d.SubscriberSpecs)
 	if len(failedSubscriptions) > 0 {

--- a/pkg/channel/distributed/dispatcher/dispatcher/dispatcher_test.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/dispatcher_test.go
@@ -576,9 +576,9 @@ func TestConfigImpl_ObserveMetrics(t *testing.T) {
 	// reporting function with a very small interval
 	dispatcher := &DispatcherImpl{
 		DispatcherConfig: DispatcherConfig{
-			Logger:             logtesting.TestLogger(t).Desugar(),
-			MetricsRegistry:    baseSaramaConfig.MetricRegistry,
-			StatsReporter:      reporter,
+			Logger:          logtesting.TestLogger(t).Desugar(),
+			MetricsRegistry: baseSaramaConfig.MetricRegistry,
+			StatsReporter:   reporter,
 		},
 		MetricsStopChan:    make(chan struct{}),
 		MetricsStoppedChan: make(chan struct{}),

--- a/pkg/channel/distributed/dispatcher/dispatcher/dispatcher_test.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/dispatcher_test.go
@@ -379,6 +379,14 @@ func TestConfigChanged(t *testing.T) {
 
 			// Verify Expected State (Not Much To Verify Due To Interface)
 			assert.Equal(t, testCase.expectNewDispatcher, newDispatcher != nil)
+
+			if testCase.expectNewDispatcher {
+				// Verify that the new dispatcher's channels are not the same as the original
+				oldImpl := dispatcher.(*DispatcherImpl)
+				newImpl := newDispatcher.(*DispatcherImpl)
+				assert.NotEqual(t, oldImpl.MetricsStopChan, newImpl.MetricsStopChan)
+				assert.NotEqual(t, oldImpl.MetricsStoppedChan, newImpl.MetricsStoppedChan)
+			}
 		})
 	}
 }
@@ -486,6 +494,14 @@ func TestSecretChanged(t *testing.T) {
 
 			// Verify Expected State (Not Much To Verify Due To Interface)
 			assert.Equal(t, testCase.expectNewDispatcher, newDispatcher != nil)
+
+			if testCase.expectNewDispatcher {
+				// Verify that the new dispatcher's channels are not the same as the original
+				oldImpl := dispatcher.(*DispatcherImpl)
+				newImpl := newDispatcher.(*DispatcherImpl)
+				assert.NotEqual(t, oldImpl.MetricsStopChan, newImpl.MetricsStopChan)
+				assert.NotEqual(t, oldImpl.MetricsStoppedChan, newImpl.MetricsStoppedChan)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Proposed Changes

-🐛 The introduction of the Sarama metrics to the dispatcher (https://github.com/knative-sandbox/eventing-kafka/pull/464) included two channels (MetricsStopChan and MetricsStoppedChan) that were inappropriately added to the DispatcherConfig instead of the DispatcherImpl.  Since the config is re-used between creation of dispatchers, these closed channels were copied to the new DispatcherImpl's config and caused a panic when Shutdown is called again.  Moving these channels to the DispatcherImpl, the fields of which are recreated each time, solves this issue.
