### PR TITLE
[Consolidated Channel] Only return true in probe verifier if all partitions found

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -537,7 +537,8 @@ func (r *Reconciler) reconcileTopic(ctx context.Context, channel *v1beta1.KafkaC
 	logger := logging.FromContext(ctx)
 
 	topicName := utils.TopicName(utils.KafkaChannelSeparator, channel.Namespace, channel.Name)
-	logger.Infow("Creating topic on Kafka cluster", zap.String("topic", topicName))
+	logger.Infow("Creating topic on Kafka cluster", zap.String("topic", topicName),
+		zap.Int32("partitions", channel.Spec.NumPartitions), zap.Int16("replication", channel.Spec.ReplicationFactor))
 	err := kafkaClusterAdmin.CreateTopic(topicName, &sarama.TopicDetail{
 		ReplicationFactor: channel.Spec.ReplicationFactor,
 		NumPartitions:     channel.Spec.NumPartitions,


### PR DESCRIPTION
Fixes #536 
## Proposed Changes

- Changes probing logic to consider probing a pod only successful if all partitions were found, otherwise keep probing even if a partial number of partitions were found.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix a bug in the consolidated KafkaChannel where some Subscriptions can stay stuck in a `SubscriptionNotMarkedReadyByChannel` state for a long while.
```