### PR TITLE
Remove creation of new dispatcher when secret changes

### DIFF
--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -209,24 +209,19 @@ func flush(logger *zap.Logger) {
 
 // secretObserver is the callback function that handles changes to our Secret
 func secretObserver(ctx context.Context, secret *corev1.Secret) {
-	logger := logging.FromContext(ctx)
+	secretLogger := logging.FromContext(ctx)
 
 	if secret == nil {
-		logger.Warn("Nil Secret passed to secretObserver; ignoring")
+		secretLogger.Warn("Nil Secret passed to secretObserver; ignoring")
 		return
 	}
 
 	if dispatcher == nil {
 		// This typically happens during startup
-		logger.Debug("Dispatcher is nil during call to secretObserver; ignoring changes")
+		secretLogger.Debug("Dispatcher is nil during call to secretObserver; ignoring changes")
 		return
 	}
 
 	// Toss the new secret to the dispatcher for inspection and action
-	newDispatcher := dispatcher.SecretChanged(ctx, secret)
-	if newDispatcher != nil {
-		// The configuration change caused a new dispatcher to be created, so switch to that one
-		logger.Info("Secret Changed; Dispatcher Reconfigured")
-		dispatcher = newDispatcher
-	}
+	dispatcher.SecretChanged(ctx, secret)
 }

--- a/pkg/channel/distributed/dispatcher/controller/kafkachannel_test.go
+++ b/pkg/channel/distributed/dispatcher/controller/kafkachannel_test.go
@@ -218,6 +218,4 @@ func (m MockDispatcher) UpdateSubscriptions(_ []eventingduck.SubscriberSpec) map
 	return nil
 }
 
-func (m MockDispatcher) SecretChanged(_ context.Context, _ *corev1.Secret) dispatcher.Dispatcher {
-	return nil
-}
+func (m MockDispatcher) SecretChanged(_ context.Context, _ *corev1.Secret) {}

--- a/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
@@ -18,7 +18,6 @@ package dispatcher
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -66,7 +65,7 @@ func NewSubscriberWrapper(subscriberSpec eventingduck.SubscriberSpec, groupId st
 
 // Dispatcher Interface
 type Dispatcher interface {
-	SecretChanged(ctx context.Context, secret *corev1.Secret) Dispatcher
+	SecretChanged(ctx context.Context, secret *corev1.Secret)
 	Shutdown()
 	UpdateSubscriptions(subscriberSpecs []eventingduck.SubscriberSpec) map[eventingduck.SubscriberSpec]error
 }
@@ -276,8 +275,8 @@ func (d *DispatcherImpl) closeConsumerGroup(subscriber *SubscriberWrapper) {
 }
 
 // SecretChanged is called by the secretObserver handler function in main() so that
-// settings specific to the dispatcher may be extracted and the dispatcher restarted if necessary.
-func (d *DispatcherImpl) SecretChanged(ctx context.Context, secret *corev1.Secret) Dispatcher {
+// settings specific to the dispatcher may be changed if necessary
+func (d *DispatcherImpl) SecretChanged(ctx context.Context, secret *corev1.Secret) {
 
 	// Debug Log The Secret Change
 	d.Logger.Debug("New Secret Received", zap.String("secret.Name", secret.ObjectMeta.Name))
@@ -285,46 +284,47 @@ func (d *DispatcherImpl) SecretChanged(ctx context.Context, secret *corev1.Secre
 	kafkaAuthCfg := commonconfig.GetAuthConfigFromSecret(secret)
 	if kafkaAuthCfg == nil {
 		d.Logger.Warn("No auth config found in secret; ignoring update")
-		return nil
+		return
 	}
 
 	// Don't Restart Dispatcher If All Auth Settings Identical
 	if kafkaAuthCfg.SASL.HasSameSettings(d.SaramaConfig) {
 		d.Logger.Info("No relevant changes in Secret; ignoring update")
-		return nil
+		return
 	}
 
 	// Build New Config Using Existing Config And New Auth Settings
 	if kafkaAuthCfg.SASL.User == "" {
 		// The config builder expects the entire config object to be nil if not using auth
 		kafkaAuthCfg = nil
+		// Any existing SASL config must be cleared explicitly or the "WithExisting" builder will keep the old values
+		d.SaramaConfig.Net.SASL.Enable = false
+		d.SaramaConfig.Net.SASL.User = ""
+		d.SaramaConfig.Net.SASL.Password = ""
 	}
 	newConfig, err := client.NewConfigBuilder().WithExisting(d.SaramaConfig).WithAuth(kafkaAuthCfg).Build(ctx)
 	if err != nil {
 		d.Logger.Error("Unable to merge new auth into sarama settings", zap.Error(err))
-		return nil
+		return
 	}
 
 	// Create A New Dispatcher With The New Configuration (Reusing All Other Existing Config)
 	d.Logger.Info("Changes Detected In New Secret - Closing & Recreating Consumer Groups")
-	return d.reconfigure(newConfig, nil)
-}
 
-// reconfigure shuts down the current dispatcher and recreates it with new settings
-func (d *DispatcherImpl) reconfigure(newConfig *sarama.Config, ekConfig *commonconfig.EventingKafkaConfig) Dispatcher {
-	d.Shutdown()
+	// Close all of the ConsumerGroups so that the settings can be changed
+	// Note: Not calling d.Shutdown because we don't want to close the metrics channel here
+	for _, subscriber := range d.subscribers {
+		d.closeConsumerGroup(subscriber)
+	}
+
+	// The only values in the secret that matter here are the username, password, and SASL type, which are all part
+	// of the SaramaConfig, so that's all that needs to be modified
 	d.DispatcherConfig.SaramaConfig = newConfig
-	if ekConfig != nil {
-		// Currently the only thing that a new dispatcher might care about in the EventingKafkaConfig is the Brokers
-		d.DispatcherConfig.Brokers = strings.Split(ekConfig.Kafka.Brokers, ",")
-	}
-	newDispatcher := NewDispatcher(d.DispatcherConfig)
-	failedSubscriptions := newDispatcher.UpdateSubscriptions(d.SubscriberSpecs)
+
+	failedSubscriptions := d.UpdateSubscriptions(d.SubscriberSpecs)
 	if len(failedSubscriptions) > 0 {
-		d.Logger.Fatal("Failed To Subscribe Kafka Subscriptions For New Dispatcher", zap.Int("Count", len(failedSubscriptions)))
-		return nil
+		d.Logger.Fatal("Failed To Subscribe Kafka Subscriptions Using Updated Secret", zap.Int("Count", len(failedSubscriptions)))
 	}
-	return newDispatcher
 }
 
 // ObserveMetrics Is An Async Process For Observing Kafka Metrics

--- a/pkg/channel/distributed/dispatcher/dispatcher/dispatcher_test.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/dispatcher_test.go
@@ -71,8 +71,14 @@ func TestNewSubscriberWrapper(t *testing.T) {
 // Test The NewDispatcher() Functionality
 func TestNewDispatcher(t *testing.T) {
 
+	baseSaramaConfig, err := commonclient.NewConfigBuilder().
+		WithDefaults().
+		WithVersion(&sarama.V2_0_0_0).
+		Build(context.TODO())
+	assert.Nil(t, err)
+
 	// Perform The Test & Verify Results (Not Much To See Due To Interface)
-	createTestDispatcher(t, nil, nil)
+	createTestDispatcher(t, nil, baseSaramaConfig)
 }
 
 // Test The Dispatcher's Shutdown() Functionality
@@ -312,67 +318,55 @@ func TestSecretChanged(t *testing.T) {
 
 	// Define The TestCase Struct
 	type TestCase struct {
-		only                bool
 		name                string
 		newSecret           *corev1.Secret
-		expectNewDispatcher bool
+		expectEmptyUsername bool
+		expectNewUsername   string
+		expectNewPassword   string
+		expectNewSaslType   string
 	}
 
 	// Create The TestCases
 	testCases := []TestCase{
 		{
-			name:                "No Changes (Same Dispatcher)",
-			newSecret:           configtesting.NewKafkaSecret(),
-			expectNewDispatcher: false,
+			name:      "No Changes (No Modifications)",
+			newSecret: configtesting.NewKafkaSecret(),
 		},
 		{
-			name:                "Password Change (New Dispatcher)",
-			newSecret:           configtesting.NewKafkaSecret(configtesting.WithModifiedPassword),
-			expectNewDispatcher: true,
+			name:              "Password Change (Modifications)",
+			newSecret:         configtesting.NewKafkaSecret(configtesting.WithModifiedPassword),
+			expectNewPassword: configtesting.ModifiedSecretPassword,
 		},
 		{
-			name:                "Username Change (New Dispatcher)",
-			newSecret:           configtesting.NewKafkaSecret(configtesting.WithModifiedUsername),
-			expectNewDispatcher: true,
+			name:              "Username Change (Modifications)",
+			newSecret:         configtesting.NewKafkaSecret(configtesting.WithModifiedUsername),
+			expectNewUsername: configtesting.ModifiedSecretUsername,
 		},
 		{
-			name:                "Empty Username Change (New Dispatcher)",
+			name:                "Empty Username Change (Modifications)",
 			newSecret:           configtesting.NewKafkaSecret(configtesting.WithEmptyUsername),
-			expectNewDispatcher: true,
+			expectEmptyUsername: true,
 		},
 		{
-			name:                "SaslType Change (New Dispatcher)",
-			newSecret:           configtesting.NewKafkaSecret(configtesting.WithModifiedSaslType),
-			expectNewDispatcher: true,
+			name:              "SaslType Change (Modifications)",
+			newSecret:         configtesting.NewKafkaSecret(configtesting.WithModifiedSaslType),
+			expectNewSaslType: configtesting.ModifiedSecretSaslType,
 		},
 		{
-			name:                "Namespace Change (Same Dispatcher)",
-			newSecret:           configtesting.NewKafkaSecret(configtesting.WithModifiedNamespace),
-			expectNewDispatcher: false,
+			name:      "Namespace Change (No Modifications)",
+			newSecret: configtesting.NewKafkaSecret(configtesting.WithModifiedNamespace),
 		},
 		{
-			name:                "No Auth Config In Secret (Same Dispatcher)",
-			newSecret:           configtesting.NewKafkaSecret(configtesting.WithMissingConfig),
-			expectNewDispatcher: false,
+			name:      "No Auth Config In Secret (No Modifications)",
+			newSecret: configtesting.NewKafkaSecret(configtesting.WithMissingConfig),
 		},
-	}
-
-	// Filter To Those With "only" Flag (If Any Specified)
-	filteredTestCases := make([]TestCase, 0)
-	for _, testCase := range testCases {
-		if testCase.only {
-			filteredTestCases = append(filteredTestCases, testCase)
-		}
-	}
-	if len(filteredTestCases) == 0 {
-		filteredTestCases = testCases
 	}
 
 	// Make Sure To Restore The NewConsumerGroup Wrapper After The Test
 	defer consumertesting.RestoreNewConsumerGroupFn()
 
 	// Run The Filtered TestCases
-	for _, testCase := range filteredTestCases {
+	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 
 			// Mock The SyncProducer & Stub The NewConsumerGroupWrapper()
@@ -383,17 +377,23 @@ func TestSecretChanged(t *testing.T) {
 			dispatcher := createTestDispatcher(t, brokers, baseSaramaConfig)
 
 			// Perform The Test
-			newDispatcher := dispatcher.SecretChanged(ctx, testCase.newSecret)
+			dispatcher.SecretChanged(ctx, testCase.newSecret)
+			impl := dispatcher.(*DispatcherImpl)
+			assert.NotNil(t, impl)
 
-			// Verify Expected State (Not Much To Verify Due To Interface)
-			assert.Equal(t, testCase.expectNewDispatcher, newDispatcher != nil)
-
-			if testCase.expectNewDispatcher {
-				// Verify that the new dispatcher's channels are not the same as the original
-				oldImpl := dispatcher.(*DispatcherImpl)
-				newImpl := newDispatcher.(*DispatcherImpl)
-				assert.NotEqual(t, oldImpl.MetricsStopChan, newImpl.MetricsStopChan)
-				assert.NotEqual(t, oldImpl.MetricsStoppedChan, newImpl.MetricsStoppedChan)
+			if testCase.expectEmptyUsername {
+				// An empty username in the secret will force no-authorization even if it was enabled before
+				assert.Equal(t, false, impl.SaramaConfig.Net.SASL.Enable)
+				assert.Equal(t, "", impl.SaramaConfig.Net.SASL.User)
+				assert.Equal(t, "", impl.SaramaConfig.Net.SASL.Password)
+			} else if testCase.expectNewUsername != "" {
+				assert.Equal(t, testCase.expectNewUsername, impl.SaramaConfig.Net.SASL.User)
+			}
+			if testCase.expectNewPassword != "" {
+				assert.Equal(t, testCase.expectNewPassword, impl.SaramaConfig.Net.SASL.Password)
+			}
+			if testCase.expectNewSaslType != "" {
+				assert.Equal(t, testCase.expectNewSaslType, string(impl.SaramaConfig.Net.SASL.Mechanism))
 			}
 		})
 	}
@@ -421,6 +421,7 @@ func createTestDispatcher(t *testing.T, brokers []string, config *sarama.Config)
 		Logger:          logger,
 		Brokers:         brokers,
 		StatsReporter:   statsReporter,
+		MetricsRegistry: config.MetricRegistry,
 		SaramaConfig:    config,
 		SubscriberSpecs: subscriberSpecs,
 	}

--- a/pkg/channel/distributed/dispatcher/dispatcher/dispatcher_test.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/dispatcher_test.go
@@ -375,10 +375,11 @@ func TestSecretChanged(t *testing.T) {
 
 			// Create A Test Dispatcher To Perform Tests Against
 			dispatcher := createTestDispatcher(t, brokers, baseSaramaConfig)
+			impl := dispatcher.(*DispatcherImpl)
+			impl.subscribers = map[types.UID]*SubscriberWrapper{uid123: createSubscriberWrapper(uid123)}
 
 			// Perform The Test
 			dispatcher.SecretChanged(ctx, testCase.newSecret)
-			impl := dispatcher.(*DispatcherImpl)
 			assert.NotNil(t, impl)
 
 			if testCase.expectEmptyUsername {

--- a/pkg/channel/distributed/receiver/producer/producer.go
+++ b/pkg/channel/distributed/receiver/producer/producer.go
@@ -19,7 +19,6 @@ package producer
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -195,6 +194,10 @@ func (p *Producer) SecretChanged(ctx context.Context, secret *corev1.Secret) *Pr
 	if kafkaAuthCfg.SASL.User == "" {
 		// The config builder expects the entire config object to be nil if not using auth
 		kafkaAuthCfg = nil
+		// Any existing SASL config must be cleared explicitly or the "WithExisting" builder will keep the old values
+		p.configuration.Net.SASL.Enable = false
+		p.configuration.Net.SASL.User = ""
+		p.configuration.Net.SASL.Password = ""
 	}
 	newConfig, err := client.NewConfigBuilder().WithExisting(p.configuration).WithAuth(kafkaAuthCfg).Build(ctx)
 	if err != nil {
@@ -204,7 +207,18 @@ func (p *Producer) SecretChanged(ctx context.Context, secret *corev1.Secret) *Pr
 
 	// Create A New Producer With The New Configuration (Reusing All Other Existing Config)
 	p.logger.Info("Changes Detected In New Secret - Closing & Recreating Producer")
-	return p.reconfigure(newConfig, nil)
+
+	// Shut down the current producer and recreate it with new settings
+	p.Close()
+	reconfiguredKafkaProducer, err := NewProducer(p.logger, newConfig, p.brokers, p.statsReporter, p.healthServer)
+	if err != nil {
+		p.logger.Fatal("Failed To Create Kafka Producer With New Configuration", zap.Error(err))
+		return nil
+	}
+
+	// Successfully Created New Producer - Close Old One And Return New One
+	p.logger.Info("Successfully Created New Producer")
+	return reconfiguredKafkaProducer
 }
 
 // Close The Producer (Stop Processing)
@@ -224,22 +238,4 @@ func (p *Producer) Close() {
 	} else {
 		p.logger.Info("Successfully Closed Kafka Producer")
 	}
-}
-
-// Shut down the current producer and recreate it with new settings
-func (p *Producer) reconfigure(newConfig *sarama.Config, ekConfig *commonconfig.EventingKafkaConfig) *Producer {
-	p.Close()
-	if ekConfig != nil {
-		// Currently the only thing that a new producer might care about in the EventingKafkaConfig is the Brokers
-		p.brokers = strings.Split(ekConfig.Kafka.Brokers, ",")
-	}
-	reconfiguredKafkaProducer, err := NewProducer(p.logger, newConfig, p.brokers, p.statsReporter, p.healthServer)
-	if err != nil {
-		p.logger.Fatal("Failed To Create Kafka Producer With New Configuration", zap.Error(err))
-		return nil
-	}
-
-	// Successfully Created New Producer - Close Old One And Return New One
-	p.logger.Info("Successfully Created New Producer")
-	return reconfiguredKafkaProducer
 }

--- a/pkg/common/config/testing/util.go
+++ b/pkg/common/config/testing/util.go
@@ -20,9 +20,10 @@ import (
 	"github.com/Shopify/sarama"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/system"
+
 	commonconstants "knative.dev/eventing-kafka/pkg/common/constants"
 	commontesting "knative.dev/eventing-kafka/pkg/common/testing"
-	"knative.dev/pkg/system"
 )
 
 // Constants

--- a/pkg/common/config/testing/util.go
+++ b/pkg/common/config/testing/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"github.com/Shopify/sarama"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	commonconstants "knative.dev/eventing-kafka/pkg/common/constants"
@@ -29,8 +30,13 @@ const (
 	DefaultKafkaBroker     = "TestBroker"
 	DefaultSecretUsername  = "TestUsername"
 	DefaultSecretPassword  = "TestPassword"
-	DefaultSecretSaslType  = "PLAIN"
+	DefaultSecretSaslType  = sarama.SASLTypePlaintext
 	DefaultSecretNamespace = "TestNamespace"
+
+	ModifiedSecretUsername  = "TestModifiedUsername"
+	ModifiedSecretPassword  = "TestModifiedPassword"
+	ModifiedSecretSaslType  = sarama.SASLTypeSCRAMSHA256
+	ModifiedSecretNamespace = "TestModifiedNamespace"
 )
 
 // KafkaSecretOption Enables Customization Of An Eventing-Kafka Secret
@@ -68,12 +74,12 @@ func NewKafkaSecret(options ...KafkaSecretOption) *corev1.Secret {
 
 // WithModifiedPassword Modifies The Default Password Section Of The Secret Data
 func WithModifiedPassword(secret *corev1.Secret) {
-	secret.Data[commonconstants.KafkaSecretKeyPassword] = []byte("TestModifiedPassword")
+	secret.Data[commonconstants.KafkaSecretKeyPassword] = []byte(ModifiedSecretPassword)
 }
 
 // WithModifiedUsername Modifies The Default Username Section Of The Secret Data
 func WithModifiedUsername(secret *corev1.Secret) {
-	secret.Data[commonconstants.KafkaSecretKeyUsername] = []byte("TestModifiedUsername")
+	secret.Data[commonconstants.KafkaSecretKeyUsername] = []byte(ModifiedSecretUsername)
 }
 
 // WithEmptyUsername Empties The Default Username Section Of The Secret Data
@@ -83,12 +89,12 @@ func WithEmptyUsername(secret *corev1.Secret) {
 
 // WithModifiedSaslType Modifies The Default SaslType Section Of The Secret Data
 func WithModifiedSaslType(secret *corev1.Secret) {
-	secret.Data[commonconstants.KafkaSecretKeySaslType] = []byte("TestModifiedSaslType")
+	secret.Data[commonconstants.KafkaSecretKeySaslType] = []byte(ModifiedSecretSaslType)
 }
 
 // WithModifiedNamespace Modifies The Default Namespace Section Of The Secret Data
 func WithModifiedNamespace(secret *corev1.Secret) {
-	secret.Data[commonconstants.KafkaSecretKeyNamespace] = []byte("TestModifiedNamespace")
+	secret.Data[commonconstants.KafkaSecretKeyNamespace] = []byte(ModifiedSecretNamespace)
 }
 
 // WithMissingConfig Removes the Data From The Secret


### PR DESCRIPTION
This isn't directly tied to an issue, but the changes for #537 made a few things in the distributed channel's "reconfigure" function obsolete; in particular it used to be called when the configmap changed as well, which could require a new dispatcher.  Now the only possible changes are from the secret, which is limited to username/password/SASLtype.  Changing those settings does not require a new dispatcher, so this PR will remove that behavior.

I would leave this alone but there is also a bug in the way the new dispatcher is created which leaves the old dispatcher referenced in the dispatcher's controller.  The controller.NewController call uses the original dispatcher and nothing ever changes that, which is something that will cause a problem with some upcoming changes that include a "consumer group manager" that maintains some state information about consumer groups.  This manager can't have "a different manager" in an abandoned dispatcher elsewhere, so it needs to be fixed.

## Proposed Changes

- 🧽  Changing the kafka-cluster secret no longer creates a new distributed dispatcher; instead simply reconfigures the existing one
- 🐛 Removing (vs. changing) authentication by changing the kafka-cluster secret had no effect; now it removes the auth properly (dispatcher and receiver)
- 🧽  merged the "reconfigure" functions from dispatcher and receiver into the SecretChanged functions (since they were only being called once now that there is no longer ConfigMap-watching functionality in these components)
