### PR TITLE
Copy volumes as well as container when creating deployment updates

### DIFF
--- a/pkg/channel/distributed/controller/util/compare.go
+++ b/pkg/channel/distributed/controller/util/compare.go
@@ -116,6 +116,7 @@ func CheckDeploymentChanged(logger *zap.Logger, oldDeployment, newDeployment *ap
 	}
 	if !containersEqual {
 		updatedDeployment.Spec.Template.Spec.Containers[0] = *newContainer
+		updatedDeployment.Spec.Template.Spec.Volumes = newDeployment.Spec.Template.Spec.Volumes
 	}
 	return updatedDeployment, true
 }


### PR DESCRIPTION
Fixes #590

## Proposed Changes

- 🐛 Volumes were not included in the list of fields that deployment updates should be able to change in a rollout-restart fashion; added them to the CheckDeploymentChanged function (but only if something in the container also changed -- in the case of the bug that prompted this fix, it was the addition of the "config-kafka" volumeMount in the container that demanded the change)

