### PR TITLE
Add resource requests and limits to kafka-webhook

### DIFF
--- a/config/channel/webhook/webhook-deployment.yaml
+++ b/config/channel/webhook/webhook-deployment.yaml
@@ -58,13 +58,11 @@ spec:
           containerPort: 8008
         resources:
           requests:
-            # taken from serving.
             cpu: 100m
             memory: 50Mi
           limits:
-            # taken from serving.
             cpu: 200m
-            memory: 200Mi
+            memory: 1024Mi
         readinessProbe: &probe
           periodSeconds: 1
           httpGet:

--- a/config/channel/webhook/webhook-deployment.yaml
+++ b/config/channel/webhook/webhook-deployment.yaml
@@ -56,8 +56,15 @@ spec:
           containerPort: 9090
         - name: profiling
           containerPort: 8008
-        # TODO set proper resource limits.
-
+        resources:
+          requests:
+            # taken from serving.
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            # taken from serving.
+            cpu: 200m
+            memory: 200Mi
         readinessProbe: &probe
           periodSeconds: 1
           httpGet:


### PR DESCRIPTION
The horizontalPodAutoscaler fails without set resources.

## Proposed Changes
- Add resources (values taken from serving, similar to eventing webhook defaults)
- :bug: Allows for hpa to work for kafka-webhook

**Release Note**
```release-note
The kafka-webhook deployment now sets resource requests and limits to enable hpa
```
