### PR TITLE
Change podDisruptionBudget for webhook to 1

### DIFF
--- a/config/channel/webhook/webhook-hpa.yaml
+++ b/config/channel/webhook/webhook-hpa.yaml
@@ -43,7 +43,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 spec:
-  minAvailable: 80%
+  minAvailable: 1
   selector:
     matchLabels:
       app: kafka-webhook


### PR DESCRIPTION
Changing the pdb to match the hpa's minimum availability

## Proposed Changes
- Change the minimum available pods to absolute (1) value instead of percentage

- 🧽 Update or clean up current behavior

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The kafka-webhook's PodDisruptionBudget.minAvailable has been changed from 80% to an absolute value of 1
```