### PR TITLE
[consolidated] Rolling deployment dispatcher on configmap change

### DIFF
--- a/config/channel/consolidated/deployments/dispatcher.yaml
+++ b/config/channel/consolidated/deployments/dispatcher.yaml
@@ -29,6 +29,8 @@ spec:
       messaging.knative.dev/role: dispatcher
   template:
     metadata:
+      annotations:
+        ConfigMapHash: ''
       labels:
         # Do not change. Used by the controller for probing.
         messaging.knative.dev/channel: kafka-channel

--- a/config/channel/consolidated/deployments/dispatcher.yaml
+++ b/config/channel/consolidated/deployments/dispatcher.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        ConfigMapHash: ''
+        kafka.eventing.knative.dev/configmap-hash: ''
       labels:
         # Do not change. Used by the controller for probing.
         messaging.knative.dev/channel: kafka-channel

--- a/config/channel/consolidated/deployments/dispatcher.yaml
+++ b/config/channel/consolidated/deployments/dispatcher.yaml
@@ -30,6 +30,8 @@ spec:
   template:
     metadata:
       annotations:
+        # This annotation is used by the controller to track updates
+        # to config-kafka and apply them in the dispatcher deployment
         kafka.eventing.knative.dev/configmap-hash: ''
       labels:
         # Do not change. Used by the controller for probing.

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -582,8 +582,7 @@ func (r *Reconciler) updateKafkaConfig(ctx context.Context, configMap *corev1.Co
 	// Eventually the previous config should be snapshotted to delete Kafka topics
 	r.kafkaConfig = kafkaConfig
 	r.kafkaConfigError = err
-	configMapDataStr := fmt.Sprintf("%v", configMap.Data)
-	r.kafkaConfigMapHash = fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(configMapDataStr)))
+	r.kafkaConfigMapHash = configmapDataCheckSum(configMap)
 
 	if err != nil {
 		logger.Errorw("Error creating AdminClient", zap.Error(err))
@@ -612,4 +611,10 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, kc *v1beta1.KafkaChannel)
 		r.statusManager.CancelProbing(s)
 	}
 	return newReconciledNormal(kc.Namespace, kc.Name) //ok to remove finalizer
+}
+
+func configmapDataCheckSum(configMap *corev1.ConfigMap) string {
+	configMapDataStr := fmt.Sprintf("%v", configMap.Data)
+	checksum := fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(configMapDataStr)))
+	return checksum
 }

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -614,6 +614,9 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, kc *v1beta1.KafkaChannel)
 }
 
 func configmapDataCheckSum(configMap *corev1.ConfigMap) string {
+	if configMap == nil || configMap.Data == nil {
+		return ""
+	}
 	configMapDataStr := fmt.Sprintf("%v", configMap.Data)
 	checksum := fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(configMapDataStr)))
 	return checksum

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -19,10 +19,10 @@ package controller
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"testing"
 
 	"github.com/Shopify/sarama"
+	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -52,6 +52,7 @@ import (
 const (
 	testNS                       = "test-namespace"
 	testDispatcherserviceAccount = "kafka-ch-dispatcher"
+	testConfigMapHash            = "deadbeef"
 	kcName                       = "test-kc"
 	testDispatcherImage          = "test-image"
 	channelServiceAddress        = "test-kc-kn-channel.test-namespace.svc.cluster.local"
@@ -331,6 +332,7 @@ func TestAllCases(t *testing.T) {
 			systemNamespace:          testNS,
 			dispatcherImage:          testDispatcherImage,
 			dispatcherServiceAccount: testDispatcherserviceAccount,
+			kafkaConfigMapHash:       testConfigMapHash,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -395,6 +397,7 @@ func TestTopicExists(t *testing.T) {
 			systemNamespace:          testNS,
 			dispatcherImage:          testDispatcherImage,
 			dispatcherServiceAccount: testDispatcherserviceAccount,
+			kafkaConfigMapHash:       testConfigMapHash,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -471,6 +474,7 @@ func TestDeploymentUpdatedOnImageChange(t *testing.T) {
 			systemNamespace:          testNS,
 			dispatcherImage:          testDispatcherImage,
 			dispatcherServiceAccount: testDispatcherserviceAccount,
+			kafkaConfigMapHash:       testConfigMapHash,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -547,6 +551,7 @@ func TestDeploymentZeroReplicas(t *testing.T) {
 			systemNamespace:          testNS,
 			dispatcherImage:          testDispatcherImage,
 			dispatcherServiceAccount: testDispatcherserviceAccount,
+			kafkaConfigMapHash:       testConfigMapHash,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -620,6 +625,84 @@ func TestDeploymentMoreThanOneReplicas(t *testing.T) {
 			systemNamespace:          testNS,
 			dispatcherImage:          testDispatcherImage,
 			dispatcherServiceAccount: testDispatcherserviceAccount,
+			kafkaConfigMapHash:       testConfigMapHash,
+			kafkaConfig: &KafkaConfig{
+				Brokers: []string{brokerName},
+			},
+			kafkachannelLister: listers.GetKafkaChannelLister(),
+			// TODO fix
+			kafkachannelInformer: nil,
+			deploymentLister:     listers.GetDeploymentLister(),
+			serviceLister:        listers.GetServiceLister(),
+			endpointsLister:      listers.GetEndpointsLister(),
+			kafkaClusterAdmin: &mockClusterAdmin{
+				mockCreateTopicFunc: func(topic string, detail *sarama.TopicDetail, validateOnly bool) error {
+					errMsg := sarama.ErrTopicAlreadyExists.Error()
+					return &sarama.TopicError{
+						Err:    sarama.ErrTopicAlreadyExists,
+						ErrMsg: &errMsg,
+					}
+				},
+			},
+			kafkaClientSet:    fakekafkaclient.Get(ctx),
+			KubeClientSet:     kubeclient.Get(ctx),
+			EventingClientSet: eventingClient.Get(ctx),
+			statusManager: &fakeStatusManager{
+				FakeIsReady: func(ctx context.Context, channel v1beta1.KafkaChannel,
+					spec eventingduckv1.SubscriberSpec) (bool, error) {
+					return true, nil
+				},
+			},
+		}
+		return kafkachannel.NewReconciler(ctx, logging.FromContext(ctx), r.kafkaClientSet, listers.GetKafkaChannelLister(), controller.GetEventRecorder(ctx), r)
+	}, zap.L()))
+}
+
+func TestDeploymentUpdatedOnConfigMapHashChange(t *testing.T) {
+	kcKey := testNS + "/" + kcName
+	row := TableRow{
+		Name: "Works, topic already exists",
+		Key:  kcKey,
+		Objects: []runtime.Object{
+			makeDeploymentWithConfigMapHash("toBeUpdated"),
+			makeService(),
+			makeReadyEndpoints(),
+			reconcilertesting.NewKafkaChannel(kcName, testNS,
+				reconcilertesting.WithKafkaFinalizer(finalizerName)),
+		},
+		WantErr: false,
+		WantCreates: []runtime.Object{
+			makeChannelService(reconcilertesting.NewKafkaChannel(kcName, testNS)),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: makeDeploymentWithConfigMapHash(testConfigMapHash),
+		}},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: reconcilertesting.NewKafkaChannel(kcName, testNS,
+				reconcilertesting.WithInitKafkaChannelConditions,
+				reconcilertesting.WithKafkaFinalizer(finalizerName),
+				reconcilertesting.WithKafkaChannelConfigReady(),
+				reconcilertesting.WithKafkaChannelTopicReady(),
+				//				reconcilekafkatesting.WithKafkaChannelDeploymentReady(),
+				reconcilertesting.WithKafkaChannelServiceReady(),
+				reconcilertesting.WithKafkaChannelEndpointsReady(),
+				reconcilertesting.WithKafkaChannelChannelServiceReady(),
+				reconcilertesting.WithKafkaChannelAddress(channelServiceAddress),
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, dispatcherDeploymentUpdated, "Dispatcher deployment updated"),
+			Eventf(corev1.EventTypeNormal, "KafkaChannelReconciled", `KafkaChannel reconciled: "test-namespace/test-kc"`),
+		},
+	}
+
+	row.Test(t, reconcilertesting.MakeFactory(func(ctx context.Context, listers *reconcilertesting.Listers, cmw configmap.Watcher) controller.Reconciler {
+
+		r := &Reconciler{
+			systemNamespace:          testNS,
+			dispatcherImage:          testDispatcherImage,
+			dispatcherServiceAccount: testDispatcherserviceAccount,
+			kafkaConfigMapHash:       testConfigMapHash,
 			kafkaConfig: &KafkaConfig{
 				Brokers: []string{brokerName},
 			},
@@ -750,14 +833,22 @@ func (ca *mockClusterAdmin) DeleteConsumerGroup(group string) error {
 
 var _ sarama.ClusterAdmin = (*mockClusterAdmin)(nil)
 
-func makeDeploymentWithImageAndReplicas(image string, replicas int32) *appsv1.Deployment {
+func makeDeploymentWithImageAndReplicasAndConfigMapHash(image string, replicas int32, configMapHash string) *appsv1.Deployment {
 	return resources.MakeDispatcher(resources.DispatcherArgs{
 		DispatcherNamespace: testNS,
 		Image:               image,
 		Replicas:            replicas,
 		ServiceAccount:      testDispatcherserviceAccount,
-		ConfigMapHash:       "",
+		ConfigMapHash:       configMapHash,
 	})
+}
+
+func makeDeploymentWithImageAndReplicas(image string, replicas int32) *appsv1.Deployment {
+	return makeDeploymentWithImageAndReplicasAndConfigMapHash(image, replicas, testConfigMapHash)
+}
+
+func makeDeploymentWithConfigMapHash(configMapHash string) *appsv1.Deployment {
+	return makeDeploymentWithImageAndReplicasAndConfigMapHash(testDispatcherImage, 1, configMapHash)
 }
 
 func makeDeployment() *appsv1.Deployment {

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -661,7 +661,7 @@ func TestDeploymentMoreThanOneReplicas(t *testing.T) {
 func TestDeploymentUpdatedOnConfigMapHashChange(t *testing.T) {
 	kcKey := testNS + "/" + kcName
 	row := TableRow{
-		Name: "Works, topic already exists",
+		Name: "ConfigMapHashChange",
 		Key:  kcKey,
 		Objects: []runtime.Object{
 			makeDeploymentWithConfigMapHash("toBeUpdated"),
@@ -833,7 +833,7 @@ func (ca *mockClusterAdmin) DeleteConsumerGroup(group string) error {
 
 var _ sarama.ClusterAdmin = (*mockClusterAdmin)(nil)
 
-func makeDeploymentWithImageAndReplicasAndConfigMapHash(image string, replicas int32, configMapHash string) *appsv1.Deployment {
+func makeDeploymentWithParams(image string, replicas int32, configMapHash string) *appsv1.Deployment {
 	return resources.MakeDispatcher(resources.DispatcherArgs{
 		DispatcherNamespace: testNS,
 		Image:               image,
@@ -844,11 +844,11 @@ func makeDeploymentWithImageAndReplicasAndConfigMapHash(image string, replicas i
 }
 
 func makeDeploymentWithImageAndReplicas(image string, replicas int32) *appsv1.Deployment {
-	return makeDeploymentWithImageAndReplicasAndConfigMapHash(image, replicas, testConfigMapHash)
+	return makeDeploymentWithParams(image, replicas, testConfigMapHash)
 }
 
 func makeDeploymentWithConfigMapHash(configMapHash string) *appsv1.Deployment {
-	return makeDeploymentWithImageAndReplicasAndConfigMapHash(testDispatcherImage, 1, configMapHash)
+	return makeDeploymentWithParams(testDispatcherImage, 1, configMapHash)
 }
 
 func makeDeployment() *appsv1.Deployment {

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"testing"
 
 	"github.com/Shopify/sarama"
@@ -974,5 +975,38 @@ func makePatch(namespace, name, patch string) clientgotesting.PatchActionImpl {
 		},
 		Name:  name,
 		Patch: []byte(patch),
+	}
+}
+
+func TestConfigmapDataCheckSum(t *testing.T) {
+	cases := []struct {
+		name      string
+		configmap *corev1.ConfigMap
+		expected  string
+	}{{
+		name:      "nil configmap",
+		configmap: nil,
+		expected:  "",
+	}, {
+		name: "nil configmap data",
+		configmap: &corev1.ConfigMap{
+			Data: nil,
+		},
+		expected: "",
+	}, {
+		name: "with configmap data",
+		configmap: &corev1.ConfigMap{
+			Data: map[string]string{"foo": "bar"},
+		},
+		expected: "f39c9878", // precomputed manually
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			retrieved := configmapDataCheckSum(tc.configmap)
+			if diff := cmp.Diff(tc.expected, retrieved); diff != "" {
+				t.Errorf("unexpected Config (-want, +got) = %v", diff)
+			}
+		})
 	}
 }

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -756,7 +756,7 @@ func makeDeploymentWithImageAndReplicas(image string, replicas int32) *appsv1.De
 		Image:               image,
 		Replicas:            replicas,
 		ServiceAccount:      testDispatcherserviceAccount,
-		ConfigMapHash:       "deadbeef",
+		ConfigMapHash:       "",
 	})
 }
 

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -756,6 +756,7 @@ func makeDeploymentWithImageAndReplicas(image string, replicas int32) *appsv1.De
 		Image:               image,
 		Replicas:            replicas,
 		ServiceAccount:      testDispatcherserviceAccount,
+		ConfigMapHash:       "deadbeef",
 	})
 }
 

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel_test.go
@@ -662,7 +662,7 @@ func TestDeploymentMoreThanOneReplicas(t *testing.T) {
 func TestDeploymentUpdatedOnConfigMapHashChange(t *testing.T) {
 	kcKey := testNS + "/" + kcName
 	row := TableRow{
-		Name: "ConfigMapHashChange",
+		Name: "ConfigMap hash changed, dispatcher updated",
 		Key:  kcKey,
 		Objects: []runtime.Object{
 			makeDeploymentWithConfigMapHash("toBeUpdated"),

--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	DispatcherContainerName    = "dispatcher"
-	ConfigMapHashAnnotationKey = "ConfigMapHash"
+	ConfigMapHashAnnotationKey = "kafka.eventing.knative.dev/configmap-hash"
 )
 
 var (

--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher.go
@@ -24,7 +24,10 @@ import (
 	"knative.dev/pkg/system"
 )
 
-const DispatcherContainerName = "dispatcher"
+const (
+	DispatcherContainerName    = "dispatcher"
+	ConfigMapHashAnnotationKey = "ConfigMapHash"
+)
 
 var (
 	dispatcherName   = "kafka-ch-dispatcher"
@@ -40,6 +43,7 @@ type DispatcherArgs struct {
 	Image               string
 	Replicas            int32
 	ServiceAccount      string
+	ConfigMapHash       string
 }
 
 // MakeDispatcher generates the dispatcher deployment for the KafKa channel
@@ -63,6 +67,9 @@ func MakeDispatcher(args DispatcherArgs) *v1.Deployment {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: dispatcherLabels,
+					Annotations: map[string]string{
+						ConfigMapHashAnnotationKey: args.ConfigMapHash,
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: args.ServiceAccount,

--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher_test.go
@@ -41,6 +41,7 @@ func TestNewDispatcher(t *testing.T) {
 		Image:               imageName,
 		Replicas:            1,
 		ServiceAccount:      serviceAccount,
+		ConfigMapHash:       "deadbeef",
 	}
 
 	replicas := int32(1)
@@ -124,6 +125,7 @@ func TestNewNamespaceDispatcher(t *testing.T) {
 		Image:               imageName,
 		Replicas:            1,
 		ServiceAccount:      serviceAccount,
+		ConfigMapHash:       "deadbeef",
 	}
 
 	replicas := int32(1)

--- a/pkg/channel/consolidated/reconciler/controller/resources/dispatcher_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/dispatcher_test.go
@@ -41,7 +41,7 @@ func TestNewDispatcher(t *testing.T) {
 		Image:               imageName,
 		Replicas:            1,
 		ServiceAccount:      serviceAccount,
-		ConfigMapHash:       "deadbeef",
+		ConfigMapHash:       testConfigMapHash,
 	}
 
 	replicas := int32(1)
@@ -62,6 +62,9 @@ func TestNewDispatcher(t *testing.T) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: dispatcherLabels,
+					Annotations: map[string]string{
+						ConfigMapHashAnnotationKey: testConfigMapHash,
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccount,
@@ -125,7 +128,7 @@ func TestNewNamespaceDispatcher(t *testing.T) {
 		Image:               imageName,
 		Replicas:            1,
 		ServiceAccount:      serviceAccount,
-		ConfigMapHash:       "deadbeef",
+		ConfigMapHash:       testConfigMapHash,
 	}
 
 	replicas := int32(1)
@@ -146,6 +149,9 @@ func TestNewNamespaceDispatcher(t *testing.T) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: dispatcherLabels,
+					Annotations: map[string]string{
+						ConfigMapHashAnnotationKey: testConfigMapHash,
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: serviceAccount,

--- a/pkg/channel/consolidated/reconciler/controller/resources/service_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/service_test.go
@@ -33,6 +33,7 @@ const (
 	testNS             = "my-test-ns"
 	testDispatcherNS   = "dispatcher-namespace"
 	testDispatcherName = "dispatcher-name"
+	testConfigMapHash  = "deadbeef"
 )
 
 func TestMakeChannelServiceAddress(t *testing.T) {


### PR DESCRIPTION
Instead of doing more complex things (making the pods commit suicide, on-the-fly reloading, shaving horde of yaks etc) within the dispatcher to reload the configuration, just watch the configmap in the controller and do a rolling update on the dispatcher deployment.

Hashes the configmap, stores it on the dispatcher deployment as an annotation. When configmap is changed (watching it in the controller), update it on the deployment annotation. That will make Kubernetes to do a rolling deployment.

I tested my changes with https://github.com/aliok/kafka-ch-reload-tests. There are 2 pods:
- sender sends messages for 2 mins
- receiver receives messages for 3 mins

With a message frequency of 10 ms, there were only 4 times the sender was unable to send messages to the channel during the rolling deployment.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Rolling deployment dispatcher on configmap change
- Alternative approach to https://github.com/knative-sandbox/eventing-kafka/pull/499, as discussed in that ticket

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽  Consolidated Kafka Channel dispatcher is now reconfigured when `config-kafka` configmap is updated

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
