### PR TITLE
Update control-protocol version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	k8s.io/apimachinery v0.20.7
 	k8s.io/client-go v0.20.7
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
-	knative.dev/control-protocol v0.0.0-20210608143842-1c4b3e61cbc0
+	knative.dev/control-protocol v0.0.0-20210616092621-1469a722be79
 	knative.dev/eventing v0.23.1-0.20210615213121-4eb1738b5e35
 	knative.dev/hack v0.0.0-20210614141220-66ab1a098940
 	knative.dev/networking v0.0.0-20210615114921-e291c8011a20

--- a/go.sum
+++ b/go.sum
@@ -1346,8 +1346,8 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-knative.dev/control-protocol v0.0.0-20210608143842-1c4b3e61cbc0 h1:dakdOWnuJDlykt6/UkfiFz6ddoUd2P3Bc4sL1aF0VvE=
-knative.dev/control-protocol v0.0.0-20210608143842-1c4b3e61cbc0/go.mod h1:iRE6O4mY88gH6xWl6ZFhG6sJobzrZjFrz5xhX4h93Ns=
+knative.dev/control-protocol v0.0.0-20210616092621-1469a722be79 h1:CepZkHLRpqnQtdbYtXa7R/V5LbjxzkKIQdQxNOFyrhY=
+knative.dev/control-protocol v0.0.0-20210616092621-1469a722be79/go.mod h1:iRE6O4mY88gH6xWl6ZFhG6sJobzrZjFrz5xhX4h93Ns=
 knative.dev/eventing v0.23.1-0.20210615213121-4eb1738b5e35 h1:+XbEA0ge3iiWi7on4tLhM3T14YR7FtC8ts2GPAVvAYk=
 knative.dev/eventing v0.23.1-0.20210615213121-4eb1738b5e35/go.mod h1:d4zElgG7AL4zDt7CY7aW6BHdITgkUifk7Hskl5p1JEI=
 knative.dev/hack v0.0.0-20210601210329-de04b70e00d0/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=

--- a/pkg/source/reconciler/source/kafkasource.go
+++ b/pkg/source/reconciler/source/kafkasource.go
@@ -109,7 +109,7 @@ type Reconciler struct {
 	configs KafkaSourceConfigAccessor
 
 	podIpGetter             ctrlreconciler.PodIpGetter
-	connectionPool          *ctrlreconciler.ControlPlaneConnectionPool
+	connectionPool          ctrlreconciler.ControlPlaneConnectionPool
 	claimsNotificationStore *ctrlreconciler.NotificationStore
 }
 

--- a/vendor/knative.dev/control-protocol/pkg/reconciler/connection_pool_option.go
+++ b/vendor/knative.dev/control-protocol/pkg/reconciler/connection_pool_option.go
@@ -18,10 +18,10 @@ package reconciler
 
 import control "knative.dev/control-protocol/pkg"
 
-type ControlPlaneConnectionPoolOption func(*ControlPlaneConnectionPool)
+type ControlPlaneConnectionPoolOption func(*controlPlaneConnectionPoolImpl)
 
 func WithServiceWrapper(wrapper control.ServiceWrapper) ControlPlaneConnectionPoolOption {
-	return func(pool *ControlPlaneConnectionPool) {
+	return func(pool *controlPlaneConnectionPoolImpl) {
 		pool.serviceWrapperFactories = append(pool.serviceWrapperFactories, wrapper)
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1110,7 +1110,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/control-protocol v0.0.0-20210608143842-1c4b3e61cbc0
+# knative.dev/control-protocol v0.0.0-20210616092621-1469a722be79
 ## explicit
 knative.dev/control-protocol/pkg
 knative.dev/control-protocol/pkg/certificates


### PR DESCRIPTION
I need to pull in the latest control-protocol version which exposes interfaces in order to test new ResetOffset (Replay) work.  This PR includes the new version and a minor adjustment to the KafkaSource which is the only current user of the control-protocol.

## Proposed Changes

🎁  Updated control-protocol to version with interfaces.
