### PR TITLE
Missing defer close kafka admin client in FinalizeKind

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -611,6 +611,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, kc *v1beta1.KafkaChannel)
 	if err != nil || r.kafkaConfig == nil {
 		logger.Errorw("Can't obtain Kafka Client", zap.String("channel", channel), zap.Error(err))
 	} else {
+		defer kafkaClusterAdmin.Close()
 		logger.Debugw("Got client, about to delete topic")
 		if err := r.deleteTopic(ctx, kc, kafkaClusterAdmin); err != nil {
 			logger.Errorw("Error deleting Kafka channel topic", zap.String("channel", channel), zap.Error(err))


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Part of #564

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Close the Kafka AdminClient in FinalizeKind


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Close the Kafka AdminClient in FinalizeKind
```
