### PR TITLE
[Source] Optimize InitOffsets

### DIFF
--- a/pkg/common/kafka/sarama/batch_get_offsets.go
+++ b/pkg/common/kafka/sarama/batch_get_offsets.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sarama
+
+import (
+	"github.com/Shopify/sarama"
+)
+
+// GetOffsets queries the cluster to get the most recent available offset at the
+// given time (in milliseconds) for the given topics and partition
+// Time should be OffsetOldest for the earliest available offset,
+// OffsetNewest for the offset of the message that will be produced next, or a time.
+//
+// See sarama.Client.GetOffset for getting the offset of a single topic/partition combination
+func GetOffsets(client sarama.Client, topicPartitions map[string][]int32, time int64) (map[string]map[int32]int64, error) {
+	if client.Closed() {
+		return nil, sarama.ErrClosedClient
+	}
+
+	version := int16(0)
+	if client.Config().Version.IsAtLeast(sarama.V0_10_1_0) {
+		version = 1
+	}
+
+	offsets := make(map[string]map[int32]int64)
+
+	// Step 1: build one OffsetRequest instance per broker.
+	requests := make(map[*sarama.Broker]*sarama.OffsetRequest)
+
+	for topic, partitions := range topicPartitions {
+		offsets[topic] = make(map[int32]int64)
+
+		for _, partitionID := range partitions {
+			broker, err := client.Leader(topic, partitionID)
+			if err != nil {
+				return nil, err
+			}
+
+			request, ok := requests[broker]
+			if !ok {
+				request = &sarama.OffsetRequest{Version: version}
+				requests[broker] = request
+			}
+
+			request.AddBlock(topic, partitionID, time, 1)
+		}
+	}
+
+	// Step 2: send requests, one per broker, and collect offsets
+	for broker, request := range requests {
+		response, err := broker.GetAvailableOffsets(request)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for topic, blocks := range response.Blocks {
+			for partitionID, block := range blocks {
+				if block.Err != sarama.ErrNoError {
+					return nil, block.Err
+				}
+
+				offsets[topic][partitionID] = block.Offset
+			}
+		}
+	}
+
+	return offsets, nil
+}

--- a/pkg/common/kafka/sarama/batch_get_offsets_test.go
+++ b/pkg/common/kafka/sarama/batch_get_offsets_test.go
@@ -18,6 +18,7 @@ package sarama
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Shopify/sarama"
 )
@@ -74,8 +75,7 @@ func TestGetOffset(t *testing.T) {
 			}
 
 			broker.SetHandlerByMap(map[string]sarama.MockResponse{
-				"OffsetRequest": offsetResponse,
-
+				"OffsetRequest":   offsetResponse,
 				"MetadataRequest": metadataResponse,
 			})
 
@@ -112,4 +112,7 @@ func TestGetOffset(t *testing.T) {
 
 		})
 	}
+
+	// Seems like there is no way to check the broker has been really closed. So wait few seconds
+	time.Sleep(2 * time.Second)
 }

--- a/pkg/common/kafka/sarama/batch_get_offsets_test.go
+++ b/pkg/common/kafka/sarama/batch_get_offsets_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sarama
+
+import (
+	"testing"
+
+	"github.com/Shopify/sarama"
+)
+
+func TestGetOffset(t *testing.T) {
+	testCases := map[string]struct {
+		topicPartitions map[string][]int32
+		topicOffsets    map[string]map[int32]int64
+	}{
+		"no topics": {
+			topicPartitions: map[string][]int32{},
+			topicOffsets:    map[string]map[int32]int64{},
+		},
+		"one topic, one partition": {
+			topicPartitions: map[string][]int32{"my-topic": {0}},
+			topicOffsets: map[string]map[int32]int64{
+				"my-topic": {
+					0: 5,
+				},
+			},
+		},
+		"several topics, several partitions": {
+			topicPartitions: map[string][]int32{
+				"my-topic":   {0, 1},
+				"my-topic-2": {0, 1, 2},
+				"my-topic-3": {0, 1, 2, 3}},
+			topicOffsets: map[string]map[int32]int64{
+				"my-topic":   {0: 5, 1: 7},
+				"my-topic-2": {0: 5, 1: 7, 2: 9},
+				"my-topic-3": {0: 5, 1: 7, 2: 2, 3: 10},
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			broker := sarama.NewMockBroker(t, 1)
+			defer broker.Close()
+			offsetResponse := sarama.NewMockOffsetResponse(t).SetVersion(1)
+			for topic, partitions := range tc.topicOffsets {
+				for partition, offset := range partitions {
+					offsetResponse = offsetResponse.SetOffset(topic, partition, -1, offset)
+				}
+			}
+
+			metadataResponse := sarama.NewMockMetadataResponse(t).
+				SetController(broker.BrokerID()).
+				SetBroker(broker.Addr(), broker.BrokerID())
+
+			for topic, partitions := range tc.topicOffsets {
+				for partition := range partitions {
+					metadataResponse = metadataResponse.SetLeader(topic, partition, broker.BrokerID())
+				}
+			}
+
+			broker.SetHandlerByMap(map[string]sarama.MockResponse{
+				"OffsetRequest": offsetResponse,
+
+				"MetadataRequest": metadataResponse,
+			})
+
+			config := sarama.NewConfig()
+			config.Version = sarama.MaxVersion
+
+			sc, err := sarama.NewClient([]string{broker.Addr()}, config)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			defer sc.Close()
+
+			offsets, err := GetOffsets(sc, tc.topicPartitions, sarama.OffsetNewest)
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if len(tc.topicOffsets) != len(offsets) {
+				t.Errorf("unexpected number of topics. wanted %d, got %d", len(tc.topicOffsets), len(offsets))
+			}
+
+			for topic, topicOffsets := range offsets {
+				if len(tc.topicOffsets[topic]) != len(topicOffsets) {
+					t.Errorf("unexpected number of partitions. wanted %d, got %d", len(tc.topicOffsets[topic]), len(topicOffsets))
+				}
+
+				for partitionID, offset := range topicOffsets {
+					if tc.topicOffsets[topic][partitionID] != offset {
+						t.Errorf("unexpected offset. wanted %d, got %d", tc.topicOffsets[topic][partitionID], offset)
+					}
+				}
+			}
+
+		})
+	}
+}


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
InitOffsets can take a long time (several seconds, sometimes minutes), when the number of partitions is high (> 500), due to Sarama inability to batch OffsetFetch requests. 


## Proposed Changes

- batch OffsetFetch requests, one per leading broker. 
- 
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
