### PR TITLE
[rekt] KafkaSource readiness test requires a topic

### DIFF
--- a/test/rekt/kafka_source_test.go
+++ b/test/rekt/kafka_source_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"knative.dev/eventing-kafka/test/rekt/features/kafkasource"
+	ks "knative.dev/eventing-kafka/test/rekt/resources/kafkasource"
 	"knative.dev/eventing/pkg/utils"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/system"
@@ -33,11 +34,12 @@ import (
 )
 
 const (
-	kafkaSASLSecret = "strimzi-sasl-secret"
-	kafkaTLSSecret  = "strimzi-tls-secret"
+	kafkaSASLSecret        = "strimzi-sasl-secret"
+	kafkaTLSSecret         = "strimzi-tls-secret"
+	kafkaBootstrapUrlPlain = "my-cluster-kafka-bootstrap.kafka.svc:9092"
 )
 
-var test_mt_soure = os.Getenv("TEST_MT_SOURCE")
+var test_mt_source = os.Getenv("TEST_MT_SOURCE")
 
 func TestKafkaSource(t *testing.T) {
 	t.Parallel()
@@ -62,9 +64,12 @@ func TestKafkaSource(t *testing.T) {
 	}
 
 	testFeatures := kafkasource.DataPlaneDelivery()
-	if test_mt_soure == "1" {
+	if test_mt_source == "1" {
 		testFeatures = append(testFeatures, kafkasource.MtDataPlaneDelivery())
 	}
+
+	testFeatures = append(testFeatures,
+		kafkasource.KafkaSourceGoesReady("readysource", ks.WithBootstrapServers([]string{kafkaBootstrapUrlPlain})))
 
 	for _, f := range testFeatures {
 		env.Test(ctx, t, f)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
This will help fixing the e2e tests in eventing-autoscaler-keda


## Proposed Changes

- Add basic KafkaSource readiness test. 
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
