### PR TITLE
Receiver liveness before sarama calls

### DIFF
--- a/cmd/channel/distributed/receiver/main.go
+++ b/cmd/channel/distributed/receiver/main.go
@@ -144,6 +144,12 @@ func main() {
 		logger.Fatal("Failed To Start Secret Watcher", zap.Error(err))
 	}
 
+	// Set The Liveness Flag - Readiness Is Set By Individual Components
+	// This is set before the call to NewProducer, because if the Sarama client takes a long time to connect
+	// it is entirely possible for the receiver to be killed by Kubernetes for not responding to a liveness request.
+	logger.Info("Registering receiver as alive")
+	healthServer.SetAlive(true)
+
 	// Initialize The Kafka Producer In Order To Start Processing Status Events
 	kafkaProducer, err = producer.NewProducer(logger, ekConfig.Sarama.Config, strings.Split(ekConfig.Kafka.Brokers, ","), statsReporter, healthServer)
 	if err != nil {
@@ -152,12 +158,6 @@ func main() {
 	defer kafkaProducer.Close()
 
 	channelReporter := eventingchannel.NewStatsReporter(environment.ContainerName, kmeta.ChildName(environment.PodName, uuid.New().String()))
-
-	// Set The Liveness Flag - Readiness Is Set By Individual Components
-	// This is set before the call to NewMessageReceiver, because if the Sarama client takes a long time to connect
-	// it is entirely possible for the receiver to be killed by Kubernetes for not responding to a liveness request.
-	logger.Info("Registering receiver as alive")
-	healthServer.SetAlive(true)
 
 	// Create A New Knative Eventing MessageReceiver (Parses The Channel From The Host Header)
 	messageReceiver, err := eventingchannel.NewMessageReceiver(handleMessage, logger, channelReporter, eventingchannel.ResolveMessageChannelFromHostHeader(eventingchannel.ParseChannel))


### PR DESCRIPTION
## Proposed Changes

- 🐛  The SetAlive(true) function in the distributed receiver's main() was after the NewProducer() call.  This leads to a situation in which calling CreateSyncProducer() on the Sarama client can delay the SetAlive call long enough (several retries per broker in the array) that kubelet will kill the receiver pod, which is not generally useful and prevents the appropriate errors from being visible in the receiver log after the Sarama calls finish failing.  It has been moved to before the NewProducer() -- the readiness state is still false until the producer is properly connected, however.
