### PR TITLE
MTAdapter update retrying

### DIFF
--- a/pkg/source/mtadapter/adapter_test.go
+++ b/pkg/source/mtadapter/adapter_test.go
@@ -63,7 +63,7 @@ func TestUpdateRemoveSources(t *testing.T) {
 		adapterStopped <- true
 	}()
 
-	adapter.Update(ctx, &sourcesv1beta1.KafkaSource{
+	err := adapter.Update(ctx, &sourcesv1beta1.KafkaSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-name",
 			Namespace: "test-ns",
@@ -76,6 +76,9 @@ func TestUpdateRemoveSources(t *testing.T) {
 				}},
 		},
 	})
+	if err != nil {
+		t.Fatalf("Updating MT source adapter failed with %v", err)
+	}
 
 	if _, ok := adapter.sources["test-ns/test-name"]; !ok {
 		t.Error(`Expected adapter to contain "test-ns/test-name"`)

--- a/pkg/source/mtadapter/controller.go
+++ b/pkg/source/mtadapter/controller.go
@@ -34,7 +34,7 @@ import (
 // MTAdapter is the interface the multi-tenant KafkaSource adapter must implement
 type MTAdapter interface {
 	// Update is called when the source is ready and when the specification and/or status has changed.
-	Update(ctx context.Context, source *v1beta1.KafkaSource)
+	Update(ctx context.Context, source *v1beta1.KafkaSource) (err error)
 
 	// Remove is called when the source has been deleted.
 	Remove(source *v1beta1.KafkaSource)

--- a/pkg/source/mtadapter/kafkasource.go
+++ b/pkg/source/mtadapter/kafkasource.go
@@ -40,8 +40,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1beta1.KafkaSou
 		return fmt.Errorf("warning: KafkaSource is not ready")
 	}
 
-	// Update the adapter state
-	r.mtadapter.Update(ctx, source)
+	// Update the adapter state; if it fails, return error for retrying reconciliation
+	err := r.mtadapter.Update(ctx, source)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes #469 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- MTAdapter Update() return errors if any, so that reconciling requeues source object and retries the update.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->



<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```



<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
