### PR TITLE
Fix memory and CPU leaks with the distributed secret watcher

### DIFF
--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -164,7 +164,7 @@ func main() {
 	}
 
 	// Watch The Secret For Changes
-	err = distributedcommonconfig.InitializeSecretWatcher(ctx, environment.KafkaSecretNamespace, environment.KafkaSecretName, secretObserver)
+	err = distributedcommonconfig.InitializeSecretWatcher(ctx, environment.KafkaSecretNamespace, environment.KafkaSecretName, environment.ResyncPeriod, secretObserver)
 	if err != nil {
 		logger.Fatal("Failed To Start Secret Watcher", zap.Error(err))
 	}

--- a/cmd/channel/distributed/receiver/main.go
+++ b/cmd/channel/distributed/receiver/main.go
@@ -149,7 +149,7 @@ func main() {
 	}
 
 	// Watch The Secret For Changes
-	err = distributedcommonconfig.InitializeSecretWatcher(ctx, environment.KafkaSecretNamespace, environment.KafkaSecretName, secretObserver)
+	err = distributedcommonconfig.InitializeSecretWatcher(ctx, environment.KafkaSecretNamespace, environment.KafkaSecretName, environment.ResyncPeriod, secretObserver)
 	if err != nil {
 		logger.Fatal("Failed To Start Secret Watcher", zap.Error(err))
 	}

--- a/pkg/channel/distributed/common/config/secretwatcher.go
+++ b/pkg/channel/distributed/common/config/secretwatcher.go
@@ -18,65 +18,40 @@ package config
 
 import (
 	"context"
+	"time"
+
+	"k8s.io/client-go/informers"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
 
 	"github.com/Shopify/sarama"
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/watch"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
 	"knative.dev/eventing-kafka/pkg/common/client"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	"knative.dev/pkg/logging"
 )
 
 type SecretObserver func(ctx context.Context, secret *corev1.Secret)
 
 //
-// Initialize The Specified Context With A Secret Watcher
+// Initialize The Specified Context With A Secret Informer
 //
-func InitializeSecretWatcher(ctx context.Context, namespace string, name string, observer SecretObserver) error {
+func InitializeSecretWatcher(ctx context.Context, namespace string, name string, resyncTime time.Duration, observer SecretObserver) error {
 
 	logger := logging.FromContext(ctx)
-	watcherOptions := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector("metadata.name", name).String()}
-	secrets := kubeclient.Get(ctx).CoreV1().Secrets(namespace)
-	watcher, err := secrets.Watch(ctx, watcherOptions)
-	if err != nil {
-		logger.Error("Failed to start secret watcher", zap.Error(err))
-		return err
-	}
+	secretsInformer := informers.NewSharedInformerFactoryWithOptions(
+		kubeclient.Get(ctx), resyncTime, informers.WithNamespace(namespace)).Core().V1().Secrets().Informer()
+	secretsInformer.AddEventHandler(controller.HandleAll(func(object interface{}) {
+		secret, ok := object.(*corev1.Secret)
+		if ok && secret.Name == name {
+			observer(ctx, secret)
+		}
+	}))
 
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				logger.Info("Stopped Secret Watcher")
-				watcher.Stop()
-				return
-			case event, ok := <-watcher.ResultChan():
-				if !ok {
-					// Channel was closed; this typically happens because watchers have a default
-					// timeout that is randomly set between 30 and 60 minutes if there is no value
-					// (or zero) in the watcherOptions.TimeoutSeconds.  Regardless of the particular
-					// value of the timeout, we need to restart the watcher when this happens.
-					logger.Debug("Watcher channel closed; restarting Secret Watcher")
-					watcher, err = secrets.Watch(ctx, watcherOptions)
-					if err != nil {
-						logger.Error("Failed to restart Secret Watcher", zap.Error(err))
-						return
-					}
-				}
-				// We only care if the secret was modified or added
-				if event.Type == watch.Added || event.Type == watch.Modified {
-					if secret, ok := event.Object.(*corev1.Secret); ok {
-						observer(ctx, secret)
-					} else {
-						logger.Error("Could not convert watched object to Secret", zap.Any("event.Object", event.Object))
-					}
-				}
-			}
-		}
+		secretsInformer.Run(ctx.Done())
+		logger.Info("Stopped Secret Watcher")
 	}()
 
 	return nil

--- a/pkg/channel/distributed/common/config/secretwatcher.go
+++ b/pkg/channel/distributed/common/config/secretwatcher.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/apimachinery/pkg/fields"
 
@@ -63,8 +62,6 @@ func InitializeSecretWatcher(ctx context.Context, namespace string, name string,
 						logger.Error("Could not convert watched object to Secret", zap.Any("event.Object", event.Object))
 					}
 				}
-			case <-time.After(5 * time.Second):
-				// Don't hang a shutdown waiting for an event
 			}
 		}
 

--- a/pkg/channel/distributed/common/config/secretwatcher.go
+++ b/pkg/channel/distributed/common/config/secretwatcher.go
@@ -57,9 +57,9 @@ func InitializeSecretWatcher(ctx context.Context, namespace string, name string,
 			case event, ok := <-watcher.ResultChan():
 				if !ok {
 					// Channel was closed; this typically happens because watchers have a default
-					// timeout that seems to be around 38m45s if there is no value (or zero) in the
-					// watcherOptions.TimeoutSeconds.  Regardless of the timeout, we need to restart
-					// the watcher when this happens.
+					// timeout that is randomly set between 30 and 60 minutes if there is no value
+					// (or zero) in the watcherOptions.TimeoutSeconds.  Regardless of the particular
+					// value of the timeout, we need to restart the watcher when this happens.
 					logger.Debug("Watcher channel closed; restarting Secret Watcher")
 					watcher, err = secrets.Watch(ctx, watcherOptions)
 					if err != nil {

--- a/pkg/channel/distributed/common/config/secretwatcher_test.go
+++ b/pkg/channel/distributed/common/config/secretwatcher_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Shopify/sarama"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,11 +101,11 @@ func TestGetConfigFromSecret_Valid(t *testing.T) {
 		commontesting.OldAuthUsername,
 		commontesting.OldAuthPassword,
 		commontesting.OldAuthNamespace,
-		commontesting.OldAuthSaslType)
+		"")
 	kafkaAuth := GetAuthConfigFromSecret(secret)
 	assert.Equal(t, commontesting.OldAuthUsername, kafkaAuth.SASL.User)
 	assert.Equal(t, commontesting.OldAuthPassword, kafkaAuth.SASL.Password)
-	assert.Equal(t, commontesting.OldAuthSaslType, kafkaAuth.SASL.SaslType)
+	assert.Equal(t, sarama.SASLTypePlaintext, kafkaAuth.SASL.SaslType)
 }
 
 func TestGetConfigFromSecret_Invalid(t *testing.T) {
@@ -133,7 +135,7 @@ func TestInitializeSecretWatcher(t *testing.T) {
 	assert.Equal(t, string(testSecret.Data[kafkaconstants.KafkaSecretKeySaslType]), commontesting.OldAuthSaslType)
 
 	// Perform The Test (Initialize The Secret Watcher)
-	err = InitializeSecretWatcher(ctx, system.Namespace(), constants.SettingsSecretName, secretWatcherHandler)
+	err = InitializeSecretWatcher(ctx, system.Namespace(), constants.SettingsSecretName, 10*time.Second, secretWatcherHandler)
 	assert.Nil(t, err)
 
 	// The secretWatcherHandler should change this back to a valid Secret after the watcher is triggered
@@ -152,9 +154,6 @@ func TestInitializeSecretWatcher(t *testing.T) {
 
 	// Wait for the secretWatcherHandler to be called
 	assert.Eventually(t, func() bool { return getWatchedSecret() != nil }, 500*time.Millisecond, 5*time.Millisecond)
-
-	// It would be nice to test that the watcher restarts after the timeout, but the fake watcher
-	// doesn't seem to do anything with the TimeoutSeconds field in the ListOptions anyway.
 
 	assert.NotNil(t, getWatchedSecret())
 	assert.Equal(t, string(testSecret.Data[kafkaconstants.KafkaSecretKeyUsername]), commontesting.NewAuthUsername)

--- a/pkg/channel/distributed/common/config/secretwatcher_test.go
+++ b/pkg/channel/distributed/common/config/secretwatcher_test.go
@@ -150,10 +150,12 @@ func TestInitializeSecretWatcher(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, string(testSecret.Data[kafkaconstants.KafkaSecretKeyPassword]), commontesting.NewAuthPassword)
 
-	// Wait for the secretWatcherHandler to be called (happens pretty quickly; loop usually only runs once)
-	for try := 0; getWatchedSecret() == nil && try < 100; try++ {
-		time.Sleep(5 * time.Millisecond)
-	}
+	// Wait for the secretWatcherHandler to be called
+	assert.Eventually(t, func() bool { return getWatchedSecret() != nil }, 500*time.Millisecond, 5*time.Millisecond)
+
+	// It would be nice to test that the watcher restarts after the timeout, but the fake watcher
+	// doesn't seem to do anything with the TimeoutSeconds field in the ListOptions anyway.
+
 	assert.NotNil(t, getWatchedSecret())
 	assert.Equal(t, string(testSecret.Data[kafkaconstants.KafkaSecretKeyUsername]), commontesting.NewAuthUsername)
 	assert.Equal(t, string(testSecret.Data[kafkaconstants.KafkaSecretKeyPassword]), commontesting.NewAuthPassword)

--- a/pkg/channel/distributed/receiver/producer/producer.go
+++ b/pkg/channel/distributed/receiver/producer/producer.go
@@ -148,6 +148,8 @@ func (p *Producer) ObserveMetrics(interval time.Duration) {
 	// Fork A New Process To Run Async Metrics Collection
 	go func() {
 
+		metricsTimer := time.NewTimer(interval)
+
 		// Infinite Loop For Periodically Observing Sarama Metrics From Registry
 		for {
 
@@ -158,12 +160,15 @@ func (p *Producer) ObserveMetrics(interval time.Duration) {
 				close(p.metricsStoppedChan)
 				return
 
-			case <-time.After(interval):
+			case <-metricsTimer.C:
 				// Get All The Sarama Metrics From The Producer's Metrics Registry
 				kafkaMetrics := p.metricsRegistry.GetAll()
 
 				// Forward Metrics To Prometheus For Observation
 				p.statsReporter.Report(kafkaMetrics)
+
+				// Schedule Another Report
+				metricsTimer.Reset(interval)
 			}
 		}
 	}()


### PR DESCRIPTION
## Proposed Changes

- 🐛 Replaced the secret watcher with a secret informer; otherwise the watcher times out after 30-60 minutes, resulting in secrets not being watched _and_ the select loop spinning the CPU out of control.
-🐛  Replaced calls to time.After() with a single re-used timer in infinite channel select loops (secret watcher, metrics loops) as these can cause some severe memory leaks in cases where the select loop is run frequently (noticed due to the other bug)
-🐛 Setting the Sarama SASL type in the kafka-cluster secret to an empty string was resulting in any secret update causing a reconfigure to happen on dispatchers and receivers (because "" isn't literally the default SASL type of "PLAIN" during the comparison) 
