### PR TITLE
[v0.21] [Consolidated Channel] Backport of #487

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/controller.go
+++ b/pkg/channel/consolidated/reconciler/controller/controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,6 +29,7 @@ import (
 
 	"knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 	"knative.dev/eventing-kafka/pkg/channel/consolidated/status"
+	kafkamessagingv1beta1 "knative.dev/eventing-kafka/pkg/client/informers/externalversions/messaging/v1beta1"
 	kafkaChannelClient "knative.dev/eventing-kafka/pkg/client/injection/client"
 	"knative.dev/eventing-kafka/pkg/client/injection/informers/messaging/v1beta1/kafkachannel"
 	kafkaChannelReconciler "knative.dev/eventing-kafka/pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel"
@@ -111,7 +111,7 @@ func NewController(
 	statusProber.Start(ctx.Done())
 	// Get and Watch the Kakfa config map and dynamically update Kafka configuration.
 	if _, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(ctx, constants.SettingsConfigMapName, metav1.GetOptions{}); err == nil {
-		cmw.Watch(constants.SettingsConfigMapName, func(configMap *v1.ConfigMap) {
+		cmw.Watch(constants.SettingsConfigMapName, func(configMap *corev1.ConfigMap) {
 			r.updateKafkaConfig(ctx, configMap)
 		})
 	} else if !apierrors.IsNotFound(err) {
@@ -159,17 +159,22 @@ func NewController(
 		),
 		Handler: cache.ResourceEventHandlerFuncs{
 			// Cancel probing when a Pod is deleted
-			DeleteFunc: func(obj interface{}) {
-				pod, ok := obj.(*corev1.Pod)
-				if ok && pod != nil {
-					logger.Debugw("Dispatcher pod deleted. Canceling pod probing.",
-						zap.String("pod", pod.GetName()))
-					statusProber.CancelPodProbing(*pod)
-					impl.GlobalResync(kafkaChannelInformer.Informer())
-				}
-			},
+			DeleteFunc: getPodInformerEventHandler(ctx, logger, statusProber, impl, kafkaChannelInformer, "Delete"),
+			AddFunc:    getPodInformerEventHandler(ctx, logger, statusProber, impl, kafkaChannelInformer, "Add"),
 		},
 	})
 
 	return impl
+}
+
+func getPodInformerEventHandler(ctx context.Context, logger *zap.SugaredLogger, statusProber *status.Prober, impl *controller.Impl, kafkaChannelInformer kafkamessagingv1beta1.KafkaChannelInformer, handlerType string) func(obj interface{}) {
+	return func(obj interface{}) {
+		pod, ok := obj.(*corev1.Pod)
+		if ok && pod != nil {
+			logger.Debugw("%s pods. Refreshing pod probing.", handlerType,
+				zap.String("pod", pod.GetName()))
+			statusProber.RefreshPodProbing(ctx)
+			impl.GlobalResync(kafkaChannelInformer.Informer())
+		}
+	}
 }

--- a/pkg/channel/consolidated/reconciler/controller/lister.go
+++ b/pkg/channel/consolidated/reconciler/controller/lister.go
@@ -70,7 +70,6 @@ func (t *DispatcherPodsLister) ListProbeTargets(ctx context.Context, kc v1beta1.
 	return &status.ProbeTarget{
 		PodIPs:  sets.NewString(readyIPs...),
 		PodPort: "8081",
-		Port:    "8081",
 		URL:     u,
 	}, nil
 }

--- a/pkg/client/injection/reconciler/bindings/v1alpha1/kafkabinding/controller.go
+++ b/pkg/client/injection/reconciler/bindings/v1alpha1/kafkabinding/controller.go
@@ -113,6 +113,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/pkg/client/injection/reconciler/bindings/v1alpha1/kafkabinding/reconciler.go
+++ b/pkg/client/injection/reconciler/bindings/v1alpha1/kafkabinding/reconciler.go
@@ -169,6 +169,9 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versio
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	return rec

--- a/pkg/client/injection/reconciler/bindings/v1beta1/kafkabinding/controller.go
+++ b/pkg/client/injection/reconciler/bindings/v1beta1/kafkabinding/controller.go
@@ -113,6 +113,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/pkg/client/injection/reconciler/bindings/v1beta1/kafkabinding/reconciler.go
+++ b/pkg/client/injection/reconciler/bindings/v1beta1/kafkabinding/reconciler.go
@@ -169,6 +169,9 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versio
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	return rec

--- a/pkg/client/injection/reconciler/messaging/v1alpha1/kafkachannel/controller.go
+++ b/pkg/client/injection/reconciler/messaging/v1alpha1/kafkachannel/controller.go
@@ -113,6 +113,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/pkg/client/injection/reconciler/messaging/v1alpha1/kafkachannel/reconciler.go
+++ b/pkg/client/injection/reconciler/messaging/v1alpha1/kafkachannel/reconciler.go
@@ -169,6 +169,9 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versio
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	return rec

--- a/pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel/controller.go
+++ b/pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel/controller.go
@@ -113,6 +113,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel/reconciler.go
+++ b/pkg/client/injection/reconciler/messaging/v1beta1/kafkachannel/reconciler.go
@@ -169,6 +169,9 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versio
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	return rec

--- a/pkg/client/injection/reconciler/sources/v1alpha1/kafkasource/controller.go
+++ b/pkg/client/injection/reconciler/sources/v1alpha1/kafkasource/controller.go
@@ -113,6 +113,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/pkg/client/injection/reconciler/sources/v1alpha1/kafkasource/reconciler.go
+++ b/pkg/client/injection/reconciler/sources/v1alpha1/kafkasource/reconciler.go
@@ -169,6 +169,9 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versio
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	return rec

--- a/pkg/client/injection/reconciler/sources/v1beta1/kafkasource/controller.go
+++ b/pkg/client/injection/reconciler/sources/v1beta1/kafkasource/controller.go
@@ -113,6 +113,9 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	rec.Recorder = createRecorder(ctx, agentName)

--- a/pkg/client/injection/reconciler/sources/v1beta1/kafkasource/reconciler.go
+++ b/pkg/client/injection/reconciler/sources/v1beta1/kafkasource/reconciler.go
@@ -169,6 +169,9 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versio
 		if opts.SkipStatusUpdates {
 			rec.skipStatusUpdates = true
 		}
+		if opts.DemoteFunc != nil {
+			rec.DemoteFunc = opts.DemoteFunc
+		}
 	}
 
 	return rec

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs the presubmit tests; it is started by prow for each PR.
+# For convenience, it can also be executed manually.
+# Running the script without parameters, or with the --all-tests
+# flag, causes all tests to be executed, in the right order.
+# Use the flags --build-tests, --unit-tests and --integration-tests
+# to run a specific set of tests.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Fix bug of probing the dispatcher for subscription readiness after dispatcher pods change.
- Backport of #487 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 A bug fix was back ported to the consolidated channel so that subscriptions becomes eventually ready even when dispatchers scale up or down. 

```