### PR TITLE
[WIP] Consolidated ch dispatcher restart when config changes

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
@@ -118,7 +118,7 @@ func makeEnv(args DispatcherArgs) []corev1.EnvVar {
 
 	if args.DispatcherScope == "namespace" {
 		vars = append(vars, corev1.EnvVar{
-			Name: "NAMESPACE",
+			Name: constants.NamespaceEnvKey,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "metadata.namespace",

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -34,4 +34,6 @@ const (
 
 	// The name of the keys in the Data section of the eventing-kafka configmap that holds Sarama and Eventing-Kafka configuration YAML
 	SaramaSettingsConfigKey = "sarama"
+
+	NamespaceEnvKey = "NAMESPACE"
 )


### PR DESCRIPTION
To be rebased: builds on top of https://github.com/knative-sandbox/eventing-kafka/pull/486

## Proposed Changes

-
-
-

Similar to https://github.com/knative-sandbox/eventing-kafka/pull/486, tested with https://github.com/aliok/kafka-ch-reload-tests

Things in that repo starts a receiver and a sender then records the messages in the receiver. Later, I change `config-kafka` and the dispatcher kills itself. A new one is created shortly after.

Here are the results:
```
sender:
-----------
tried to send 11748 messages
Success:11653
Errors:95

receiver:
----------------
11925 received
manual investigation: 272 received duplicates
manual investigation: unique received: 11653
```

So, there's some downtime and the sender cannot send the messages during that time.

How should we handle this?

I think I would see some downtime in distributed channel too which is doing on-the-fly reloading. Though, the duration would be shorter.


Alternatively, can we achieve this zero downtime with a proper rolling deployment? Like, trigger a rolling deployment of the dispatcher in the channel controller. Kube should handle the rest, right?
