### PR TITLE
[v0.20] [Consolidated Channel] Backport of #487 

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -163,6 +163,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 		kc.Status.MarkConfigFailed("InvalidConfiguration", "Unable to build Kafka admin client for channel %s: %v", kc.Name, err)
 		return err
 	}
+	defer kafkaClusterAdmin.Close()
 
 	kc.Status.MarkConfigTrue()
 
@@ -226,7 +227,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 	// Reconcile the k8s service representing the actual Channel. It points to the Dispatcher service via ExternalName
 	svc, err := r.reconcileChannelService(ctx, dispatcherNamespace, kc)
 	if err != nil {
-
 		return err
 	}
 	kc.Status.MarkChannelServiceTrue()
@@ -234,15 +234,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 		Scheme: "http",
 		Host:   network.GetServiceHostname(svc.Name, svc.Namespace),
 	})
-	err = r.setupSubscriptionStatusWatcher(ctx, kc)
+	err = r.reconcileSubscribers(ctx, kc)
 	if err != nil {
-		logger.Errorw("error setting up some subscription status watchers", zap.Error(err))
-	}
-	// close the connection
-	err = kafkaClusterAdmin.Close()
-	if err != nil {
-		logger.Errorw("Error closing the connection", zap.Error(err))
-		return err
+		return fmt.Errorf("error reconciling subscribers %v", err)
 	}
 
 	// Ok, so now the Dispatcher Deployment & Service have been created, we're golden since the
@@ -250,10 +244,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 	return newReconciledNormal(kc.Namespace, kc.Name)
 }
 
-func (r *Reconciler) setupSubscriptionStatusWatcher(ctx context.Context, ch *v1beta1.KafkaChannel) error {
+func (r *Reconciler) reconcileSubscribers(ctx context.Context, ch *v1beta1.KafkaChannel) error {
 	after := ch.DeepCopy()
 	after.Status.Subscribers = make([]v1.SubscriberStatus, 0)
-
 	for _, s := range ch.Spec.Subscribers {
 		if r, _ := r.statusManager.IsReady(ctx, *ch, s); r {
 			logging.FromContext(ctx).Debugw("marking subscription", zap.Any("subscription", s))

--- a/pkg/channel/consolidated/reconciler/controller/lister.go
+++ b/pkg/channel/consolidated/reconciler/controller/lister.go
@@ -70,7 +70,6 @@ func (t *DispatcherPodsLister) ListProbeTargets(ctx context.Context, kc v1beta1.
 	return &status.ProbeTarget{
 		PodIPs:  sets.NewString(readyIPs...),
 		PodPort: "8081",
-		Port:    "8081",
 		URL:     u,
 	}, nil
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Fix bug of probing the dispatcher for subscription readiness after dispatcher pods change.
- Backport of #487 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 A bug fix was back ported to the consolidated channel so that subscriptions becomes eventually ready even when dispatchers scale up or down. 

```