### PR TITLE
Support eventing metrics

### DIFF
--- a/pkg/channel/consolidated/dispatcher/consumer_message_handler.go
+++ b/pkg/channel/consolidated/dispatcher/consumer_message_handler.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 
+	nethttp "net/http"
+
 	"github.com/Shopify/sarama"
 	protocolkafka "github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -29,7 +31,6 @@ import (
 	"knative.dev/eventing-kafka/pkg/common/tracing"
 	eventingchannels "knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/kncloudevents"
-	nethttp "net/http"
 )
 
 type consumerMessageHandler struct {

--- a/pkg/channel/consolidated/dispatcher/consumer_message_handler.go
+++ b/pkg/channel/consolidated/dispatcher/consumer_message_handler.go
@@ -77,6 +77,9 @@ func (c consumerMessageHandler) Handle(ctx context.Context, consumerMessage *sar
 	te := kncloudevents.TypeExtractorTransformer("")
 
 	bufferedMessage, err := buffering.CopyMessage(ctx, message, &te)
+	if err != nil {
+		return false, err
+	}
 	args := eventingchannels.ReportArgs{
 		Ns:        c.channelNs,
 		EventType: string(te),

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -58,6 +58,7 @@ type KafkaDispatcherArgs struct {
 type KafkaDispatcher struct {
 	receiver   *eventingchannels.MessageReceiver
 	dispatcher *eventingchannels.MessageDispatcherImpl
+	reporter   eventingchannels.StatsReporter
 
 	// Receiver data structures
 	// map[string]eventingchannels.ChannelReference
@@ -112,6 +113,7 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 		return nil, err
 	}
 	reporter := eventingchannels.NewStatsReporter(containerName, kmeta.ChildName(podName, uuid.New().String()))
+	dispatcher.reporter = reporter
 	receiverFunc, err := eventingchannels.NewMessageReceiver(
 		func(ctx context.Context, channel eventingchannels.ChannelReference, message binding.Message, transformers []binding.Transformer, _ nethttp.Header) error {
 			kafkaProducerMessage := sarama.ProducerMessage{
@@ -303,6 +305,8 @@ func (d *KafkaDispatcher) subscribe(channelRef types.NamespacedName, sub Subscri
 		d.dispatcher,
 		kafkaSubscription,
 		groupID,
+		d.reporter,
+		channelRef.Namespace,
 	}
 	d.logger.Debugw("Starting consumer group", zap.Any("channelRef", channelRef),
 		zap.Any("subscription", sub.UID), zap.String("topic", topicName), zap.String("consumer group", groupID))

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -18,11 +18,8 @@ package dispatcher
 import (
 	"context"
 	"fmt"
-	nethttp "net/http"
 	"strings"
 	"sync"
-
-	"knative.dev/eventing-kafka/pkg/common/config"
 
 	"github.com/Shopify/sarama"
 	protocolkafka "github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
@@ -32,6 +29,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/eventing-kafka/pkg/common/config"
 	"knative.dev/pkg/logging"
 
 	eventingchannels "knative.dev/eventing/pkg/channel"
@@ -41,6 +39,7 @@ import (
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/env"
 	"knative.dev/eventing-kafka/pkg/common/consumer"
 	"knative.dev/eventing-kafka/pkg/common/tracing"
+	nethttp "net/http"
 )
 
 const (

--- a/pkg/channel/consolidated/dispatcher/dispatcher.go
+++ b/pkg/channel/consolidated/dispatcher/dispatcher.go
@@ -35,11 +35,12 @@ import (
 	eventingchannels "knative.dev/eventing/pkg/channel"
 	"knative.dev/pkg/kmeta"
 
+	nethttp "net/http"
+
 	"knative.dev/eventing-kafka/pkg/channel/consolidated/utils"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/env"
 	"knative.dev/eventing-kafka/pkg/common/consumer"
 	"knative.dev/eventing-kafka/pkg/common/tracing"
-	nethttp "net/http"
 )
 
 const (


### PR DESCRIPTION
Fixes #683 

Sample output:
```
# HELP kafkachannel_dispatcher_event_count Number of events dispatched by the channel
# TYPE kafkachannel_dispatcher_event_count counter
kafkachannel_dispatcher_event_count{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a"} 2
kafkachannel_dispatcher_event_count{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a"} 3
# HELP kafkachannel_dispatcher_event_dispatch_latencies The time spent by the channel dispatching an event
# TYPE kafkachannel_dispatcher_event_dispatch_latencies histogram
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="1"} 0
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="2"} 0
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="5"} 1
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="10"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="20"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="50"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="100"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="200"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="500"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="1000"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="2000"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="5000"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="10000"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="+Inf"} 2
kafkachannel_dispatcher_event_dispatch_latencies_sum{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a"} 7
kafkachannel_dispatcher_event_dispatch_latencies_count{container_name="dispatcher",event_type="dev.knative.apiserver.resource.add",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="1"} 0
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="2"} 0
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="5"} 1
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="10"} 1
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="20"} 1
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="50"} 1
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="100"} 2
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="200"} 3
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="500"} 3
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="1000"} 3
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="2000"} 3
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="5000"} 3
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="10000"} 3
kafkachannel_dispatcher_event_dispatch_latencies_bucket{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a",le="+Inf"} 3
kafkachannel_dispatcher_event_dispatch_latencies_sum{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a"} 190
kafkachannel_dispatcher_event_dispatch_latencies_count{container_name="dispatcher",event_type="dev.knative.apiserver.resource.update",namespace_name="default",response_code="200",response_code_class="2xx",unique_name="kafka-ch-dispatcher-68895d8745-bd888bfba0cbe24fb46b24bb140e613a"} 3
```
Emit metrics when they are consumed successfully by the subscriber.