### PR TITLE
[Consolidated] Rewrote the dispatcher reconciler

### DIFF
--- a/pkg/channel/consolidated/dispatcher/config.go
+++ b/pkg/channel/consolidated/dispatcher/config.go
@@ -16,14 +16,17 @@ limitations under the License.
 
 package dispatcher
 
-type Config struct {
-	// The configuration of each channel in this handler.
-	ChannelConfigs []ChannelConfig
-}
-
 type ChannelConfig struct {
 	Namespace     string
 	Name          string
 	HostName      string
 	Subscriptions []Subscription
+}
+
+func (cc ChannelConfig) SubscriptionsUIDs() []string {
+	res := make([]string, 0, len(cc.Subscriptions))
+	for _, s := range cc.Subscriptions {
+		res = append(res, string(s.UID))
+	}
+	return res
 }

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -251,16 +251,19 @@ func (d *KafkaDispatcher) RegisterChannelHost(channelConfig *ChannelConfig) erro
 		Name:      channelConfig.Name,
 		Namespace: channelConfig.Namespace,
 	})
-	if ok && !(old.(eventingchannels.ChannelReference).Namespace == channelConfig.Namespace && old.(eventingchannels.ChannelReference).Name == channelConfig.Name) {
-		// If something is already there, but it's not the same channel, then fail
-		return fmt.Errorf(
-			"duplicate hostName found. Each channel must have a unique host header. HostName:%s, channel:%s.%s, channel:%s.%s",
-			channelConfig.HostName,
-			old.(eventingchannels.ChannelReference).Namespace,
-			old.(eventingchannels.ChannelReference).Name,
-			channelConfig.Namespace,
-			channelConfig.Name,
-		)
+	if ok {
+		oldChannelRef := old.(eventingchannels.ChannelReference)
+		if !(oldChannelRef.Namespace == channelConfig.Namespace && oldChannelRef.Name == channelConfig.Name) {
+			// If something is already there, but it's not the same channel, then fail
+			return fmt.Errorf(
+				"duplicate hostName found. Each channel must have a unique host header. HostName:%s, channel:%s.%s, channel:%s.%s",
+				channelConfig.HostName,
+				old.(eventingchannels.ChannelReference).Namespace,
+				old.(eventingchannels.ChannelReference).Name,
+				channelConfig.Namespace,
+				channelConfig.Name,
+			)
+		}
 	}
 	return nil
 }

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -251,7 +251,8 @@ func (d *KafkaDispatcher) RegisterChannelHost(channelConfig *ChannelConfig) erro
 		Name:      channelConfig.Name,
 		Namespace: channelConfig.Namespace,
 	})
-	if ok {
+	if ok && !(old.(eventingchannels.ChannelReference).Namespace == channelConfig.Namespace && old.(eventingchannels.ChannelReference).Name == channelConfig.Name) {
+		// If something is already there, but it's not the same channel, then fail
 		return fmt.Errorf(
 			"duplicate hostName found. Each channel must have a unique host header. HostName:%s, channel:%s.%s, channel:%s.%s",
 			channelConfig.HostName,

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -174,7 +174,7 @@ func (d *KafkaDispatcher) Start(ctx context.Context) error {
 type UpdateError map[types.UID]error
 
 func (k UpdateError) Error() string {
-	var errs []string
+	errs := make([]string, 0, len(k))
 	for uid, err := range k {
 		errs = append(errs, fmt.Sprintf("subscription %s: %v", uid, err))
 	}

--- a/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
@@ -78,7 +78,6 @@ func TestDispatcher(t *testing.T) {
 		ClientID:  "testing",
 		Brokers:   []string{"localhost:9092"},
 		TopicFunc: utils.TopicName,
-		Logger:    logger.Sugar(),
 	}
 
 	// Create the dispatcher. At this point, if Kafka is not up, this thing fails

--- a/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_it_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"knative.dev/eventing-kafka/pkg/common/constants"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -156,58 +158,46 @@ func TestDispatcher(t *testing.T) {
 	)
 
 	// send -> channela -> sub with transformationServer and reply to channelb -> channelb -> sub with receiver -> receiver
-	config := Config{
-		ChannelConfigs: []ChannelConfig{
+	channelAConfig := &ChannelConfig{
+		Namespace: "default",
+		Name:      "channela",
+		HostName:  "channela.svc",
+		Subscriptions: []Subscription{
 			{
-				Namespace: "default",
-				Name:      "channela",
-				HostName:  "channela.svc",
-				Subscriptions: []Subscription{
-					{
-						UID: "aaaa",
-						Subscription: fanout.Subscription{
-							Subscriber: mustParseUrl(t, transformationsServer.URL),
-							Reply:      mustParseUrl(t, channelBProxy.URL),
-						},
-					},
-					{
-						UID: "cccc",
-						Subscription: fanout.Subscription{
-							Subscriber: mustParseUrl(t, transformationsFailureServer.URL),
-							Reply:      mustParseUrl(t, channelBProxy.URL),
-							DeadLetter: mustParseUrl(t, deadLetterServer.URL),
-						},
-					},
+				UID: "aaaa",
+				Subscription: fanout.Subscription{
+					Subscriber: mustParseUrl(t, transformationsServer.URL),
+					Reply:      mustParseUrl(t, channelBProxy.URL),
 				},
 			},
 			{
-				Namespace: "default",
-				Name:      "channelb",
-				HostName:  "channelb.svc",
-				Subscriptions: []Subscription{
-					{
-						UID: "bbbb",
-						Subscription: fanout.Subscription{
-							Subscriber: mustParseUrl(t, receiverServer.URL),
-						},
-					},
+				UID: "cccc",
+				Subscription: fanout.Subscription{
+					Subscriber: mustParseUrl(t, transformationsFailureServer.URL),
+					Reply:      mustParseUrl(t, channelBProxy.URL),
+					DeadLetter: mustParseUrl(t, deadLetterServer.URL),
 				},
 			},
 		},
 	}
+	require.NoError(t, dispatcher.RegisterChannelHost(channelAConfig))
+	require.NoError(t, dispatcher.ReconcileConsumers(channelAConfig))
 
-	err = dispatcher.UpdateHostToChannelMap(&config)
-	if err != nil {
-		t.Fatal(err)
+	channelBConfig := &ChannelConfig{
+		Namespace: "default",
+		Name:      "channelb",
+		HostName:  "channelb.svc",
+		Subscriptions: []Subscription{
+			{
+				UID: "bbbb",
+				Subscription: fanout.Subscription{
+					Subscriber: mustParseUrl(t, receiverServer.URL),
+				},
+			},
+		},
 	}
-
-	failed, err := dispatcher.UpdateKafkaConsumers(&config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(failed) != 0 {
-		t.Fatal(err)
-	}
+	require.NoError(t, dispatcher.RegisterChannelHost(channelBConfig))
+	require.NoError(t, dispatcher.ReconcileConsumers(channelBConfig))
 
 	time.Sleep(5 * time.Second)
 
@@ -240,18 +230,8 @@ func TestDispatcher(t *testing.T) {
 	receiverWg.Wait()
 
 	// Try to close consumer groups
-	err = dispatcher.UpdateHostToChannelMap(&Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	failed, err = dispatcher.UpdateKafkaConsumers(&Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(failed) != 0 {
-		t.Fatal(err)
-	}
+	require.NoError(t, dispatcher.CleanupChannel("channela", "default", "channela.svc"))
+	require.NoError(t, dispatcher.CleanupChannel("channelb", "default", "channelb.svc"))
 }
 
 func createReverseProxy(t *testing.T, host string) *httputil.ReverseProxy {

--- a/pkg/channel/consolidated/dispatcher/dispatcher_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_test.go
@@ -110,6 +110,28 @@ func TestKafkaDispatcher_RegisterChannelHost(t *testing.T) {
 	require.Error(t, d.RegisterChannelHost(secondChannelConfig))
 }
 
+func TestKafkaDispatcher_RegisterSameChannelTwiceShouldNotFail(t *testing.T) {
+	channelConfig := &ChannelConfig{
+		Namespace: "default",
+		Name:      "test-channel-1",
+		HostName:  "a.b.c.d",
+	}
+
+	d := &KafkaDispatcher{
+		kafkaConsumerFactory: &mockKafkaConsumerFactory{},
+		channelSubscriptions: make(map[types.NamespacedName]*KafkaSubscription),
+		subsConsumerGroups:   make(map[types.UID]sarama.ConsumerGroup),
+		subscriptions:        make(map[types.UID]Subscription),
+		topicFunc:            utils.TopicName,
+		logger:               zaptest.NewLogger(t).Sugar(),
+	}
+
+	require.NoError(t, d.RegisterChannelHost(channelConfig))
+	require.Contains(t, d.getHostToChannelMap(), "a.b.c.d")
+	require.NoError(t, d.RegisterChannelHost(channelConfig))
+	require.Contains(t, d.getHostToChannelMap(), "a.b.c.d")
+}
+
 func TestDispatcher_UpdateConsumers(t *testing.T) {
 	subscriber, _ := url.Parse("http://test/subscriber")
 

--- a/pkg/channel/consolidated/dispatcher/dispatcher_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_test.go
@@ -455,6 +455,8 @@ func TestSubscribeError(t *testing.T) {
 		kafkaConsumerFactory: cf,
 		logger:               zap.NewNop().Sugar(),
 		topicFunc:            utils.TopicName,
+		subscriptions:        map[types.UID]Subscription{},
+		channelSubscriptions: map[types.NamespacedName]*KafkaSubscription{},
 	}
 
 	channelRef := types.NamespacedName{

--- a/pkg/channel/consolidated/dispatcher/dispatcher_test.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher_test.go
@@ -484,7 +484,6 @@ func TestNewDispatcher(t *testing.T) {
 		ClientID:  "kafka-ch-dispatcher",
 		Brokers:   []string{"localhost:10000"},
 		TopicFunc: utils.TopicName,
-		Logger:    nil,
 	}
 	_, err := NewDispatcher(context.TODO(), args)
 	if err == nil {

--- a/pkg/channel/consolidated/dispatcher/kafka_subscription.go
+++ b/pkg/channel/consolidated/dispatcher/kafka_subscription.go
@@ -27,10 +27,18 @@ import (
 
 type KafkaSubscription struct {
 	logger *zap.SugaredLogger
-	subs   []types.UID
+	subs   sets.String
 	// readySubscriptionsLock must be used to synchronize access to channelReadySubscriptions
 	readySubscriptionsLock    sync.RWMutex
 	channelReadySubscriptions map[string]sets.Int32
+}
+
+func NewKafkaSubscription(logger *zap.SugaredLogger) *KafkaSubscription {
+	return &KafkaSubscription{
+		logger:                    logger,
+		subs:                      sets.NewString(),
+		channelReadySubscriptions: map[string]sets.Int32{},
+	}
 }
 
 // SetReady will mark the subid in the KafkaSubscription and call any registered callbacks

--- a/pkg/channel/consolidated/dispatcher/subscription_endpoint.go
+++ b/pkg/channel/consolidated/dispatcher/subscription_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
-	eventingchannels "knative.dev/eventing/pkg/channel"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // subscriptionEndpoint is serving the subscription status of the Kafka channel.
@@ -29,7 +29,7 @@ func (d *subscriptionEndpoint) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Re
 		return
 	}
 	channelRefNamespace, channelRefName := uriSplit[1], uriSplit[2]
-	channelRef := eventingchannels.ChannelReference{
+	channelRef := types.NamespacedName{
 		Name:      channelRefName,
 		Namespace: channelRefNamespace,
 	}

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -171,10 +171,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel
 	}
 
 	// Update dispatcher side
-	failedSubscriptions := r.kafkaDispatcher.ReconcileConsumers(config)
-	if len(failedSubscriptions) > 0 {
-		logging.FromContext(ctx).Errorw("Some kafka subscriptions failed to subscribe", zap.Error(failedSubscriptions))
-		return fmt.Errorf("some kafka subscriptions failed to subscribe: %v", failedSubscriptions)
+	err := r.kafkaDispatcher.ReconcileConsumers(config)
+	if err != nil {
+		logging.FromContext(ctx).Errorw("Some kafka subscriptions failed to subscribe", zap.Error(err))
+		return fmt.Errorf("some kafka subscriptions failed to subscribe: %v", err)
 	}
 	return nil
 }

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -101,7 +101,6 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		KafkaAuthConfig:          kafkaAuthCfg,
 		SaramaSettingsYamlString: kafkaConfig.SaramaSettingsYamlString,
 		TopicFunc:                utils.TopicName,
-		Logger:                   logger,
 	}
 	kafkaDispatcher, err := dispatcher.NewDispatcher(ctx, args)
 	if err != nil {

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -127,7 +127,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	kafkaChannelInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: filterWithAnnotation(injection.HasNamespaceScope(ctx)),
-			Handler:    	cache.ResourceEventHandlerFuncs{
+			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc:    r.impl.Enqueue,
 				UpdateFunc: controller.PassNew(r.impl.Enqueue),
 				DeleteFunc: func(obj interface{}) {

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -155,7 +155,7 @@ func filterWithAnnotation(namespaced bool) func(obj interface{}) bool {
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel) pkgreconciler.Event {
-	logging.FromContext(ctx).Debugw("ObserveKind for channel", zap.String("channel", kc.Name))
+	logging.FromContext(ctx).Debugw("ReconcileKind for channel", zap.String("channel", kc.Name))
 	return r.syncChannel(ctx, kc)
 }
 

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -191,7 +191,7 @@ func (r *Reconciler) CleanupChannel(kc *v1beta1.KafkaChannel) pkgreconciler.Even
 	return r.kafkaDispatcher.CleanupChannel(kc.Name, kc.Namespace, kc.Status.Address.URL.Host)
 }
 
-// newConfigFromKafkaChannels creates a new Config from the list of kafka channels.
+// newConfigFromKafkaChannel creates a new Config from the list of kafka channels.
 func (r *Reconciler) newConfigFromKafkaChannel(c *v1beta1.KafkaChannel) *dispatcher.ChannelConfig {
 	channelConfig := dispatcher.ChannelConfig{
 		Namespace: c.Namespace,

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -157,6 +157,15 @@ func filterWithAnnotation(namespaced bool) func(obj interface{}) bool {
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, kc *v1beta1.KafkaChannel) pkgreconciler.Event {
 	logging.FromContext(ctx).Debugw("ObserveKind for channel", zap.String("channel", kc.Name))
+	return r.syncChannel(ctx, kc)
+}
+
+func (r *Reconciler) ObserveKind(ctx context.Context, kc *v1beta1.KafkaChannel) pkgreconciler.Event {
+	logging.FromContext(ctx).Debugw("ObserveKind for channel", zap.String("channel", kc.Name))
+	return r.syncChannel(ctx, kc)
+}
+
+func (r *Reconciler) syncChannel(ctx context.Context, kc *v1beta1.KafkaChannel) pkgreconciler.Event {
 	if !kc.Status.IsReady() {
 		logging.FromContext(ctx).Debugw("KafkaChannel still not ready, short-circuiting the reconciler", zap.String("channel", kc.Name))
 		return nil

--- a/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/dispatcher/kafkachannel.go
@@ -170,7 +170,7 @@ func (r *Reconciler) syncChannel(ctx context.Context, kc *v1beta1.KafkaChannel) 
 		return nil
 	}
 
-	config := r.newChannelConfigFromKafkaChannel(kc)
+	config := r.newConfigFromKafkaChannel(kc)
 
 	// Update receiver side
 	if err := r.kafkaDispatcher.RegisterChannelHost(config); err != nil {
@@ -192,7 +192,7 @@ func (r *Reconciler) CleanupChannel(kc *v1beta1.KafkaChannel) pkgreconciler.Even
 }
 
 // newConfigFromKafkaChannels creates a new Config from the list of kafka channels.
-func (r *Reconciler) newChannelConfigFromKafkaChannel(c *v1beta1.KafkaChannel) *dispatcher.ChannelConfig {
+func (r *Reconciler) newConfigFromKafkaChannel(c *v1beta1.KafkaChannel) *dispatcher.ChannelConfig {
 	channelConfig := dispatcher.ChannelConfig{
 		Namespace: c.Namespace,
 		Name:      c.Name,

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -461,8 +461,8 @@ function test_consolidated_channel_plain() {
   install_consolidated_channel_crds || return 1
   install_consolidated_sources_crds || return 1
 
-  go_test_e2e -tags=e2e,source -timeout=40m -test.parallel=${TEST_PARALLEL} ./test/e2e -channels=messaging.knative.dev/v1beta1:KafkaChannel  || fail_test
-  go_test_e2e -tags=e2e,source -timeout=5m -test.parallel=${TEST_PARALLEL} ./test/conformance -channels=messaging.knative.dev/v1beta1:KafkaChannel -sources=sources.knative.dev/v1beta1:KafkaSource || fail_test
+  go_test_e2e -v -tags=e2e,source -timeout=40m -test.parallel=${TEST_PARALLEL} ./test/e2e -channels=messaging.knative.dev/v1beta1:KafkaChannel  || fail_test
+  go_test_e2e -v -tags=e2e,source -timeout=5m -test.parallel=${TEST_PARALLEL} ./test/conformance -channels=messaging.knative.dev/v1beta1:KafkaChannel -sources=sources.knative.dev/v1beta1:KafkaSource || fail_test
 
   uninstall_sources_crds || return 1
   uninstall_channel_crds || return 1

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -461,8 +461,8 @@ function test_consolidated_channel_plain() {
   install_consolidated_channel_crds || return 1
   install_consolidated_sources_crds || return 1
 
-  go_test_e2e -v -tags=e2e,source -timeout=40m -test.parallel=${TEST_PARALLEL} ./test/e2e -channels=messaging.knative.dev/v1beta1:KafkaChannel  || fail_test
-  go_test_e2e -v -tags=e2e,source -timeout=5m -test.parallel=${TEST_PARALLEL} ./test/conformance -channels=messaging.knative.dev/v1beta1:KafkaChannel -sources=sources.knative.dev/v1beta1:KafkaSource || fail_test
+  go_test_e2e -tags=e2e,source -timeout=40m -test.parallel=${TEST_PARALLEL} ./test/e2e -channels=messaging.knative.dev/v1beta1:KafkaChannel  || fail_test
+  go_test_e2e -tags=e2e,source -timeout=5m -test.parallel=${TEST_PARALLEL} ./test/conformance -channels=messaging.knative.dev/v1beta1:KafkaChannel -sources=sources.knative.dev/v1beta1:KafkaSource || fail_test
 
   uninstall_sources_crds || return 1
   uninstall_channel_crds || return 1


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fix #245

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: Now we reconcile one channel at the time, more than doing a global resync every time
- :broom: Removed some bad concurrency patterns on the hot path
- :broom: Implemented CleanupChannel in dispatcher
