### PR TITLE
Reducing noise of the 'Changes detected' logger

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/controller.go
+++ b/pkg/channel/consolidated/reconciler/controller/controller.go
@@ -107,7 +107,7 @@ func NewController(
 
 	// Call GlobalResync on kafkachannels.
 	grCh := func(obj interface{}) {
-		logger.Info("Changes detected, doing global resync")
+		logger.Debug("Changes detected, doing global resync")
 		impl.GlobalResync(kafkaChannelInformer.Informer())
 	}
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Noticed a bit of logger verbosity, like:

```
{"level":"info","ts":"2021-04-26T14:03:53.520Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:53.522Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:53.527Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:53.544Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:53.613Z","logger":"kafkachannel-controller","caller":"sharedmain/main.go:237","msg":"Starting controllers...","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:53.613Z","logger":"kafkachannel-controller","caller":"leaderelection/context.go:138","msg":"kafkachannel-controller.knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.reconciler.00-of-01 will run in leader-elected mode with id \"kafka-ch-controller-76d44c6d49-hk844_d1803262-8f09-411d-9671-9d4a05140c5c\"","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:53.613Z","logger":"kafkachannel-controller","caller":"controller/controller.go:463","msg":"Starting controller and workers","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844","knative.dev/controller":"knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.Reconciler","knative.dev/kind":"messaging.knative.dev.KafkaChannel"}
{"level":"info","ts":"2021-04-26T14:03:53.613Z","logger":"kafkachannel-controller","caller":"controller/controller.go:473","msg":"Started workers","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844","knative.dev/controller":"knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.Reconciler","knative.dev/kind":"messaging.knative.dev.KafkaChannel"}
I0426 14:03:53.613888       1 leaderelection.go:243] attempting to acquire leader lease  knative-eventing/kafkachannel-controller.knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.reconciler.00-of-01...
I0426 14:03:53.619250       1 leaderelection.go:253] successfully acquired lease knative-eventing/kafkachannel-controller.knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.reconciler.00-of-01
{"level":"info","ts":"2021-04-26T14:03:53.619Z","logger":"kafkachannel-controller","caller":"leaderelection/context.go:147","msg":"\"kafka-ch-controller-76d44c6d49-hk844_d1803262-8f09-411d-9671-9d4a05140c5c\" has started leading \"kafkachannel-controller.knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.reconciler.00-of-01\"","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:54.742Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:54.749Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:55.745Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:55.751Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:59.791Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:03:59.802Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
{"level":"info","ts":"2021-04-26T14:04:00.804Z","logger":"kafkachannel-controller","caller":"controller/controller.go:110","msg":"Changes detected, doing global resync","knative.dev/pod":"kafka-ch-controller-76d44c6d49-hk844"}
```


## Proposed Changes

- less verbose logger
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
