### PR TITLE
[Consolidated] Pass ServiceAccount to use in consolidated channel via an env var

### DIFF
--- a/config/channel/consolidated/deployments/controller.yaml
+++ b/config/channel/consolidated/deployments/controller.yaml
@@ -50,6 +50,10 @@ spec:
           value: config-leader-election
         - name: DISPATCHER_IMAGE
           value: ko://knative.dev/eventing-kafka/cmd/channel/consolidated/dispatcher
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: kafka-ch-dispatcher
         ports:
         - containerPort: 9090
           name: metrics

--- a/config/channel/consolidated/deployments/controller.yaml
+++ b/config/channel/consolidated/deployments/controller.yaml
@@ -51,9 +51,7 @@ spec:
         - name: DISPATCHER_IMAGE
           value: ko://knative.dev/eventing-kafka/cmd/channel/consolidated/dispatcher
         - name: SERVICE_ACCOUNT
-          valueFrom:
-            fieldRef:
-              fieldPath: kafka-ch-dispatcher
+          value: kafka-ch-dispatcher
         ports:
         - containerPort: 9090
           name: metrics

--- a/config/channel/consolidated/deployments/controller.yaml
+++ b/config/channel/consolidated/deployments/controller.yaml
@@ -50,6 +50,7 @@ spec:
           value: config-leader-election
         - name: DISPATCHER_IMAGE
           value: ko://knative.dev/eventing-kafka/cmd/channel/consolidated/dispatcher
+        # service account used in the dispatcher
         - name: SERVICE_ACCOUNT
           value: kafka-ch-dispatcher
         ports:

--- a/pkg/channel/consolidated/reconciler/controller/controller.go
+++ b/pkg/channel/consolidated/reconciler/controller/controller.go
@@ -89,11 +89,8 @@ func NewController(
 		logger.Panicf("unable to process Kafka channel's required environment variables: %v", err)
 	}
 
-	if env.Image == "" {
-		logger.Panic("unable to process Kafka channel's required environment variables (missing DISPATCHER_IMAGE)")
-	}
-
 	r.dispatcherImage = env.Image
+	r.serviceAccount = env.ServiceAccount
 
 	impl := kafkaChannelReconciler.NewImpl(ctx, r)
 

--- a/pkg/channel/consolidated/reconciler/controller/controller.go
+++ b/pkg/channel/consolidated/reconciler/controller/controller.go
@@ -90,7 +90,7 @@ func NewController(
 	}
 
 	r.dispatcherImage = env.Image
-	r.serviceAccount = env.ServiceAccount
+	r.dispatcherServiceAccount = env.DispatcherServiceAccount
 
 	impl := kafkaChannelReconciler.NewImpl(ctx, r)
 

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -112,9 +112,9 @@ type Reconciler struct {
 
 	EventingClientSet eventingclientset.Interface
 
-	systemNamespace string
-	dispatcherImage string
-	serviceAccount  string
+	systemNamespace          string
+	dispatcherImage          string
+	dispatcherServiceAccount string
 
 	kafkaConfig      *utils.KafkaConfig
 	kafkaAuthConfig  *client.KafkaAuthConfig
@@ -134,8 +134,8 @@ type Reconciler struct {
 }
 
 type envConfig struct {
-	Image          string `envconfig:"DISPATCHER_IMAGE" required:"true"`
-	ServiceAccount string `envconfig:"SERVICE_ACCOUNT" required:"true"`
+	Image                    string `envconfig:"DISPATCHER_IMAGE" required:"true"`
+	DispatcherServiceAccount string `envconfig:"SERVICE_ACCOUNT" required:"true"`
 }
 
 // Check that our Reconciler implements kafka's injection Interface
@@ -309,7 +309,7 @@ func (r *Reconciler) reconcileDispatcher(ctx context.Context, scope string, disp
 		DispatcherNamespace: dispatcherNamespace,
 		Image:               r.dispatcherImage,
 		Replicas:            1,
-		ServiceAccount:      r.serviceAccount,
+		ServiceAccount:      r.dispatcherServiceAccount,
 	}
 
 	expected := resources.MakeDispatcher(args)

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -114,6 +114,7 @@ type Reconciler struct {
 
 	systemNamespace string
 	dispatcherImage string
+	serviceAccount  string
 
 	kafkaConfig      *utils.KafkaConfig
 	kafkaAuthConfig  *client.KafkaAuthConfig
@@ -133,7 +134,8 @@ type Reconciler struct {
 }
 
 type envConfig struct {
-	Image string `envconfig:"DISPATCHER_IMAGE" required:"true"`
+	Image          string `envconfig:"DISPATCHER_IMAGE" required:"true"`
+	ServiceAccount string `envconfig:"SERVICE_ACCOUNT" required:"true"`
 }
 
 // Check that our Reconciler implements kafka's injection Interface
@@ -307,6 +309,7 @@ func (r *Reconciler) reconcileDispatcher(ctx context.Context, scope string, disp
 		DispatcherNamespace: dispatcherNamespace,
 		Image:               r.dispatcherImage,
 		Replicas:            1,
+		ServiceAccount:      r.serviceAccount,
 	}
 
 	expected := resources.MakeDispatcher(args)

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -330,6 +330,7 @@ func TestAllCases(t *testing.T) {
 		r := &Reconciler{
 			systemNamespace: testNS,
 			dispatcherImage: testDispatcherImage,
+			serviceAccount:  serviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -393,6 +394,7 @@ func TestTopicExists(t *testing.T) {
 		r := &Reconciler{
 			systemNamespace: testNS,
 			dispatcherImage: testDispatcherImage,
+			serviceAccount:  serviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -468,6 +470,7 @@ func TestDeploymentUpdatedOnImageChange(t *testing.T) {
 		r := &Reconciler{
 			systemNamespace: testNS,
 			dispatcherImage: testDispatcherImage,
+			serviceAccount:  serviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -543,6 +546,7 @@ func TestDeploymentZeroReplicas(t *testing.T) {
 		r := &Reconciler{
 			systemNamespace: testNS,
 			dispatcherImage: testDispatcherImage,
+			serviceAccount:  serviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -615,6 +619,7 @@ func TestDeploymentMoreThanOneReplicas(t *testing.T) {
 		r := &Reconciler{
 			systemNamespace: testNS,
 			dispatcherImage: testDispatcherImage,
+			serviceAccount:  serviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -51,6 +51,7 @@ import (
 
 const (
 	testNS                = "test-namespace"
+	serviceAccount        = "kafka-ch-dispatcher"
 	kcName                = "test-kc"
 	testDispatcherImage   = "test-image"
 	channelServiceAddress = "test-kc-kn-channel.test-namespace.svc.cluster.local"
@@ -749,6 +750,7 @@ func makeDeploymentWithImageAndReplicas(image string, replicas int32) *appsv1.De
 		DispatcherNamespace: testNS,
 		Image:               image,
 		Replicas:            replicas,
+		ServiceAccount:      serviceAccount,
 	})
 }
 

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -50,16 +50,16 @@ import (
 )
 
 const (
-	testNS                = "test-namespace"
-	serviceAccount        = "kafka-ch-dispatcher"
-	kcName                = "test-kc"
-	testDispatcherImage   = "test-image"
-	channelServiceAddress = "test-kc-kn-channel.test-namespace.svc.cluster.local"
-	brokerName            = "test-broker"
-	finalizerName         = "kafkachannels.messaging.knative.dev"
-	sub1UID               = "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1"
-	sub2UID               = "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1"
-	twoSubscribersPatch   = `[{"op":"add","path":"/status/subscribers","value":[{"observedGeneration":1,"ready":"True","uid":"2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1"},{"observedGeneration":2,"ready":"True","uid":"34c5aec8-deb6-11e8-9f32-f2801f1b9fd1"}]}]`
+	testNS                       = "test-namespace"
+	testDispatcherserviceAccount = "kafka-ch-dispatcher"
+	kcName                       = "test-kc"
+	testDispatcherImage          = "test-image"
+	channelServiceAddress        = "test-kc-kn-channel.test-namespace.svc.cluster.local"
+	brokerName                   = "test-broker"
+	finalizerName                = "kafkachannels.messaging.knative.dev"
+	sub1UID                      = "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1"
+	sub2UID                      = "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1"
+	twoSubscribersPatch          = `[{"op":"add","path":"/status/subscribers","value":[{"observedGeneration":1,"ready":"True","uid":"2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1"},{"observedGeneration":2,"ready":"True","uid":"34c5aec8-deb6-11e8-9f32-f2801f1b9fd1"}]}]`
 )
 
 var (
@@ -328,9 +328,9 @@ func TestAllCases(t *testing.T) {
 	table.Test(t, reconcilertesting.MakeFactory(func(ctx context.Context, listers *reconcilertesting.Listers, cmw configmap.Watcher) controller.Reconciler {
 
 		r := &Reconciler{
-			systemNamespace: testNS,
-			dispatcherImage: testDispatcherImage,
-			serviceAccount:  serviceAccount,
+			systemNamespace:          testNS,
+			dispatcherImage:          testDispatcherImage,
+			dispatcherServiceAccount: testDispatcherserviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -392,9 +392,9 @@ func TestTopicExists(t *testing.T) {
 	row.Test(t, reconcilertesting.MakeFactory(func(ctx context.Context, listers *reconcilertesting.Listers, cmw configmap.Watcher) controller.Reconciler {
 
 		r := &Reconciler{
-			systemNamespace: testNS,
-			dispatcherImage: testDispatcherImage,
-			serviceAccount:  serviceAccount,
+			systemNamespace:          testNS,
+			dispatcherImage:          testDispatcherImage,
+			dispatcherServiceAccount: testDispatcherserviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -468,9 +468,9 @@ func TestDeploymentUpdatedOnImageChange(t *testing.T) {
 	row.Test(t, reconcilertesting.MakeFactory(func(ctx context.Context, listers *reconcilertesting.Listers, cmw configmap.Watcher) controller.Reconciler {
 
 		r := &Reconciler{
-			systemNamespace: testNS,
-			dispatcherImage: testDispatcherImage,
-			serviceAccount:  serviceAccount,
+			systemNamespace:          testNS,
+			dispatcherImage:          testDispatcherImage,
+			dispatcherServiceAccount: testDispatcherserviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -544,9 +544,9 @@ func TestDeploymentZeroReplicas(t *testing.T) {
 	row.Test(t, reconcilertesting.MakeFactory(func(ctx context.Context, listers *reconcilertesting.Listers, cmw configmap.Watcher) controller.Reconciler {
 
 		r := &Reconciler{
-			systemNamespace: testNS,
-			dispatcherImage: testDispatcherImage,
-			serviceAccount:  serviceAccount,
+			systemNamespace:          testNS,
+			dispatcherImage:          testDispatcherImage,
+			dispatcherServiceAccount: testDispatcherserviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -617,9 +617,9 @@ func TestDeploymentMoreThanOneReplicas(t *testing.T) {
 	row.Test(t, reconcilertesting.MakeFactory(func(ctx context.Context, listers *reconcilertesting.Listers, cmw configmap.Watcher) controller.Reconciler {
 
 		r := &Reconciler{
-			systemNamespace: testNS,
-			dispatcherImage: testDispatcherImage,
-			serviceAccount:  serviceAccount,
+			systemNamespace:          testNS,
+			dispatcherImage:          testDispatcherImage,
+			dispatcherServiceAccount: testDispatcherserviceAccount,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -755,7 +755,7 @@ func makeDeploymentWithImageAndReplicas(image string, replicas int32) *appsv1.De
 		DispatcherNamespace: testNS,
 		Image:               image,
 		Replicas:            replicas,
-		ServiceAccount:      serviceAccount,
+		ServiceAccount:      testDispatcherserviceAccount,
 	})
 }
 

--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
@@ -27,9 +27,8 @@ import (
 const DispatcherContainerName = "dispatcher"
 
 var (
-	serviceAccountName = "kafka-ch-dispatcher"
-	dispatcherName     = "kafka-ch-dispatcher"
-	dispatcherLabels   = map[string]string{
+	dispatcherName   = "kafka-ch-dispatcher"
+	dispatcherLabels = map[string]string{
 		"messaging.knative.dev/channel": "kafka-channel",
 		"messaging.knative.dev/role":    "dispatcher",
 	}
@@ -40,6 +39,7 @@ type DispatcherArgs struct {
 	DispatcherNamespace string
 	Image               string
 	Replicas            int32
+	ServiceAccount      string
 }
 
 // MakeDispatcher generates the dispatcher deployment for the KafKa channel
@@ -65,7 +65,7 @@ func MakeDispatcher(args DispatcherArgs) *v1.Deployment {
 					Labels: dispatcherLabels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: serviceAccountName,
+					ServiceAccountName: args.ServiceAccount,
 					Containers: []corev1.Container{
 						{
 							Name:  DispatcherContainerName,

--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	imageName = "my-test-image"
+	imageName      = "my-test-image"
+	serviceAccount = "kafka-ch-dispatcher"
 )
 
 func TestNewDispatcher(t *testing.T) {
@@ -39,6 +40,7 @@ func TestNewDispatcher(t *testing.T) {
 		DispatcherNamespace: testNS,
 		Image:               imageName,
 		Replicas:            1,
+		ServiceAccount:      serviceAccount,
 	}
 
 	replicas := int32(1)
@@ -61,7 +63,7 @@ func TestNewDispatcher(t *testing.T) {
 					Labels: dispatcherLabels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: serviceAccountName,
+					ServiceAccountName: serviceAccount,
 					Containers: []corev1.Container{
 						{
 							Name:  "dispatcher",
@@ -121,6 +123,7 @@ func TestNewNamespaceDispatcher(t *testing.T) {
 		DispatcherNamespace: testNS,
 		Image:               imageName,
 		Replicas:            1,
+		ServiceAccount:      serviceAccount,
 	}
 
 	replicas := int32(1)
@@ -143,7 +146,7 @@ func TestNewNamespaceDispatcher(t *testing.T) {
 					Labels: dispatcherLabels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: serviceAccountName,
+					ServiceAccountName: serviceAccount,
 					Containers: []corev1.Container{
 						{
 							Name:  "dispatcher",

--- a/pkg/channel/consolidated/reconciler/controller/resources/role_binding_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/role_binding_test.go
@@ -44,12 +44,12 @@ func TestNewRoleBinding(t *testing.T) {
 			{
 				Kind:      "ServiceAccount",
 				Namespace: testNS,
-				Name:      serviceAccountName,
+				Name:      serviceAccount,
 			},
 		},
 	}
 
-	sa := MakeServiceAccount(testNS, serviceAccountName)
+	sa := MakeServiceAccount(testNS, serviceAccount)
 	got := MakeRoleBinding(testNS, rbName, sa, crName)
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/pkg/channel/consolidated/reconciler/controller/resources/service_account_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/service_account_test.go
@@ -28,11 +28,11 @@ func TestNewServiceAccount(t *testing.T) {
 	want := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNS,
-			Name:      serviceAccountName,
+			Name:      serviceAccount,
 		},
 	}
 
-	got := MakeServiceAccount(testNS, serviceAccountName)
+	got := MakeServiceAccount(testNS, serviceAccount)
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected condition (-want, +got) = %v", diff)


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Pass ServiceAccount to use in consolidated channel via an env var
- This is done that way in distributed channel
- Currently, the value of the env var is set to previously hardcoded value

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
