### PR TITLE
[source] fix issue with offset not being initialized before session is closed

### DIFF
--- a/pkg/common/consumer/consumer_handler.go
+++ b/pkg/common/consumer/consumer_handler.go
@@ -24,8 +24,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var _ sarama.ConsumerGroupHandler = (*SaramaConsumerHandler)(nil)
-
 type KafkaConsumerHandler interface {
 	// When this function returns true, the consumer group offset is marked as consumed.
 	// The returned error is enqueued in errors channel.
@@ -54,16 +52,6 @@ func WithSaramaConsumerLifecycleListener(listener SaramaConsumerLifecycleListene
 	}
 }
 
-func noopOffsetInitializer(sarama.ConsumerGroupSession) error {
-	return nil
-}
-
-func WithOffsetInitializer(initializer func(sarama.ConsumerGroupSession) error) SaramaConsumerHandlerOption {
-	return func(handler *SaramaConsumerHandler) {
-		handler.offsetInitializer = initializer
-	}
-}
-
 // ConsumerHandler implements sarama.ConsumerGroupHandler and provides some glue code to simplify message handling
 // You must implement KafkaConsumerHandler and create a new SaramaConsumerHandler with it
 type SaramaConsumerHandler struct {
@@ -71,7 +59,6 @@ type SaramaConsumerHandler struct {
 	handler KafkaConsumerHandler
 
 	lifecycleListener SaramaConsumerLifecycleListener
-	offsetInitializer func(sarama.ConsumerGroupSession) error
 
 	logger *zap.SugaredLogger
 
@@ -85,7 +72,6 @@ func NewConsumerHandler(logger *zap.SugaredLogger, handler KafkaConsumerHandler,
 	sch := SaramaConsumerHandler{
 		handler:           handler,
 		lifecycleListener: noopSaramaConsumerLifecycleListener{},
-		offsetInitializer: noopOffsetInitializer,
 		logger:            logger,
 		errors:            errorsCh,
 	}
@@ -101,8 +87,7 @@ func NewConsumerHandler(logger *zap.SugaredLogger, handler KafkaConsumerHandler,
 func (consumer *SaramaConsumerHandler) Setup(session sarama.ConsumerGroupSession) error {
 	consumer.logger.Info("setting up handler")
 	consumer.lifecycleListener.Setup(session)
-
-	return consumer.offsetInitializer(session)
+	return nil
 }
 
 // Cleanup is run at the end of a session, once all ConsumeClaim goroutines have exited
@@ -155,3 +140,5 @@ func (consumer *SaramaConsumerHandler) ConsumeClaim(session sarama.ConsumerGroup
 	consumer.logger.Infof("Stopping partition consumer, topic: %s, partition: %d", claim.Topic(), claim.Partition())
 	return nil
 }
+
+var _ sarama.ConsumerGroupHandler = (*SaramaConsumerHandler)(nil)

--- a/pkg/source/adapter/adapter_test.go
+++ b/pkg/source/adapter/adapter_test.go
@@ -538,13 +538,14 @@ func TestInitOffset(t *testing.T) {
 			adapter := NewAdapter(context.Background(), NewEnvConfig(), nil, nil).(*Adapter)
 			adapter.config.ConsumerGroup = group
 			adapter.config.Topics = tc.topics
+			adapter.config.BootstrapServers = []string{broker.Addr()}
 
 			config := sarama.NewConfig()
 			config.Version = sarama.MaxVersion
+			adapter.saramaConfig = config
 
-			fn := adapter.InitOffsets([]string{broker.Addr()}, config)
 			session := new(sampleConsumerSession)
-			err := fn(session)
+			err := adapter.InitOffsets(session)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

Make sure the KafkaSource is Ready (ie. guarantee to not lose events) before starting the consumer group. 

Without this fix, events sent to partitions with an uninitialized consumer group offset could be lost (as per def above) if these events are sent while the consumer group session is closed or is being rebalanced.

## Proposed Changes

- Make sure all consumer group offsets are initialized before starting consuming events.
- 
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
 

/cc @devguyio @slinkydeveloper 
