### PR TITLE
Debug log consume message

### DIFF
--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -174,7 +174,7 @@ func formatDispatcherExecutionInfo(info *channel.DispatchExecutionInfo) string {
 	}
 	truncate := len(info.ResponseBody)
 	if truncate > 500 {
-		truncate = 500
+		truncate = 500	// Responses aren't typically large, but don't dump a massive response body
 	}
 	return fmt.Sprintf("%v (%v): %v", info.ResponseCode, info.Time, string(info.ResponseBody[:truncate]))
 }

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -19,9 +19,8 @@ package dispatcher
 import (
 	"context"
 	"errors"
-	"strings"
-
 	"net/url"
+	"strings"
 
 	"github.com/Shopify/sarama"
 	kafkasaramaprotocol "github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
@@ -156,7 +155,7 @@ func (h *Handler) consumeMessage(context context.Context, consumerMessage *saram
 
 	// Dispatch The Message With Configured Retries & Return Any Errors
 	info, dispatchError := h.MessageDispatcher.DispatchMessageWithRetries(ctx, message, nil, destinationURL, replyURL, deadLetterURL, retryConfig)
-	h.Logger.Debug("Received Dispatcher Response", zap.Any("ExecutionInfo", executionInfoWrapper{info}))
+	h.Logger.Debug("Received Response", zap.Any("ExecutionInfo", executionInfoWrapper{info}))
 
 	return dispatchError
 }

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -19,14 +19,15 @@ package dispatcher
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/url"
 	"strings"
+
+	"net/url"
 
 	"github.com/Shopify/sarama"
 	kafkasaramaprotocol "github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"knative.dev/eventing-kafka/pkg/common/tracing"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/channel"
@@ -131,9 +132,8 @@ func (h *Handler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama
 // Consume A Single Message
 func (h *Handler) consumeMessage(context context.Context, consumerMessage *sarama.ConsumerMessage, destinationURL *url.URL, replyURL *url.URL, deadLetterURL *url.URL, retryConfig *kncloudevents.RetryConfig) error {
 
-	debug := h.Logger.Core().Enabled(zap.DebugLevel)
 	// Debug Log Kafka ConsumerMessage
-	if debug {
+	if h.Logger.Core().Enabled(zap.DebugLevel) {
 		// Checked Logging Level First To Avoid Calling StringifyHeaderPtrs In Production
 		h.Logger.Debug("Consuming Kafka Message",
 			zap.Any("Headers", kafkasarama.StringifyHeaderPtrs(consumerMessage.Headers)), // Log human-readable strings, not base64
@@ -156,25 +156,24 @@ func (h *Handler) consumeMessage(context context.Context, consumerMessage *saram
 
 	// Dispatch The Message With Configured Retries & Return Any Errors
 	info, dispatchError := h.MessageDispatcher.DispatchMessageWithRetries(ctx, message, nil, destinationURL, replyURL, deadLetterURL, retryConfig)
+	h.Logger.Debug("Received Dispatcher Response", zap.Any("ExecutionInfo", executionInfoWrapper{info}))
 
-	if debug {
-		// Checked Logging Level First To Avoid Calling formatDispatcherExecutionInfo In Production
-		h.Logger.Debug("Dispatcher Response: " + formatDispatcherExecutionInfo(info))
-	}
 	return dispatchError
 }
 
-func formatDispatcherExecutionInfo(info *channel.DispatchExecutionInfo) string {
-	if info == nil {
-		return "<nil>"
+// executionInfoWrapper wraps a DispatchExecutionInfo struct so that zap.Any can lazily marshal it
+type executionInfoWrapper struct {
+	*channel.DispatchExecutionInfo
+}
+
+// MarshalLogObject implements the zapcore.ObjectMarshaler interface on the executionInfoWrapper
+func (w executionInfoWrapper) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddDuration("Time", w.Time)
+	enc.AddInt("ResponseCode", w.ResponseCode)
+	if len(w.ResponseBody) > 500 {
+		enc.AddString("Body", string(w.ResponseBody[:500])+"...")
+	} else {
+		enc.AddString("Body", string(w.ResponseBody))
 	}
-	// The body for Dispatcher responses is usually empty, so don't bother printing it in those cases
-	if len(info.ResponseBody) == 0 {
-		return fmt.Sprintf("%v (%v)", info.ResponseCode, info.Time)
-	}
-	truncate := len(info.ResponseBody)
-	if truncate > 500 {
-		truncate = 500 // Responses aren't typically large, but don't dump a massive response body
-	}
-	return fmt.Sprintf("%v (%v): %v", info.ResponseCode, info.Time, string(info.ResponseBody[:truncate]))
+	return nil
 }

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -174,7 +174,7 @@ func formatDispatcherExecutionInfo(info *channel.DispatchExecutionInfo) string {
 	}
 	truncate := len(info.ResponseBody)
 	if truncate > 500 {
-		truncate = 500	// Responses aren't typically large, but don't dump a massive response body
+		truncate = 500 // Responses aren't typically large, but don't dump a massive response body
 	}
 	return fmt.Sprintf("%v (%v): %v", info.ResponseCode, info.Time, string(info.ResponseBody[:truncate]))
 }

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
@@ -28,13 +28,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
-	dispatchertesting "knative.dev/eventing-kafka/pkg/channel/distributed/dispatcher/testing"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	logtesting "knative.dev/pkg/logging/testing"
+
+	dispatchertesting "knative.dev/eventing-kafka/pkg/channel/distributed/dispatcher/testing"
 )
 
 // Test Data
@@ -365,4 +366,19 @@ func createConsumerMessage(t *testing.T) *sarama.ConsumerMessage {
 
 	// Return The Test ConsumerMessage
 	return consumerMessage
+}
+
+func Test_formatDispatcherExecutionInfo(t *testing.T) {
+	assert.Equal(t, "<nil>", formatDispatcherExecutionInfo(nil))
+	assert.Equal(t, "0 (0s)", formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{}))
+	assert.Equal(t, "200 (1.234ms)", formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{
+		Time:         1234 * time.Microsecond,
+		ResponseCode: 200,
+		ResponseBody: nil,
+	}))
+	assert.Equal(t, "500 (12.345ms): testBody", formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{
+		Time:         12345 * time.Microsecond,
+		ResponseCode: 500,
+		ResponseBody: []byte("testBody"),
+	}))
 }

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
@@ -19,6 +19,7 @@ package dispatcher
 import (
 	"context"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -372,13 +373,9 @@ func Test_formatDispatcherExecutionInfo(t *testing.T) {
 	assert.Equal(t, "<nil>", formatDispatcherExecutionInfo(nil))
 	assert.Equal(t, "0 (0s)", formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{}))
 	assert.Equal(t, "200 (1.234ms)", formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{
-		Time:         1234 * time.Microsecond,
-		ResponseCode: 200,
-		ResponseBody: nil,
-	}))
-	assert.Equal(t, "500 (12.345ms): testBody", formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{
-		Time:         12345 * time.Microsecond,
-		ResponseCode: 500,
-		ResponseBody: []byte("testBody"),
-	}))
+		Time: 1234 * time.Microsecond, ResponseCode: 200, ResponseBody: nil}))
+	assert.Equal(t, "400 (12.345ms): testBody", formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{
+		Time: 12345 * time.Microsecond, ResponseCode: 400, ResponseBody: []byte("testBody")}))
+	assert.Equal(t, "500 (123.456ms): " + strings.Repeat("x", 500), formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{
+		Time: 123456 * time.Microsecond, ResponseCode: 500, ResponseBody: []byte(strings.Repeat("x", 501))}))
 }

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
@@ -376,6 +376,6 @@ func Test_formatDispatcherExecutionInfo(t *testing.T) {
 		Time: 1234 * time.Microsecond, ResponseCode: 200, ResponseBody: nil}))
 	assert.Equal(t, "400 (12.345ms): testBody", formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{
 		Time: 12345 * time.Microsecond, ResponseCode: 400, ResponseBody: []byte("testBody")}))
-	assert.Equal(t, "500 (123.456ms): " + strings.Repeat("x", 500), formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{
+	assert.Equal(t, "500 (123.456ms): "+strings.Repeat("x", 500), formatDispatcherExecutionInfo(&channel.DispatchExecutionInfo{
 		Time: 123456 * time.Microsecond, ResponseCode: 500, ResponseBody: []byte(strings.Repeat("x", 501))}))
 }

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler_test.go
@@ -18,11 +18,10 @@ package dispatcher
 
 import (
 	"context"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
-
-	"net/url"
 
 	"github.com/Shopify/sarama"
 	kafkasaramaprotocol "github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"

--- a/pkg/source/adapter/adapter_test.go
+++ b/pkg/source/adapter/adapter_test.go
@@ -520,7 +520,7 @@ func TestInitOffset(t *testing.T) {
 				SetController(broker.BrokerID()).
 				SetBroker(broker.Addr(), broker.BrokerID())
 			for topic, partitions := range tc.topicOffsets {
-				for partition, _ := range partitions {
+				for partition := range partitions {
 					metadataResponse = metadataResponse.SetLeader(topic, partition, broker.BrokerID())
 				}
 			}


### PR DESCRIPTION
## Proposed Changes

- 🧽  Log (in debug mode) the response from DispatchMessageWithRetries() in the consumeMessage() call

Seeing the response from a dispatched message can be extremely useful, especially if the target URL doesn't have easily accessible logs.  Sample log output from this PR's code (omitting the surrounding JSON):

Ordinary 200 response, no response body:
```
Dispatching event
Response is a non event, discarding it
Dispatcher Response: 200 (20.6957ms)
```
500 response (target pod down), descriptive response body:
```
Dispatching event
Dispatcher Response: 500 (15.0306917s): dispatch error: Post "http://my-service.my-namespace.svc.cluster.local/": dial tcp 10.108.46.168:80: connect: connection refused
```
Ordinary 400 response, no response body:
```
Dispatching event
Dispatcher Response: 400 (8.6064ms)
```