### PR TITLE
Drop --strict flag on ko

### DIFF
--- a/config/channel/distributed/README.md
+++ b/config/channel/distributed/README.md
@@ -18,10 +18,8 @@ correctly populated for the user provided Kafka cluster. Similarly the **data**
 values of the [eventing-kafka-configmap.yaml](300-eventing-kafka-configmap.yaml)
 file should be configured for your particular use case.
 
-Install via `ko apply --strict -f ./config/channel/distributed` from the
-repository root directory in order to build and deploy the project. The
-`--strict` option is really only needed when using the `custom` AdminType, but
-shouldn't hurt in other cases.
+Install via `ko apply -f ./config/channel/distributed` from the
+repository root directory in order to build and deploy the project.
 
 ## Kafka Admin Types
 

--- a/docs/kind_kafka_cluster.md
+++ b/docs/kind_kafka_cluster.md
@@ -126,7 +126,7 @@ steps could be used for the Consolidated KafkaChannel or Source.
     export KO_DOCKER_REPO=<docker-registry-path>
 
     # Build / Deploy
-    ko apply --strict -f config/channel/distributed/
+    ko apply -f config/channel/distributed/
     ```
 
 ## Uninstall Distributed KafkaChannel

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -45,7 +45,6 @@ function build_release() {
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Knative Eventing Contrib - ${config}"
-    # TODO(chizhg): reenable --strict mode after https://github.com/knative/test-infra/issues/1262 is fixed.
     ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done


### PR DESCRIPTION
As per title. Since https://github.com/google/ko/commit/6586a72f8a458b6b2139fd8b97d4412afab91f03 this has been the default and we recently updated `ko` in CI.

/assign @matzew @slinkydeveloper 