### PR TITLE
Remove istio sidecar annotation

### DIFF
--- a/pkg/source/reconciler/source/resources/receive_adapter.go
+++ b/pkg/source/reconciler/source/resources/receive_adapter.go
@@ -93,9 +93,6 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 			Replicas: args.Source.Spec.Consumers,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"sidecar.istio.io/inject": "true",
-					},
 					Labels: args.Labels,
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/source/reconciler/source/resources/receive_adapter_test.go
+++ b/pkg/source/reconciler/source/resources/receive_adapter_test.go
@@ -130,9 +130,6 @@ func TestMakeReceiveAdapter(t *testing.T) {
 			Replicas: &one,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"sidecar.istio.io/inject": "true",
-					},
 					Labels: map[string]string{
 						"test-key1": "test-value1",
 						"test-key2": "test-value2",
@@ -311,9 +308,6 @@ func TestMakeReceiveAdapterNoNet(t *testing.T) {
 			Replicas: &one,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"sidecar.istio.io/inject": "true",
-					},
 					Labels: map[string]string{
 						"test-key1": "test-value1",
 						"test-key2": "test-value2",
@@ -541,9 +535,6 @@ func TestMakeReceiveAdapterKeyType(t *testing.T) {
 			Replicas: &one,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"sidecar.istio.io/inject": "true",
-					},
 					Labels: map[string]string{
 						"test-key1": "test-value1",
 						"test-key2": "test-value2",


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #294

A bit related to an oder PR in this direction, where same has done to all components that have existed back than:
https://github.com/knative/eventing/pull/1119

At the time of that PR, there was no KafkaSource

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove Istio sidecar from the kafka source
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
KafkaSource will not have Istio side-cars, it does not need Istio to function, however it will continue work if Istio is present.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
