### PR TITLE
Revert to setting consumer.fetch options instead of MaxReponseSize

### DIFF
--- a/config/source/multi/deployments/adapter.yaml
+++ b/config/source/multi/deployments/adapter.yaml
@@ -47,9 +47,11 @@ spec:
         - name: VREPLICA_LIMITS_MPS
           value: '50'
 
-        # The pod requested memory (see resources.requests.memory)
-        - name: REQUESTS_MEMORY
-          value: '300Mi'
+        # The memory limit, per vreplica. Must be a quantity.
+        # see https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L31
+        # Should be (pod requested memory - overhead) / pod capacity (see controller.yaml)
+        - name: VREPLICA_LIMITS_MEMORY
+          value: '6Mi'
 
         # DO NOT MODIFY: The values below are being filled by the kafka source controller
         # See 500-controller.yaml
@@ -64,11 +66,11 @@ spec:
 
         resources:
           requests:
-            cpu: 100m
-            memory: 300Mi
+            cpu: 1000m
+            memory: 700Mi # 600Mi for vreplicas + 100Mi overhead
           limits:
-            cpu: 200m
-            memory: 500Mi
+            cpu: 2000m
+            memory: 1000Mi
 
         ports:
         - name: metrics


### PR DESCRIPTION
Fixes #691

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Revert https://github.com/knative-sandbox/eventing-kafka/pull/668/files as MaxResponseSize does not work as expected (see #691 for an explanation)
- Beef up the adapter pod to be able to handle larger messages. Not a definitive number, we can adjust as we gather more data.
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
