### PR TITLE
Adjust MaxResponseSize based on the number of active stadapters

### DIFF
--- a/config/source/multi/deployments/adapter.yaml
+++ b/config/source/multi/deployments/adapter.yaml
@@ -47,12 +47,9 @@ spec:
         - name: VREPLICA_LIMITS_MPS
           value: '50'
 
-        # The memory limit, per vreplica. Must be a quantity.
-        # see https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L31
-        # Should be pod requested memory / pod capacity (see controller.yaml)
-        - name: VREPLICA_LIMITS_MEMORY
-          value: '2Mi'
-
+        # The pod requested memory (see resources.requests.memory)
+        - name: REQUESTS_MEMORY
+          value: '250Mi'
 
         # DO NOT MODIFY: The values below are being filled by the kafka source controller
         # See 500-controller.yaml

--- a/config/source/multi/deployments/adapter.yaml
+++ b/config/source/multi/deployments/adapter.yaml
@@ -49,7 +49,7 @@ spec:
 
         # The pod requested memory (see resources.requests.memory)
         - name: REQUESTS_MEMORY
-          value: '250Mi'
+          value: '300Mi'
 
         # DO NOT MODIFY: The values below are being filled by the kafka source controller
         # See 500-controller.yaml
@@ -65,10 +65,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 250Mi
+            memory: 300Mi
           limits:
             cpu: 200m
-            memory: 300Mi
+            memory: 500Mi
 
         ports:
         - name: metrics

--- a/config/source/multi/deployments/controller.yaml
+++ b/config/source/multi/deployments/controller.yaml
@@ -49,7 +49,7 @@ spec:
         - name: AUTOSCALER_REFRESH_PERIOD
           value: '100'
 
-        # The number of virtual replicas this pod can handle.
+        # The number of virtual replicas each adapter pod can handle.
         - name: POD_CAPACITY
           value: '100'
 

--- a/pkg/source/mtadapter/adapter.go
+++ b/pkg/source/mtadapter/adapter.go
@@ -287,9 +287,9 @@ func (a *Adapter) adjustResponseSize() {
 	if a.memoryRequest > 0 {
 		maxResponseSize := int32(float64(a.memoryRequest) / float64(len(a.sources)))
 
-		// cap the response size to 100MB.
-		if maxResponseSize > 100*1024*1024 {
-			maxResponseSize = 100 * 1024 * 1024
+		// cap the response size to 50MB.
+		if maxResponseSize > 50*1024*1024 {
+			maxResponseSize = 50 * 1024 * 1024
 		}
 		// Check for compliance.
 		if maxResponseSize < 64*1024 {

--- a/pkg/source/mtadapter/adapter_test.go
+++ b/pkg/source/mtadapter/adapter_test.go
@@ -418,7 +418,7 @@ func TestAdjustResponseSize(t *testing.T) {
 		"no memory request":                           {memoryRequest: 0, sourceCount: 1, want: 100 * 1024 * 1024},
 		"memory request, response size less 64k":      {memoryRequest: 128 * 1024, sourceCount: 4, want: 32 * 1024},
 		"memory request, response size more 64k":      {memoryRequest: 512 * 1024, sourceCount: 4, want: 128 * 1024},
-		"memory request, response size more than cap": {memoryRequest: 100 * 1024 * 1024, sourceCount: 1, want: 50 * 1024 * 1024},
+		"memory request, response size more than cap": {memoryRequest: 100 * 1024 * 1024, sourceCount: 1, want: responseSizeCap},
 	}
 
 	for n, tc := range testCases {

--- a/pkg/source/mtadapter/adapter_test.go
+++ b/pkg/source/mtadapter/adapter_test.go
@@ -18,14 +18,17 @@ package mtadapter
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/Shopify/sarama"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	logtesting "knative.dev/pkg/logging/testing"
 	pkgtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/source"
 
@@ -51,7 +54,7 @@ func TestUpdateRemoveSources(t *testing.T) {
 	ctx, _ := pkgtesting.SetupFakeContext(t)
 	ctx, cancelAdapter := context.WithCancel(ctx)
 
-	env := &AdapterConfig{PodName: podName, MemoryLimit: "0"}
+	env := &AdapterConfig{PodName: podName, MemoryRequest: "0"}
 	ceClient := adaptertest.NewTestClient()
 
 	mtadapter := newAdapter(ctx, env, ceClient, newSampleAdapter).(*Adapter)
@@ -352,7 +355,7 @@ func TestSourceMTAdapter(t *testing.T) {
 
 			ctx, cancelAdapter := context.WithCancel(ctx)
 
-			env := &AdapterConfig{PodName: podName, MemoryLimit: "0"}
+			env := &AdapterConfig{PodName: podName, MemoryRequest: "0"}
 			ceClient := adaptertest.NewTestClient()
 
 			adapter := newAdapter(ctx, env, ceClient, newSampleAdapter).(*Adapter)
@@ -404,4 +407,40 @@ func (d *sampleAdapter) Start(ctx context.Context) error {
 	stoppingAdapterChan <- d
 
 	return nil
+}
+
+func TestAdjustResponseSize(t *testing.T) {
+	testCases := map[string]struct {
+		memoryRequest int64
+		sourceCount   int
+		want          int32
+	}{
+		"no memory request":                      {memoryRequest: 0, sourceCount: 1, want: 100 * 1024 * 1024},
+		"memory request, response size less 64k": {memoryRequest: 128 * 1024, sourceCount: 4, want: 32 * 1024},
+		"memory request, response size more 64k": {memoryRequest: 512 * 1024, sourceCount: 4, want: 128 * 1024},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			// must run sequentially.
+			sarama.MaxResponseSize = 100 * 1024 * 1024
+
+			sources := make(map[string]cancelContext)
+			for i := 0; i < tc.sourceCount; i++ {
+				sources["s"+strconv.Itoa(i)] = cancelContext{}
+			}
+
+			a := Adapter{
+				memoryRequest: tc.memoryRequest,
+				sources:       sources,
+				logger:        logtesting.TestLogger(t),
+			}
+			a.adjustResponseSize()
+
+			if sarama.MaxResponseSize != tc.want {
+				t.Errorf("Unexpected MaxResponseSize. wanted %d, got %d", tc.want, sarama.MaxResponseSize)
+			}
+		})
+	}
+
 }

--- a/pkg/source/mtadapter/adapter_test.go
+++ b/pkg/source/mtadapter/adapter_test.go
@@ -415,9 +415,10 @@ func TestAdjustResponseSize(t *testing.T) {
 		sourceCount   int
 		want          int32
 	}{
-		"no memory request":                      {memoryRequest: 0, sourceCount: 1, want: 100 * 1024 * 1024},
-		"memory request, response size less 64k": {memoryRequest: 128 * 1024, sourceCount: 4, want: 32 * 1024},
-		"memory request, response size more 64k": {memoryRequest: 512 * 1024, sourceCount: 4, want: 128 * 1024},
+		"no memory request":                           {memoryRequest: 0, sourceCount: 1, want: 100 * 1024 * 1024},
+		"memory request, response size less 64k":      {memoryRequest: 128 * 1024, sourceCount: 4, want: 32 * 1024},
+		"memory request, response size more 64k":      {memoryRequest: 512 * 1024, sourceCount: 4, want: 128 * 1024},
+		"memory request, response size more than cap": {memoryRequest: 100 * 1024 * 1024, sourceCount: 1, want: 50 * 1024 * 1024},
 	}
 
 	for n, tc := range testCases {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- MaxResponseSize is now Container Memory request / # of source instances in container. Cap at 50MB 
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
