### PR TITLE
Fix no kafka channel address issue

### DIFF
--- a/pkg/channel/consolidated/utils/util.go
+++ b/pkg/channel/consolidated/utils/util.go
@@ -84,6 +84,11 @@ func GetKafkaConfig(ctx context.Context, clientId string, configMap map[string]s
 		)
 		// Since LoadSettings isn't going to be called in this situation, we need to call getAuth explicitly
 		eventingKafkaConfig.Auth = getAuth(ctx, eventingKafkaConfig.Kafka.AuthSecretName, eventingKafkaConfig.Kafka.AuthSecretNamespace)
+		ekConfigFromOldFormat, err := sarama.LoadSettings(ctx, clientId, configMap, getAuth)
+		if err != nil {
+			return nil, err
+		}
+		eventingKafkaConfig.Sarama = ekConfigFromOldFormat.Sarama
 	} else {
 		eventingKafkaConfig, err = sarama.LoadSettings(ctx, clientId, configMap, getAuth)
 	}

--- a/pkg/channel/consolidated/utils/util_test.go
+++ b/pkg/channel/consolidated/utils/util_test.go
@@ -282,6 +282,9 @@ func TestGetKafkaConfig(t *testing.T) {
 				EventingKafka: &config.EventingKafkaConfig{
 					CloudEvents: defaultCloudEvents,
 					Kafka:       kafkaConfig("kafkabroker.kafka:9092", kafkasarama.DefaultAuthSecretName, system.Namespace()),
+					Sarama: config.EKSaramaConfig{
+						Config: saramaEmptyConfig,
+					},
 				},
 			},
 		},
@@ -293,6 +296,9 @@ func TestGetKafkaConfig(t *testing.T) {
 				EventingKafka: &config.EventingKafkaConfig{
 					CloudEvents: defaultCloudEvents,
 					Kafka:       kafkaConfig("kafkabroker.kafka:9092", "kafka-auth-secret", "default"),
+					Sarama: config.EKSaramaConfig{
+						Config: saramaEmptyConfig,
+					},
 				},
 			},
 		},
@@ -304,6 +310,9 @@ func TestGetKafkaConfig(t *testing.T) {
 				EventingKafka: &config.EventingKafkaConfig{
 					CloudEvents: defaultCloudEvents,
 					Kafka:       kafkaConfig("kafkabroker1.kafka:9092,kafkabroker2.kafka:9092", kafkasarama.DefaultAuthSecretName, system.Namespace()),
+					Sarama: config.EKSaramaConfig{
+						Config: saramaEmptyConfig,
+					},
 				},
 			},
 		},
@@ -318,6 +327,9 @@ func TestGetKafkaConfig(t *testing.T) {
 						MaxIdleConnsPerHost: 100,
 					},
 					Kafka: kafkaConfig("kafkabroker.kafka:9092", kafkasarama.DefaultAuthSecretName, system.Namespace()),
+					Sarama: config.EKSaramaConfig{
+						Config: saramaEmptyConfig,
+					},
 				},
 			},
 		},
@@ -332,6 +344,9 @@ func TestGetKafkaConfig(t *testing.T) {
 						MaxIdleConnsPerHost: 900,
 					},
 					Kafka: kafkaConfig("kafkabroker.kafka:9092", kafkasarama.DefaultAuthSecretName, system.Namespace()),
+					Sarama: config.EKSaramaConfig{
+						Config: saramaEmptyConfig,
+					},
 				},
 			},
 		},
@@ -346,6 +361,9 @@ func TestGetKafkaConfig(t *testing.T) {
 						MaxIdleConnsPerHost: 600,
 					},
 					Kafka: kafkaConfig("kafkabroker.kafka:9092", kafkasarama.DefaultAuthSecretName, system.Namespace()),
+					Sarama: config.EKSaramaConfig{
+						Config: saramaEmptyConfig,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #

```
=== CONT  TestSingleStructuredEventForChannel/KafkaChannel-messaging.knative.dev/v1beta1
    operation.go:95: Failed to get all KResources ready failed waiting for {TypeMeta:{Kind:Subscription APIVersion:messaging.knative.dev/v1} ObjectMeta:{Name:e2e-singleevent-subscription-structured GenerateName: Namespace:eventing-e2e24 SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]}} to become ready: timed out waiting for the condition
    operation.go:116: Failed to get all test resources ready: failed waiting for {TypeMeta:{Kind:Subscription APIVersion:messaging.knative.dev/v1} ObjectMeta:{Name:e2e-singleevent-subscription-structured GenerateName: Namespace:eventing-e2e24 SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]}} to become ready: timed out waiting for the condition
```

Consolidated KafkaChannel was not getting its address in status.
The root cause is that Sarama config is not read and because of that the controller can't even come to the stage that it initializes the status nor scales the dispatcher.

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
