### PR TITLE
[MTSource] ST Adapter start returns error instead of panic

### DIFF
--- a/pkg/source/adapter/adapter.go
+++ b/pkg/source/adapter/adapter.go
@@ -104,7 +104,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 	consumerGroupFactory := consumer.NewConsumerGroupFactory(addrs, config)
 	group, err := consumerGroupFactory.StartConsumerGroup(a.config.ConsumerGroup, a.config.Topics, a.logger, a)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to start consumer group: %w", err)
 	}
 	defer func() {
 		err := group.Close()

--- a/pkg/source/adapter/adapter_test.go
+++ b/pkg/source/adapter/adapter_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/v2/types"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/source"
@@ -441,9 +440,9 @@ func TestAdapter_Start(t *testing.T) { // just increase code coverage
 	_ = os.Setenv("KAFKA_BOOTSTRAP_SERVERS", "my-cluster-kafka-bootstrap.my-kafka-namespace:9092")
 
 	a := NewAdapter(ctx, NewEnvConfig(), nil, nil)
-	require.Panics(t, func() {
-		_ = a.Start(ctx)
-	})
-
+	err := a.Start(ctx)
+	if err == nil {
+		t.Errorf("expected error, but got nil")
+	}
 	cancel()
 }


### PR DESCRIPTION
Signed-off-by: Ansu Varghese <avarghese@us.ibm.com>

Fixes #195

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- One line change to remove panic when kafka group cannot be started due to bootstrap server url, auth issues etc. Instead, an error is returned.
```
k get kafkasource (with MT adapter)
NAME            TOPICS         BOOTSTRAPSERVERS                                   READY   REASON   AGE
kafka-source    ["my-topic"]   ["my-cluster-kafka-bootstrap.kafka.svc:9092"]      True             6m25s
kafka-source1   ["my-topic"]   ["my-cluster-kafka-bootstrapppp.kafka.svc:9092"]   True             5m20s
kafka-source2   ["my-topic"]   ["my-cluster-kafka-bootstrap.kafka.svc:9092"]      True             69s
```

```
k get kafkasource (with ST adapter)
NAME            TOPICS         BOOTSTRAPSERVERS                                   READY   REASON   AGE
kafka-source    ["my-topic"]   ["my-cluster-kafka-bootstrap.kafka.svc:9092"]      True             6m25s
kafka-source1   ["my-topic"]   ["my-cluster-kafka-bootstrapppp.kafka.svc:9092"]   False   DeploymentUnavailable   19s
kafka-source2   ["my-topic"]   ["my-cluster-kafka-bootstrap.kafka.svc:9092"]      True             69s
```

ST adapter behavior - pod crashes for bad config
```
k get pods
kafkasource-kafka-source1-c82a8015-169f-4d09-9cd9-c0749200l5cf8   0/1     CrashLoopBackOff   5          5m34s
```

MT adapter behavior - pod does not crash letting other kafka sources to continue working
```
k get pods -n knative-eventing
kafka-controller-manager-f96fb5bb6-z45bm   1/1     Running   0          44m
kafkasource-mt-adapter-0                   1/1     Running   0          7m19s
```

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->


<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```


<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
