### PR TITLE
Adding RetentionMillis at kafka channel spec level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.iml
 .idea/
 .run/
+.history/
 
 # System Files
 .DS_Store

--- a/config/channel/resources/kafkachannel-crd.yaml
+++ b/config/channel/resources/kafkachannel-crd.yaml
@@ -49,7 +49,7 @@ spec:
                   maximum: 32767
                   default: 1
                 retentionMillis:
-                  description: retentionMillis is the topic retention period (in ms) of a Kafka Topic. This is an optional field. By default, the Channel default retention time would be used
+                  description: retentionMillis is the topic retention period (in ms) of a Kafka Topic. This is an optional field. By default, the Channel default retention time provided in the ConfigMap would be used. If the default value is not provided in Config Map, 604800000(1 week) is used.
                   type: integer
                 delivery:
                   description: DeliverySpec contains the default delivery spec for each subscription to this Channelable. Each subscription delivery spec, if any, overrides this global delivery spec.

--- a/config/channel/resources/kafkachannel-crd.yaml
+++ b/config/channel/resources/kafkachannel-crd.yaml
@@ -48,6 +48,9 @@ spec:
                   type: integer
                   maximum: 32767
                   default: 1
+                retentionMillis:
+                  description: retentionMillis is the topic retention period (in ms) of a Kafka Topic. This is an optional field. By default, the Channel default retention time would be used
+                  type: integer
                 delivery:
                   description: DeliverySpec contains the default delivery spec for each subscription to this Channelable. Each subscription delivery spec, if any, overrides this global delivery spec.
                   type: object

--- a/pkg/apis/messaging/v1beta1/kafka_channel_types.go
+++ b/pkg/apis/messaging/v1beta1/kafka_channel_types.go
@@ -67,6 +67,10 @@ type KafkaChannelSpec struct {
 	// ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.
 	ReplicationFactor int16 `json:"replicationFactor"`
 
+	// RetentionMillis is the retention Time period (in millisecond) of a Kafka topic.
+	// +optional
+	RetentionMillis int64 `json:"retentionMillis,omitempty"`
+
 	// Channel conforms to Duck type Channelable.
 	eventingduck.ChannelableSpec `json:",inline"`
 }

--- a/pkg/channel/consolidated/README.md
+++ b/pkg/channel/consolidated/README.md
@@ -52,11 +52,13 @@ topics.
    spec:
      numPartitions: 1
      replicationFactor: 1
+     retentionMillis: 604800000
    ```
 
    You can configure the number of partitions with `numPartitions`, as well as
-   the replication factor with `replicationFactor`. If not set, both will
-   default to the values provided in the `eventing-kafka.kafka.topic` section of
+   the replication factor with `replicationFactor`. You can set the 
+   retention Time of topic (in millisecond) with `retentionMillis`. If not set, 
+   all values will default to the values provided in the `eventing-kafka.kafka.topic` section of
    the `config-kafka` ConfigMap.
 
 ## Components
@@ -136,6 +138,7 @@ metadata:
 spec:
   numPartitions: 1
   replicationFactor: 1
+  retentionMillis: 604800000
 ```
 
 The dispatcher is created in `<YOUR_NAMESPACE>`:

--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -546,11 +546,7 @@ func (r *Reconciler) reconcileTopic(ctx context.Context, channel *v1beta1.KafkaC
 	logger.Infow("Creating topic on Kafka cluster", zap.String("topic", topicName),
 		zap.Int32("partitions", channel.Spec.NumPartitions), zap.Int16("replication", channel.Spec.ReplicationFactor))
 
-	// TODO - The eventing-kafka KafkaChannel spec does not include RetentionMillis so we're
-	//        currently just using the default value specified in the ConfigMap.  If/when the
-	//        RetentionMillis is added, any value from channel.Spec.RetentionMillis should
-	//        take precedence.
-	retentionMillisString := strconv.FormatInt(r.kafkaConfig.EventingKafka.Kafka.Topic.DefaultRetentionMillis, 10)
+	retentionMillisString := strconv.FormatInt(commonconfig.RetentionMillis(channel, r.kafkaConfig.EventingKafka, logger), 10)
 
 	err := kafkaClusterAdmin.CreateTopic(topicName, &sarama.TopicDetail{
 		ReplicationFactor: commonconfig.ReplicationFactor(channel, r.kafkaConfig.EventingKafka, logger),

--- a/pkg/channel/distributed/controller/kafkachannel/topic.go
+++ b/pkg/channel/distributed/controller/kafkachannel/topic.go
@@ -48,11 +48,7 @@ func (r *Reconciler) reconcileKafkaTopic(ctx context.Context, channel *kafkav1be
 	numPartitions := config.NumPartitions(channel, r.config, logger)
 	replicationFactor := config.ReplicationFactor(channel, r.config, logger)
 
-	// TODO - The eventing-kafka KafkaChannel spec does not include RetentionMillis so we're
-	//        currently just using the default value specified in the ConfigMap.  If/when the
-	//        RetentionMillis is added, any value from channel.Spec.RetentionMillis should
-	//        take precedence.
-	retentionMillis := r.config.Kafka.Topic.DefaultRetentionMillis
+	retentionMillis := config.RetentionMillis(channel, r.config, logger)
 
 	// Create The Topic (Handles Case Where Already Exists)
 	err := r.createTopic(ctx, topicName, numPartitions, replicationFactor, retentionMillis)

--- a/pkg/channel/distributed/controller/kafkachannel/topic_test.go
+++ b/pkg/channel/distributed/controller/kafkachannel/topic_test.go
@@ -85,7 +85,7 @@ func TestReconcileTopic(t *testing.T) {
 			WantTopicDetail: &sarama.TopicDetail{
 				NumPartitions:     controllertesting.NumPartitions,
 				ReplicationFactor: controllertesting.ReplicationFactor,
-				ConfigEntries:     map[string]*string{commonconstants.KafkaTopicConfigRetentionMs: &controllertesting.DefaultRetentionMillisString},
+				ConfigEntries:     map[string]*string{commonconstants.KafkaTopicConfigRetentionMs: &controllertesting.RetentionMillisString},
 			},
 		},
 		{
@@ -104,7 +104,7 @@ func TestReconcileTopic(t *testing.T) {
 			WantTopicDetail: &sarama.TopicDetail{
 				NumPartitions:     controllertesting.NumPartitions,
 				ReplicationFactor: controllertesting.ReplicationFactor,
-				ConfigEntries:     map[string]*string{commonconstants.KafkaTopicConfigRetentionMs: &controllertesting.DefaultRetentionMillisString},
+				ConfigEntries:     map[string]*string{commonconstants.KafkaTopicConfigRetentionMs: &controllertesting.RetentionMillisString},
 			},
 			MockErrorCode: sarama.ErrTopicAlreadyExists,
 		},
@@ -124,7 +124,7 @@ func TestReconcileTopic(t *testing.T) {
 			WantTopicDetail: &sarama.TopicDetail{
 				NumPartitions:     controllertesting.NumPartitions,
 				ReplicationFactor: controllertesting.ReplicationFactor,
-				ConfigEntries:     map[string]*string{commonconstants.KafkaTopicConfigRetentionMs: &controllertesting.DefaultRetentionMillisString},
+				ConfigEntries:     map[string]*string{commonconstants.KafkaTopicConfigRetentionMs: &controllertesting.RetentionMillisString},
 			},
 			MockErrorCode: sarama.ErrBrokerNotAvailable,
 			WantError:     sarama.ErrBrokerNotAvailable.Error() + " - " + controllertesting.ErrorString,

--- a/pkg/channel/distributed/controller/testing/data.go
+++ b/pkg/channel/distributed/controller/testing/data.go
@@ -89,6 +89,8 @@ const (
 	NumPartitions = 123
 	// ReplicationFactor - ChannelSpec Test Data
 	ReplicationFactor = 456
+	// RetentionMillis - ChannelSpec Test Data
+	RetentionMillis = 123456
 
 	// ErrorString - Mock Test Error MetaData
 	ErrorString = "Expected Mock Test Error"
@@ -167,6 +169,7 @@ Producer:
 var (
 	DefaultRetentionMillisString = strconv.FormatInt(DefaultRetentionMillis, 10)
 	DeletionTimestamp            = metav1.Now()
+	RetentionMillisString 		 = strconv.FormatInt(RetentionMillis, 10)
 )
 
 //
@@ -521,7 +524,7 @@ func NewKafkaChannel(options ...KafkaChannelOption) *kafkav1beta1.KafkaChannel {
 		Spec: kafkav1beta1.KafkaChannelSpec{
 			NumPartitions:     NumPartitions,
 			ReplicationFactor: ReplicationFactor,
-			// TODO RetentionMillis:   RetentionMillis,
+			RetentionMillis:   RetentionMillis,
 		},
 	}
 

--- a/pkg/common/config/util.go
+++ b/pkg/common/config/util.go
@@ -127,3 +127,13 @@ func ReplicationFactor(channel *kafkav1beta1.KafkaChannel, configuration *Eventi
 	}
 	return value
 }
+
+// RetentionMillis Gets The RetentionMillis - First From Channel Spec And Then From ConfigMap-Provided Settings
+func RetentionMillis(channel *kafkav1beta1.KafkaChannel, configuration *EventingKafkaConfig, logger *zap.SugaredLogger) int64 {
+	value := channel.Spec.RetentionMillis
+	if value <= 0 && configuration != nil {
+		logger.Debug("Kafka Channel Spec 'RetentionMillis' Not Specified - Using Default", zap.Int64("Value", configuration.Kafka.Topic.DefaultRetentionMillis))
+		value = int64(configuration.Kafka.Topic.DefaultRetentionMillis)
+	}
+	return value
+}

--- a/pkg/common/config/util_test.go
+++ b/pkg/common/config/util_test.go
@@ -24,6 +24,8 @@ const (
 	defaultNumPartitions     = int32(987)
 	replicationFactor        = int16(22)
 	defaultReplicationFactor = int16(33)
+	retentionMillis			 = int64(123456)
+	defaultRetentionMillis	 = int64(604800000)
 )
 
 func TestConfigmapDataCheckSum(t *testing.T) {
@@ -256,4 +258,24 @@ func TestReplicationFactor(t *testing.T) {
 	channel = &kafkav1beta1.KafkaChannel{Spec: kafkav1beta1.KafkaChannelSpec{ReplicationFactor: replicationFactor}}
 	actualReplicationFactor = ReplicationFactor(channel, configuration, logger)
 	assert.Equal(t, replicationFactor, actualReplicationFactor)
+}
+
+// Test The RetentionMillis Accessor
+func TestRetentionMillis(t *testing.T) {
+
+	// Test Logger
+	logger := logtesting.TestLogger(t)
+
+	// Test Data
+	configuration := &EventingKafkaConfig{Kafka: EKKafkaConfig{Topic: EKKafkaTopicConfig{DefaultRetentionMillis: defaultRetentionMillis}}}
+
+	// Test The Default Failover Use Case
+	channel := &kafkav1beta1.KafkaChannel{}
+	actualRetentionMillis := RetentionMillis(channel, configuration, logger)
+	assert.Equal(t, defaultRetentionMillis, actualRetentionMillis)
+
+	// Test The Valid RetentionMillis Use Case
+	channel = &kafkav1beta1.KafkaChannel{Spec: kafkav1beta1.KafkaChannelSpec{RetentionMillis: retentionMillis}}
+	actualRetentionMillis = RetentionMillis(channel, configuration, logger)
+	assert.Equal(t, retentionMillis, actualRetentionMillis)
 }


### PR DESCRIPTION
Fixes #643

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🎁  Kafka Channel RetentionMillis can now be provided on Channel spec. Works for both Consolidated and Distributed Channel. Its an Optional field which if absent will default to the defaultRetentionMillis value provided in the Common ConfigMap. If the defaultRetentionMillis is not provided in config map, the default value of 604800000(1 Week) is taken from constants in code.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Kafka Channel RetentionMillis can now be provided on Channel spec. Works for both Consolidated and Distributed Channel. Its an Optional field which if absent will default to the value provided in the Common ConfigMap
```
