### PR TITLE
Distributed channel - watch config-kafka like consolidated channel

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -568,10 +568,22 @@ func (r *Reconciler) deleteTopic(ctx context.Context, channel *v1beta1.KafkaChan
 
 func (r *Reconciler) updateKafkaConfig(ctx context.Context, configMap *corev1.ConfigMap) {
 	logger := logging.FromContext(ctx)
+
+	if r == nil {
+		// This typically happens during startup and can be ignored
+		return
+	}
+
+	if configMap == nil {
+		logger.Warn("Nil ConfigMap passed to configMapObserver; ignoring")
+		return
+	}
+
 	logger.Info("Reloading Kafka configuration")
 	kafkaConfig, err := utils.GetKafkaConfig(configMap.Data)
 	if err != nil {
 		logger.Errorw("Error reading Kafka configuration", zap.Error(err))
+		return
 	}
 
 	if kafkaConfig.AuthSecretName != "" {

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -595,11 +595,6 @@ func (r *Reconciler) updateKafkaConfig(ctx context.Context, configMap *corev1.Co
 	r.kafkaConfig = kafkaConfig
 	r.kafkaConfigError = err
 	r.kafkaConfigMapHash = configmapDataCheckSum(configMap)
-
-	if err != nil {
-		logger.Errorw("Error creating AdminClient", zap.Error(err))
-		return
-	}
 }
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, kc *v1beta1.KafkaChannel) pkgreconciler.Event {

--- a/pkg/channel/distributed/controller/kafkachannel/controller.go
+++ b/pkg/channel/distributed/controller/kafkachannel/controller.go
@@ -18,10 +18,11 @@ package kafkachannel
 
 import (
 	"context"
-	corev1 "k8s.io/api/core/v1"
 	"sync"
 
 	"go.uber.org/zap"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	kafkachannelv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"

--- a/pkg/channel/distributed/controller/kafkachannel/controller.go
+++ b/pkg/channel/distributed/controller/kafkachannel/controller.go
@@ -131,7 +131,6 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		adminClientType:      kafkaAdminClientType,
 		adminClient:          nil,
 		adminMutex:           &sync.Mutex{},
-		configObserver:       rec.configMapObserver, // Maintains a reference so that the ConfigWatcher can call it
 		kafkaSecret:          kafkaSecretName,
 		kafkaBrokers:         configuration.Kafka.Brokers,
 		kafkaUsername:        kafkaUsername,

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler.go
@@ -246,6 +246,12 @@ func (r *Reconciler) configMapObserver(ctx context.Context, configMap *corev1.Co
 
 	logger.Info("Reloading Kafka configuration")
 
+	// Validate The ConfigMap Data
+	if configMap.Data == nil {
+		logger.Fatal("Attempted to merge sarama settings with empty configmap", zap.Any("configMap", configMap))
+		return
+	}
+
 	// Enable Sarama Logging If Specified In ConfigMap
 	if ekConfig, err := kafkasarama.LoadEventingKafkaSettings(configMap); err == nil && ekConfig != nil {
 		kafkasarama.EnableSaramaLogging(ekConfig.Kafka.EnableSaramaLogging)
@@ -261,12 +267,6 @@ func (r *Reconciler) configMapObserver(ctx context.Context, configMap *corev1.Co
 	// which simply uses the r.saramaConfig set here whenever necessary.  This means that calling
 	// env.GetEnvironment is not necessary now.  If	those settings are needed in the future, the
 	// environment will also need to be re-parsed here.
-
-	// Validate The ConfigMap Data
-	if configMap.Data == nil {
-		logger.Fatal("Attempted to merge sarama settings with empty configmap", zap.Any("configMap", configMap))
-		return
-	}
 
 	// Get The Sarama Config Yaml From The ConfigMap
 	saramaSettingsYamlString := configMap.Data[commonconstants.SaramaSettingsConfigKey]

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler.go
@@ -61,7 +61,6 @@ type Reconciler struct {
 	kafkachannelInformer cache.SharedIndexInformer
 	deploymentLister     appsv1listers.DeploymentLister
 	serviceLister        corev1listers.ServiceLister
-	configObserver       commonconfig.LoggingObserver
 	adminMutex           *sync.Mutex
 	kafkaSecret          string
 	kafkaBrokers         string

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler.go
@@ -230,8 +230,8 @@ func (r *Reconciler) reconcile(ctx context.Context, channel *kafkav1beta1.KafkaC
 	return nil
 }
 
-// configMapObserver is the callback function that handles changes to our ConfigMap
-func (r *Reconciler) configMapObserver(ctx context.Context, configMap *corev1.ConfigMap) {
+// updateKafkaConfig is the callback function that handles changes to our ConfigMap
+func (r *Reconciler) updateKafkaConfig(ctx context.Context, configMap *corev1.ConfigMap) {
 	logger := logging.FromContext(ctx)
 
 	if r == nil {
@@ -259,14 +259,6 @@ func (r *Reconciler) configMapObserver(ctx context.Context, configMap *corev1.Co
 	} else {
 		logger.Error("Could Not Extract Eventing-Kafka Setting From Updated ConfigMap", zap.Any("configMap", configMap), zap.Error(err))
 	}
-
-	// Though the new configmap could technically have changes to the eventing-kafka section
-	// (aside from the Sarama logging) as well as the sarama section, we currently do not do
-	// anything proactive based on configuration changes to those items.  The only component
-	// in the controller that uses any of the fields after startup currently is the AdminClient,
-	// which simply uses the r.saramaConfig set here whenever necessary.  This means that calling
-	// env.GetEnvironment is not necessary now.  If	those settings are needed in the future, the
-	// environment will also need to be re-parsed here.
 
 	// Get The Sarama Config Yaml From The ConfigMap
 	saramaSettingsYamlString := configMap.Data[commonconstants.SaramaSettingsConfigKey]

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler.go
@@ -244,6 +244,8 @@ func (r *Reconciler) configMapObserver(ctx context.Context, configMap *corev1.Co
 		return
 	}
 
+	logger.Info("Reloading Kafka configuration")
+
 	// Enable Sarama Logging If Specified In ConfigMap
 	if ekConfig, err := kafkasarama.LoadEventingKafkaSettings(configMap); err == nil && ekConfig != nil {
 		kafkasarama.EnableSaramaLogging(ekConfig.Kafka.EnableSaramaLogging)


### PR DESCRIPTION
Addresses controller part of #455.

I tried to do things in small steps in separate PRs.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Watch the configmap in the controller (already existing)
- When the configmap is changed, do a global resync of the KafkaChannel CRs so that they're reconciled

- Bonus: copy over some good stuff from distributed channel to consolidated channel (some nil checks etc. I found missing in consolidated channel)

I tested my changes with https://github.com/aliok/kafka-ch-reload-tests/tree/distr-channel (beware the `distr-channel` branch). There are 2 pods:
- sender sends messages for 2 mins
- receiver receives messages for 3 mins

I haven't seen any message lost (sent to Kafka but not received by the receiver) or non-posted (couldn't sent by the sender to Kafka).


FYI, this the plan I have in my mind:
- Do a global resync of CRs when configmap changes
- Remove configmap watching in dispatcher and receiver and mount the configmap to these
- Controller to trigger a rolling update of dispatcher and receiver deployments when configmap changes (similar to https://github.com/knative-sandbox/eventing-kafka/pull/514)

With these done, the behaviour and code will look very very similar on both channel implementations when it comes to handling the changes in `config-kafka`.



<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
