### PR TITLE
[v0.21] Cancel dispatching messages when consumer group session is closed

### DIFF
--- a/pkg/common/consumer/consumer_handler.go
+++ b/pkg/common/consumer/consumer_handler.go
@@ -19,6 +19,7 @@ package consumer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
@@ -38,8 +39,8 @@ type SaramaConsumerHandler struct {
 	// The user message handler
 	handler KafkaConsumerHandler
 
-	logger *zap.SugaredLogger
-
+	logger  *zap.SugaredLogger
+	timeout time.Duration
 	// Errors channel
 	errors chan error
 }
@@ -49,6 +50,7 @@ func NewConsumerHandler(logger *zap.SugaredLogger, handler KafkaConsumerHandler,
 		logger:  logger,
 		handler: handler,
 		errors:  errorsCh,
+		timeout: 60 * time.Second,
 	}
 }
 
@@ -79,20 +81,51 @@ func (consumer *SaramaConsumerHandler) ConsumeClaim(session sarama.ConsumerGroup
 	// Do not move the code below to a goroutine.
 	// The `ConsumeClaim` itself is called within a goroutine, see:
 	// https://github.com/Shopify/sarama/blob/master/consumer_group.go#L27-L29
+	c := make(chan bool)
+
 	for message := range claim.Messages() {
 
 		if ce := consumer.logger.Desugar().Check(zap.DebugLevel, "debugging"); ce != nil {
 			consumer.logger.Debugw("Message claimed", zap.String("topic", message.Topic), zap.Binary("value", message.Value))
 		}
+		// Preemptively interrupt processing messages if the session is closed.
+		// Processing all messages from the buffered channel can take a long time,
+		// potentially exceeding the session timeout, leading to duplicate events.
+		if session.Context().Err() != nil {
+			consumer.logger.Infof("Session closed for %s/%d. Exiting ConsumeClaim ", claim.Topic(), claim.Partition())
+			break
+		}
+		// We need to control when to cancel Handle calls so give it a downstream context
+		hctx, cancel := context.WithCancel(context.Background())
+		// Start Handle routine
+		go func() {
+			mustMark, err := consumer.handler.Handle(hctx, message)
 
-		// Don't use the session context since it is closed before messages are drained.
-		// Handle must finish before the session timeout.
-		mustMark, err := consumer.handler.Handle(context.Background(), message)
+			if err != nil {
+				consumer.logger.Errorw("Failure while handling a message", zap.String("topic", message.Topic), zap.Int32("partition", message.Partition), zap.Int64("offset", message.Offset), zap.Error(err))
+				consumer.errors <- err
+				consumer.handler.SetReady(claim.Partition(), false)
+			}
+			c <- mustMark
+		}()
 
-		if err != nil {
-			consumer.logger.Infow("Failure while handling a message", zap.String("topic", message.Topic), zap.Int32("partition", message.Partition), zap.Int64("offset", message.Offset), zap.Error(err))
-			consumer.errors <- err
-			consumer.handler.SetReady(claim.Partition(), false)
+		var mustMark bool
+		select {
+		case mustMark = <-c:
+			// Handle returned gracefully, call cancel to free the context resources.
+			cancel()
+		case <-session.Context().Done():
+			// Consumer session canceled, wait for in-flight request to finish before we hit a rebalance timeout
+			select {
+			case <-time.After(consumer.timeout):
+				// Handle still didn't return, cancel the in-flight request
+				cancel()
+				// Unblock the Handle goroutine
+				mustMark = <-c
+			case mustMark = <-c:
+				// Handle returned gracefully, call cancel to free the context resources.
+				cancel()
+			}
 		}
 
 		if mustMark {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Cancel dispatching messages when consumer group session is closed

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix a bug in consolidate channel where deleting a KafkaChannel-backed Broker with events in flight blocks new subscriptions in SubscriptionNotMarkedReadyByChannel . 
```
