### PR TITLE
[scheduler] Compact vreplicas

### DIFF
--- a/pkg/common/scheduler/scheduler.go
+++ b/pkg/common/scheduler/scheduler.go
@@ -31,6 +31,9 @@ var (
 // VPodLister is the function signature for returning a list of VPods
 type VPodLister func() ([]VPod, error)
 
+// Evictor allows for vreplicas to be evicted
+type Evictor func(vpod VPod, from *duckv1alpha1.Placement) error
+
 // Scheduler is responsible for placing VPods into real Kubernetes pods
 type Scheduler interface {
 	// Schedule computes the new set of placements for vpod.

--- a/pkg/common/scheduler/scheduler.go
+++ b/pkg/common/scheduler/scheduler.go
@@ -31,7 +31,9 @@ var (
 // VPodLister is the function signature for returning a list of VPods
 type VPodLister func() ([]VPod, error)
 
-// Evictor allows for vreplicas to be evicted
+// Evictor allows for vreplicas to be evicted.
+// For instance, the evictor is used by the statefulset scheduler to
+// move vreplicas to pod with a lower ordinal.
 type Evictor func(vpod VPod, from *duckv1alpha1.Placement) error
 
 // Scheduler is responsible for placing VPods into real Kubernetes pods

--- a/pkg/common/scheduler/statefulset/autoscaler.go
+++ b/pkg/common/scheduler/statefulset/autoscaler.go
@@ -208,7 +208,11 @@ func (a *autoscaler) compact(s *state) error {
 			ordinal := ordinalFromPodName(placement.PodName)
 
 			if ordinal == s.lastOrdinal {
-				a.logger.Infow("evicting vreplica(s)", zap.String("podname", placement.PodName), zap.Int("vreplicas", int(placement.VReplicas)))
+				a.logger.Infow("evicting vreplica(s)",
+					zap.String("name", vpod.GetKey().Name),
+					zap.String("namespace", vpod.GetKey().Namespace),
+					zap.String("podname", placement.PodName),
+					zap.Int("vreplicas", int(placement.VReplicas)))
 
 				err = a.evictor(vpod, &placement)
 				if err != nil {

--- a/pkg/common/scheduler/statefulset/autoscaler.go
+++ b/pkg/common/scheduler/statefulset/autoscaler.go
@@ -47,7 +47,7 @@ type autoscaler struct {
 	logger            *zap.SugaredLogger
 	stateAccessor     stateAccessor
 	trigger           chan int32
-	evict             scheduler.Evictor
+	evictor           scheduler.Evictor
 
 	// capacity is the total number of virtual replicas available per pod.
 	capacity int32
@@ -70,7 +70,7 @@ func NewAutoscaler(ctx context.Context,
 		statefulSetName:   name,
 		vpodLister:        lister,
 		stateAccessor:     stateAccessor,
-		evict:             evictor,
+		evictor:           evictor,
 		trigger:           make(chan int32, 1),
 		capacity:          capacity,
 		refreshPeriod:     refreshPeriod,
@@ -210,7 +210,7 @@ func (a *autoscaler) compact(s *state) error {
 			if ordinal == s.lastOrdinal {
 				a.logger.Infow("evicting vreplica(s)", zap.String("podname", placement.PodName), zap.Int("vreplicas", int(placement.VReplicas)))
 
-				err = a.evict(vpod, &placement)
+				err = a.evictor(vpod, &placement)
 				if err != nil {
 					return err
 				}

--- a/pkg/source/reconciler/mtsource/controller.go
+++ b/pkg/source/reconciler/mtsource/controller.go
@@ -18,9 +18,15 @@ package mtsource
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kelseyhightower/envconfig"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis/duck"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -30,18 +36,20 @@ import (
 
 	"knative.dev/eventing/pkg/reconciler/source"
 
+	duckv1alpha1 "knative.dev/eventing-kafka/pkg/apis/duck/v1alpha1"
 	sourcesv1beta1 "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
 	kafkaclient "knative.dev/eventing-kafka/pkg/client/injection/client"
 	kafkainformer "knative.dev/eventing-kafka/pkg/client/injection/informers/sources/v1beta1/kafkasource"
 	"knative.dev/eventing-kafka/pkg/client/injection/reconciler/sources/v1beta1/kafkasource"
-	scheduler "knative.dev/eventing-kafka/pkg/common/scheduler/statefulset"
+	scheduler "knative.dev/eventing-kafka/pkg/common/scheduler"
+	stsscheduler "knative.dev/eventing-kafka/pkg/common/scheduler/statefulset"
 	nodeinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/node"
 )
 
 type envConfig struct {
-	SchedulerRefreshPeriod int64                         `envconfig:"AUTOSCALER_REFRESH_PERIOD" required:"true"`
-	PodCapacity            int32                         `envconfig:"POD_CAPACITY" required:"true"`
-	SchedulerPolicy        scheduler.SchedulerPolicyType `envconfig:"SCHEDULER_POLICY_TYPE" required:"true"`
+	SchedulerRefreshPeriod int64                            `envconfig:"AUTOSCALER_REFRESH_PERIOD" required:"true"`
+	PodCapacity            int32                            `envconfig:"POD_CAPACITY" required:"true"`
+	SchedulerPolicy        stsscheduler.SchedulerPolicyType `envconfig:"SCHEDULER_POLICY_TYPE" required:"true"`
 }
 
 func NewController(
@@ -73,7 +81,53 @@ func NewController(
 	sourcesv1beta1.RegisterAlternateKafkaConditionSet(sourcesv1beta1.KafkaMTSourceCondSet)
 
 	rp := time.Duration(env.SchedulerRefreshPeriod) * time.Second
-	c.scheduler = scheduler.NewScheduler(ctx, system.Namespace(), mtadapterName, c.vpodLister, rp, env.PodCapacity, env.SchedulerPolicy, nodeInformer.Lister())
+	evictor := func(vpod scheduler.VPod, from *duckv1alpha1.Placement) error {
+		key := vpod.GetKey()
+		sources := kafkaclient.Get(ctx).SourcesV1beta1().KafkaSources(key.Namespace)
+
+		before, err := sources.Get(ctx, key.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		after := before.DeepCopy()
+
+		bp := after.GetPlacements()
+		ap := make([]duckv1alpha1.Placement, 0, len(bp)-1)
+		for _, p := range bp {
+			if p.PodName != from.PodName {
+				ap = append(ap, p)
+			}
+		}
+		after.Status.Placement = ap
+
+		jsonPatch, err := duck.CreatePatch(before, after)
+		if err != nil {
+			return err
+		}
+
+		// If there is nothing to patch, we are good, just return.
+		// Empty patch is [], hence we check for that.
+		if len(jsonPatch) == 0 {
+			return nil
+		}
+
+		patch, err := jsonPatch.MarshalJSON()
+		if err != nil {
+			return fmt.Errorf("marshaling JSON patch: %w", err)
+		}
+
+		patched, err := kafkaclient.Get(ctx).SourcesV1beta1().KafkaSources(key.Namespace).Patch(ctx, key.Name, types.JSONPatchType, patch, metav1.PatchOptions{}, "status")
+		if err != nil {
+			return fmt.Errorf("Failed patching: %w", err)
+		}
+		logging.FromContext(ctx).Debugw("Patched resource", zap.Any("patch", patch), zap.Any("patched", patched))
+		return nil
+	}
+
+	c.scheduler = stsscheduler.NewScheduler(ctx,
+		system.Namespace(), mtadapterName, c.vpodLister, rp, env.PodCapacity, env.SchedulerPolicy,
+		nodeInformer.Lister(), evictor)
 
 	logging.FromContext(ctx).Info("Setting up kafka event handlers")
 	kafkaInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))


### PR DESCRIPTION
Fixes #699

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- The statefulset autoscaler now attempts to compact vreplicas (MaxFillUp strategy only)
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🎁 The multi-tenant KafkaSource controller periodically attempts to relocate KafkaSource consumers to Statefulset pods with a lower ordinal
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
