### PR TITLE
Fix stop start without locking

### DIFF
--- a/pkg/common/consumer/consumer_manager.go
+++ b/pkg/common/consumer/consumer_manager.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	defaultLockTimeout = 5 * time.Minute
-	internalToken = "internal-token"
+	internalToken      = "internal-token"
 )
 
 // KafkaConsumerGroupManager keeps track of Sarama consumer groups and handles messages from control-protocol clients

--- a/pkg/common/consumer/consumer_manager.go
+++ b/pkg/common/consumer/consumer_manager.go
@@ -49,6 +49,7 @@ import (
 
 const (
 	defaultLockTimeout = 5 * time.Minute
+	internalToken = "internal-token"
 )
 
 // KafkaConsumerGroupManager keeps track of Sarama consumer groups and handles messages from control-protocol clients
@@ -118,7 +119,7 @@ func (m *kafkaConsumerGroupManagerImpl) Reconfigure(brokers []string, config *sa
 	var multiErr error
 	groupsToRestart := make([]string, 0, len(m.groups))
 	for groupId := range m.groups {
-		err := m.stopConsumerGroup(&commands.CommandLock{Token: "internal-token", LockBefore: true}, groupId)
+		err := m.stopConsumerGroup(&commands.CommandLock{Token: internalToken, LockBefore: true}, groupId)
 		if err != nil {
 			// If we couldn't stop a group, or failed to obtain a lock, note it as an error.  However,
 			// in a practical sense, the new brokers/config will be used when whatever locked the group
@@ -135,7 +136,7 @@ func (m *kafkaConsumerGroupManagerImpl) Reconfigure(brokers []string, config *sa
 	// Restart any groups this function stopped
 	m.logger.Info("Reconfigure Consumer Group Manager - Starting All Managed Consumer Groups")
 	for _, groupId := range groupsToRestart {
-		err := m.startConsumerGroup(&commands.CommandLock{Token: "internal-token", UnlockAfter: true}, groupId)
+		err := m.startConsumerGroup(&commands.CommandLock{Token: internalToken, UnlockAfter: true}, groupId)
 		if err != nil {
 			multierr.AppendInto(&multiErr, err)
 		}

--- a/pkg/common/consumer/consumer_manager.go
+++ b/pkg/common/consumer/consumer_manager.go
@@ -51,9 +51,6 @@ const (
 	defaultLockTimeout = 5 * time.Minute
 )
 
-// GroupLockedError is the error returned if the a locked managed group is given a different token for access
-var GroupLockedError = fmt.Errorf("managed group lock failed: locked by a different token")
-
 // KafkaConsumerGroupManager keeps track of Sarama consumer groups and handles messages from control-protocol clients
 type KafkaConsumerGroupManager interface {
 	Reconfigure(brokers []string, config *sarama.Config) error
@@ -63,10 +60,8 @@ type KafkaConsumerGroupManager interface {
 	IsManaged(groupId string) bool
 }
 
-// groupMap is a mapping of GroupIDs to managed Consumer Group pointers (fields in the managedGroup
-// are modified directly by the kafkaConsumerGroupManagerImpl receiver functions; the pointer makes
-// removing and re-adding them to the map unnecessary in those cases)
-type groupMap map[string]*managedGroup
+// groupMap is a mapping of GroupIDs to managed Consumer Group interfaces
+type groupMap map[string]managedGroup
 
 // kafkaConsumerGroupManagerImpl is the primary implementation of a KafkaConsumerGroupManager, which
 // handles control protocol messages and stopping/starting ("pausing/resuming") of ConsumerGroups.
@@ -123,7 +118,7 @@ func (m *kafkaConsumerGroupManagerImpl) Reconfigure(brokers []string, config *sa
 	var multiErr error
 	groupsToRestart := make([]string, 0, len(m.groups))
 	for groupId := range m.groups {
-		err := m.stopConsumerGroup(getInternalLockCommand(true), groupId)
+		err := m.stopConsumerGroup(&commands.CommandLock{Token: "internal-token", LockBefore: true}, groupId)
 		if err != nil {
 			// If we couldn't stop a group, or failed to obtain a lock, note it as an error.  However,
 			// in a practical sense, the new brokers/config will be used when whatever locked the group
@@ -140,23 +135,12 @@ func (m *kafkaConsumerGroupManagerImpl) Reconfigure(brokers []string, config *sa
 	// Restart any groups this function stopped
 	m.logger.Info("Reconfigure Consumer Group Manager - Starting All Managed Consumer Groups")
 	for _, groupId := range groupsToRestart {
-		err := m.startConsumerGroup(getInternalLockCommand(false), groupId)
+		err := m.startConsumerGroup(&commands.CommandLock{Token: "internal-token", UnlockAfter: true}, groupId)
 		if err != nil {
 			multierr.AppendInto(&multiErr, err)
 		}
 	}
 	return multiErr
-}
-
-// getInternalLockCommand returns a CommandLock object with a constant lock token used internally by
-// the consumer manager.
-func getInternalLockCommand(lock bool) *commands.CommandLock {
-	return &commands.CommandLock{
-		Token:       "consumer-manager-internal-token",
-		Timeout:     time.Minute,
-		LockBefore:  lock,
-		UnlockAfter: !lock,
-	}
 }
 
 // StartConsumerGroup uses the consumer factory to create a new ConsumerGroup, add it to the list
@@ -171,10 +155,6 @@ func (m *kafkaConsumerGroupManagerImpl) StartConsumerGroup(groupId string, topic
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	managedGrp := createManagedGroup(m.logger, group, cancel)
-
-	// Begin listening on the group's Errors() channel and write them to the managedGroup's errors channel
-	managedGrp.transferErrors(ctx)
 
 	// consume is passed in to the KafkaConsumerGroupFactory so that it will call the manager's
 	// consume() function instead of the one on the internal sarama ConsumerGroup.  This allows the
@@ -186,7 +166,7 @@ func (m *kafkaConsumerGroupManagerImpl) StartConsumerGroup(groupId string, topic
 
 	// The only thing we really want from the factory is the cancel function for the customConsumerGroup
 	customGroup := m.factory.startExistingConsumerGroup(group, consume, topics, logger, handler, options...)
-	managedGrp.cancelConsume = customGroup.cancel
+	managedGrp := createManagedGroup(ctx, m.logger, group, cancel, customGroup.cancel)
 
 	// Add the Sarama ConsumerGroup we obtained from the factory to the managed group map,
 	// so that it can be stopped and started via control-protocol messages.
@@ -200,24 +180,12 @@ func (m *kafkaConsumerGroupManagerImpl) StartConsumerGroup(groupId string, topic
 func (m *kafkaConsumerGroupManagerImpl) CloseConsumerGroup(groupId string) error {
 	groupLogger := m.logger.With(zap.String("GroupId", groupId))
 	groupLogger.Info("Closing ConsumerGroup and removing from management")
-	managedGrp, ok := m.groups[groupId]
-	if !ok {
+	managedGrp := m.getGroup(groupId)
+	if managedGrp == nil {
 		groupLogger.Warn("CloseConsumerGroup called on unmanaged group")
 		return fmt.Errorf("could not close consumer group with id '%s' - group is not present in the managed map", groupId)
 	}
-	// Make sure a managed group is "started" before closing the inner ConsumerGroup; otherwise anything
-	// waiting for the manager to restart the group will never return.
-	managedGrp.closeRestartChannel()
-	if managedGrp.cancelErrors != nil {
-		m.logger.Warn("The cancelErrors function of the managed group is nil")
-		managedGrp.cancelErrors() // This will terminate any transferError call that is waiting for a restart
-	}
-	if managedGrp.cancelConsume != nil {
-		m.logger.Warn("The cancelConsume function of the managed group is nil")
-		managedGrp.cancelConsume() // This will stop the factory's consume loop after the ConsumerGroup is closed
-	}
-	err := managedGrp.group.Close()
-	if err != nil {
+	if err := managedGrp.close(); err != nil {
 		groupLogger.Error("Failed To Close Managed ConsumerGroup", zap.Error(err))
 		return err
 	}
@@ -232,10 +200,11 @@ func (m *kafkaConsumerGroupManagerImpl) CloseConsumerGroup(groupId string) error
 // is different than using the Errors() channel of a ConsumerGroup directly, as it will remain open during
 //  a stop/start ("pause/resume") cycle
 func (m *kafkaConsumerGroupManagerImpl) Errors(groupId string) <-chan error {
-	if !m.IsManaged(groupId) {
+	group := m.getGroup(groupId)
+	if group == nil {
 		return nil
 	}
-	return m.groups[groupId].errors
+	return group.errors()
 }
 
 // IsManaged returns true if the given groupId corresponds to a managed ConsumerGroup
@@ -251,22 +220,7 @@ func (m *kafkaConsumerGroupManagerImpl) consume(ctx context.Context, groupId str
 	if managedGrp == nil {
 		return fmt.Errorf("consume called on nonexistent groupId '%s'", groupId)
 	}
-	for {
-		// Call the internal sarama ConsumerGroup's Consume function directly
-		err := managedGrp.group.Consume(ctx, topics, handler)
-		if !managedGrp.isStopped() {
-			m.logger.Debug("Managed Consume Finished Without Stop", zap.String("GroupId", groupId), zap.Error(err))
-			// This ConsumerGroup wasn't stopped by the manager, so pass the error along to the caller
-			return err
-		}
-		// Wait for the managed ConsumerGroup to be restarted
-		m.logger.Debug("Consume is waiting for managed group restart")
-		if !managedGrp.waitForStart(ctx) {
-			// Context was canceled; abort
-			m.logger.Debug("Managed Consume Canceled", zap.String("GroupId", groupId))
-			return fmt.Errorf("context was canceled waiting for group '%s' to start", groupId)
-		}
-	}
+	return managedGrp.consume(ctx, topics, handler)
 }
 
 // stopConsumerGroups closes the managed ConsumerGroup identified by the provided groupId, and marks it
@@ -288,22 +242,13 @@ func (m *kafkaConsumerGroupManagerImpl) stopConsumerGroup(lock *commands.Command
 		return fmt.Errorf("stop requested for consumer group not in managed list: %s", groupId)
 	}
 
-	// The managedGroup's start channel must be created (that is, the managedGroup must be marked
-	// as "stopped") before closing the internal ConsumerGroup, otherwise the consume function would
-	// return control to the factory.
-	managedGrp.createRestartChannel()
-	// Close the inner sarama ConsumerGroup, which will cause our consume() function to stop
-	// and wait for the managedGroup to start again.
-	err := managedGrp.group.Close()
-	if err != nil {
-		groupLogger.Error("Failed To Close Managed ConsumerGroup", zap.Error(err))
-		// Don't leave the start channel open if the group.Close() call failed; that would be misleading
-		managedGrp.closeRestartChannel()
+	if err := managedGrp.stop(); err != nil {
+		groupLogger.Error("Failed to stop managed consumer group", zap.Error(err))
 		return err
 	}
 
 	// Unlock the managedGroup after stopping it, if lock.UnlockAfter is true
-	if err = m.unlockAfter(lock, groupId); err != nil {
+	if err := m.unlockAfter(lock, groupId); err != nil {
 		groupLogger.Error("Failed to unlock consumer group after stopping", zap.Error(err))
 		return err
 	}
@@ -321,7 +266,8 @@ func (m *kafkaConsumerGroupManagerImpl) startConsumerGroup(lock *commands.Comman
 	}
 
 	groupLogger.Info("Starting Managed ConsumerGroup")
-	if !m.IsManaged(groupId) {
+	managedGrp := m.getGroup(groupId)
+	if managedGrp == nil {
 		groupLogger.Info("ConsumerGroup Not Managed - Ignoring Start Request")
 		return fmt.Errorf("start requested for consumer group not in managed list: %s", groupId)
 	}
@@ -332,9 +278,8 @@ func (m *kafkaConsumerGroupManagerImpl) startConsumerGroup(lock *commands.Comman
 		return err
 	}
 
-	managedGrp := m.getGroup(groupId)
-	managedGrp.group = group
-	managedGrp.closeRestartChannel() // Closing this allows the waitForStart function to finish
+	// Instruct the managed group to use this new ConsumerGroup
+	managedGrp.start(group)
 
 	// Unlock the managedGroup after starting it, if lock.UnlockAfter is true
 	if err = m.unlockAfter(lock, groupId); err != nil {
@@ -345,14 +290,14 @@ func (m *kafkaConsumerGroupManagerImpl) startConsumerGroup(lock *commands.Comman
 }
 
 // getGroup returns a group from the groups map using the groupLock mutex
-func (m *kafkaConsumerGroupManagerImpl) getGroup(groupId string) *managedGroup {
+func (m *kafkaConsumerGroupManagerImpl) getGroup(groupId string) managedGroup {
 	m.groupLock.RLock()
 	defer m.groupLock.RUnlock()
 	return m.groups[groupId]
 }
 
 // getGroup associates a group with a groupId in the groups map using the groupLock mutex
-func (m *kafkaConsumerGroupManagerImpl) setGroup(groupId string, group *managedGroup) {
+func (m *kafkaConsumerGroupManagerImpl) setGroup(groupId string, group managedGroup) {
 	m.groupLock.Lock()
 	m.groups[groupId] = group
 	m.groupLock.Unlock()
@@ -367,51 +312,20 @@ func (m *kafkaConsumerGroupManagerImpl) removeGroup(groupId string) {
 
 // lockBefore will lock the managedGroup corresponding to the groupId, if lock.LockBefore is true
 func (m *kafkaConsumerGroupManagerImpl) lockBefore(lock *commands.CommandLock, groupId string) error {
-	return m.processLock(lock, groupId, true)
-}
-
-// unlockAfter will unlock the managedGroup corresponding to the groupId, if lock.UnlockAfter is true
-func (m *kafkaConsumerGroupManagerImpl) unlockAfter(lock *commands.CommandLock, groupId string) error {
-	return m.processLock(lock, groupId, false)
-}
-
-// processLock handles setting and removing the managedGroup's lock status.
-// For the managedGroup with the given groupId, if that group exists, this function will:
-// - Lock the group, if "lock" is true and cmdLock.LockBefore is true
-// - Unlock the group, if "lock" is false and cmdLock.UnlockAfter is true
-// Returns an error if the lock.Token field doesn't match an existing token in the managedGroup (for either case), as
-// this indicates that the group is locked by a different sender
-func (m *kafkaConsumerGroupManagerImpl) processLock(cmdLock *commands.CommandLock, groupId string, lock bool) error {
-	if cmdLock == nil {
-		return nil // No lock processing was requested
-	}
-
 	group := m.getGroup(groupId)
 	if group == nil {
 		return nil // Can't lock a nonexistent group
 	}
+	return group.processLock(lock, true)
+}
 
-	if (lock && !cmdLock.LockBefore) || (!lock && !cmdLock.UnlockAfter) {
-		return nil // If neither a lock nor unlock were requested, no need to go any further
+// unlockAfter will unlock the managedGroup corresponding to the groupId, if lock.UnlockAfter is true
+func (m *kafkaConsumerGroupManagerImpl) unlockAfter(lock *commands.CommandLock, groupId string) error {
+	group := m.getGroup(groupId)
+	if group == nil {
+		return nil // Can't unlock a nonexistent group
 	}
-
-	if !group.canUnlock(cmdLock.Token) {
-		m.logger.Info("Managed group access denied; already locked with a different token",
-			zap.String("Token", cmdLock.Token), zap.String("GroupId", groupId))
-		return GroupLockedError // Already locked by a different command token
-	}
-
-	if lock && cmdLock.LockBefore {
-		timeout := cmdLock.Timeout
-		if timeout == 0 {
-			timeout = defaultLockTimeout
-		}
-		group.resetLock(cmdLock.Token, timeout)
-	} else if cmdLock.UnlockAfter {
-		group.removeLock()
-	}
-
-	return nil // Lock succeeded
+	return group.processLock(lock, false)
 }
 
 // processAsyncGroupNotification calls the provided groupFunction with whatever GroupId is contained

--- a/pkg/common/consumer/consumer_manager.go
+++ b/pkg/common/consumer/consumer_manager.go
@@ -297,7 +297,7 @@ func (m *kafkaConsumerGroupManagerImpl) getGroup(groupId string) managedGroup {
 	return m.groups[groupId]
 }
 
-// getGroup associates a group with a groupId in the groups map using the groupLock mutex
+// setGroup associates a group with a groupId in the groups map using the groupLock mutex
 func (m *kafkaConsumerGroupManagerImpl) setGroup(groupId string, group managedGroup) {
 	m.groupLock.Lock()
 	m.groups[groupId] = group

--- a/pkg/common/consumer/consumer_manager.go
+++ b/pkg/common/consumer/consumer_manager.go
@@ -315,6 +315,7 @@ func (m *kafkaConsumerGroupManagerImpl) removeGroup(groupId string) {
 func (m *kafkaConsumerGroupManagerImpl) lockBefore(lock *commands.CommandLock, groupId string) error {
 	group := m.getGroup(groupId)
 	if group == nil {
+		m.logger.Warn("Attempted to lock a nonexistent group ID", zap.String("GroupId", groupId))
 		return nil // Can't lock a nonexistent group
 	}
 	return group.processLock(lock, true)
@@ -324,6 +325,7 @@ func (m *kafkaConsumerGroupManagerImpl) lockBefore(lock *commands.CommandLock, g
 func (m *kafkaConsumerGroupManagerImpl) unlockAfter(lock *commands.CommandLock, groupId string) error {
 	group := m.getGroup(groupId)
 	if group == nil {
+		m.logger.Warn("Attempted to unlock a nonexistent group ID", zap.String("GroupId", groupId))
 		return nil // Can't unlock a nonexistent group
 	}
 	return group.processLock(lock, false)

--- a/pkg/common/consumer/consumer_manager_test.go
+++ b/pkg/common/consumer/consumer_manager_test.go
@@ -176,7 +176,7 @@ func TestConsume(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			manager := &kafkaConsumerGroupManagerImpl{groups: make(groupMap)}
+			manager := &kafkaConsumerGroupManagerImpl{logger: logtesting.TestLogger(t).Desugar(), groups: make(groupMap)}
 			if testCase.groupId != "" {
 				mockGroup := &mockManagedGroup{}
 				mockGroup.On("consume", context.Background(), []string{"topic"}, nil).Return(nil)
@@ -210,7 +210,7 @@ func TestLockUnlockWrappers(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			manager := &kafkaConsumerGroupManagerImpl{groups: make(groupMap)}
+			manager := &kafkaConsumerGroupManagerImpl{logger: logtesting.TestLogger(t).Desugar(), groups: make(groupMap)}
 			if testCase.groupId != "" {
 				mockGroup := &mockManagedGroup{}
 				mockGroup.On("processLock", mock.Anything, mock.Anything).Return(fmt.Errorf("test error"))
@@ -421,7 +421,7 @@ func TestNotifications(t *testing.T) {
 				mockGroup := &mockManagedGroup{}
 				mockGroup.On("processLock", mock.Anything, true).Return(nil)
 				mockGroup.On("stop").Return(nil)
-				mockGroup.On("start", mock.Anything).Return()
+				mockGroup.On("start", mock.Anything).Return(nil)
 				mockGroup.On("processLock", mock.Anything, false).Return(fmt.Errorf("unlock error"))
 				impl.groups[testCase.groupId] = mockGroup
 			}

--- a/pkg/common/consumer/managed_group.go
+++ b/pkg/common/consumer/managed_group.go
@@ -61,7 +61,7 @@ type managedGroupImpl struct {
 // empty string (i.e. "unlocked") after that time has passed.
 func createManagedGroup(ctx context.Context, logger *zap.Logger, group sarama.ConsumerGroup, cancelErrors func(), cancelConsume func()) managedGroup {
 
-	managedGrp := managedGroupImpl{
+	managedGrp := &managedGroupImpl{
 		logger:        logger,
 		group:         group,
 		groupErrors:   make(chan error),
@@ -78,7 +78,7 @@ func createManagedGroup(ctx context.Context, logger *zap.Logger, group sarama.Co
 	// Begin listening on the group's Errors() channel and write them to the managedGroup's errors channel
 	managedGrp.transferErrors(ctx)
 
-	return &managedGrp
+	return managedGrp
 }
 
 // stop stops the managed group (which means closing the internal ConsumerGroup and marking the managed group as stopped)

--- a/pkg/common/consumer/managed_group.go
+++ b/pkg/common/consumer/managed_group.go
@@ -109,6 +109,9 @@ func (m *managedGroupImpl) start(group sarama.ConsumerGroup) {
 	m.closeRestartChannel() // Closing this allows the waitForStart function to finish
 }
 
+// close shuts down the internal sarama ConsumerGroup, canceling the consume and/or error transfer
+// loops first.  This is distinct from "stop" which expects the consume/error loops to continue while
+// waiting for a restart.
 func (m *managedGroupImpl) close() error {
 	// Make sure a managed group is "started" before closing the inner ConsumerGroup; otherwise anything
 	// waiting for the manager to restart the group will never return.

--- a/pkg/common/consumer/managed_group.go
+++ b/pkg/common/consumer/managed_group.go
@@ -18,18 +18,34 @@ package consumer
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
+
+	"knative.dev/eventing-kafka/pkg/common/controlprotocol/commands"
 
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
 )
 
+// GroupLockedError is the error returned if the a locked managed group is given a different token for access
+var GroupLockedError = fmt.Errorf("managed group lock failed: locked by a different token")
+
 // managedGroup contains information about a Sarama ConsumerGroup that is required to start (i.e. re-create) it
-type managedGroup struct {
+type managedGroup interface {
+	consume(context.Context, []string, sarama.ConsumerGroupHandler) error
+	start(sarama.ConsumerGroup)
+	stop() error
+	close() error
+	errors() chan error
+	processLock(*commands.CommandLock, bool) error
+}
+
+// managedGroupImpl implements the managedGroup interface
+type managedGroupImpl struct {
 	logger             *zap.Logger
 	group              sarama.ConsumerGroup // The Sarama ConsumerGroup which is under management
-	errors             chan error           // An error channel that will replicate the errors from the Sarama ConsumerGroup
+	groupErrors        chan error           // An error channel that will replicate the errors from the Sarama ConsumerGroup
 	restartWaitChannel chan struct{}        // A channel that will be closed when a stopped group is restarted
 	stopped            atomic.Value         // Boolean value indicating that the managed group is stopped
 	cancelErrors       func()               // Called by the manager's CloseConsumerGroup to terminate the error forwarding
@@ -41,13 +57,14 @@ type managedGroup struct {
 // createManagedGroup associates a Sarama ConsumerGroup and cancel function (usually from the factory)
 // inside a new managedGroup struct.  If a timeout is given (nonzero), the lockId will be reset to an
 // empty string (i.e. "unlocked") after that time has passed.
-func createManagedGroup(logger *zap.Logger, group sarama.ConsumerGroup, cancel func()) *managedGroup {
+func createManagedGroup(ctx context.Context, logger *zap.Logger, group sarama.ConsumerGroup, cancelErrors func(), cancelConsume func()) managedGroup {
 
-	managedGrp := managedGroup{
-		logger:       logger,
-		group:        group,
-		errors:       make(chan error),
-		cancelErrors: cancel,
+	managedGrp := managedGroupImpl{
+		logger:        logger,
+		group:         group,
+		groupErrors:   make(chan error),
+		cancelErrors:  cancelErrors,
+		cancelConsume: cancelConsume,
 	}
 
 	// Atomic values must be initialized with their desired type before being accessed, or a nil
@@ -55,13 +72,82 @@ func createManagedGroup(logger *zap.Logger, group sarama.ConsumerGroup, cancel f
 	managedGrp.lockedBy.Store("")   // Empty token string indicates "unlocked"
 	managedGrp.stopped.Store(false) // A managed group defaults to "started" when created
 
+	// Begin listening on the group's Errors() channel and write them to the managedGroup's errors channel
+	managedGrp.transferErrors(ctx)
+
 	return &managedGrp
+}
+
+// stop stops the managed group (which means closing the internal ConsumerGroup and marking the managed group as stopped)
+func (m *managedGroupImpl) stop() error {
+	// The managedGroup's start channel must be created (that is, the managedGroup must be marked
+	// as "stopped") before closing the internal ConsumerGroup, otherwise the consume function would
+	// return control to the factory.
+	m.createRestartChannel()
+	// Close the inner sarama ConsumerGroup, which will cause our consume() function to stop
+	// and wait for the managedGroup to start again.
+	if err := m.group.Close(); err != nil {
+		// Don't leave the start channel open if the group.Close() call failed; that would be misleading
+		m.closeRestartChannel()
+		return err
+	}
+	return nil
+}
+
+// start starts the managed group, using the provided group as the "restarted" internal group
+func (m *managedGroupImpl) start(group sarama.ConsumerGroup) {
+	m.group = group
+	m.closeRestartChannel() // Closing this allows the waitForStart function to finish
+}
+
+func (m *managedGroupImpl) close() error {
+	// Make sure a managed group is "started" before closing the inner ConsumerGroup; otherwise anything
+	// waiting for the manager to restart the group will never return.
+	m.closeRestartChannel()
+
+	// Stop the error transfer and consume loops of this managedGroup, if cancel functions exist
+	if m.cancelErrors == nil {
+		m.logger.Warn("The cancelErrors function of the managed group is nil")
+	} else {
+		m.cancelErrors() // This will terminate any transferError call that is waiting for a restart
+	}
+	if m.cancelConsume == nil {
+		m.logger.Warn("The cancelConsume function of the managed group is nil")
+	} else {
+		m.cancelConsume() // This will stop the factory's consume loop after the ConsumerGroup is closed
+	}
+	return m.group.Close()
+}
+
+// consume calls the Consume function on the managed ConsumerGroup, supporting the stop/start functionality
+func (m *managedGroupImpl) consume(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error {
+	for {
+		// Call the internal sarama ConsumerGroup's Consume function directly
+		err := m.group.Consume(ctx, topics, handler)
+		if !m.isStopped() {
+			m.logger.Debug("Managed Consume Finished Without Stop", zap.Error(err))
+			// This ConsumerGroup wasn't stopped by the manager, so pass the error along to the caller
+			return err
+		}
+		// Wait for the managed ConsumerGroup to be restarted
+		m.logger.Debug("Consume is waiting for managed group restart")
+		if !m.waitForStart(ctx) {
+			// Context was canceled; abort
+			m.logger.Debug("Managed Consume Canceled")
+			return fmt.Errorf("context was canceled waiting for group to start")
+		}
+	}
+}
+
+// getErrors returns the error channel, which is relayed from the internal managed ConsumerGroup
+func (m *managedGroupImpl) errors() chan error {
+	return m.groupErrors
 }
 
 // resetLock will set the "lockedBy" field to the given lockToken (need not be the same as the
 // existing one) and reset the timer to the provided timeout.  After the timer expires, the lockToken
 // will be set to an empty string (representing "unlocked")
-func (m *managedGroup) resetLock(lockToken string, timeout time.Duration) {
+func (m *managedGroupImpl) resetLock(lockToken string, timeout time.Duration) {
 
 	// Stop any existing timer (without releasing the lock) so that it won't inadvertently do an unlock later
 	if m.cancelLockTimeout != nil {
@@ -77,7 +163,7 @@ func (m *managedGroup) resetLock(lockToken string, timeout time.Duration) {
 		m.cancelLockTimeout = cancel
 		// Mark this group as "locked" by the provided token
 		m.lockedBy.Store(lockToken)
-		m.logger.Info("Managed group locked", zap.String("token", lockToken))
+		m.logger.Info("Managed group locked", zap.String("token", lockToken), zap.Duration("Timeout", timeout))
 
 		// Reset the lockedBy field to an empty string when the lockTimer expires.  We create a new routine
 		// each time (instead of calling lockTimer.Reset) because an existing timer may have expired long ago
@@ -106,13 +192,13 @@ func (m *managedGroup) resetLock(lockToken string, timeout time.Duration) {
 
 // canUnlock returns true if the provided token is sufficient to unlock the group (that is,
 // if it either matches the existing token, or if the existing token is empty)
-func (m *managedGroup) canUnlock(token string) bool {
+func (m *managedGroupImpl) canUnlock(token string) bool {
 	lockToken := m.lockedBy.Load()
 	return lockToken == "" || lockToken == token
 }
 
 // removeLock sets the lockedBy token to an empty string, meaning "unlocked"
-func (m *managedGroup) removeLock() {
+func (m *managedGroupImpl) removeLock() {
 	if m.lockedBy.Load() != "" {
 		m.logger.Debug("Managed Group lock removed")
 		m.lockedBy.Store("")
@@ -120,16 +206,51 @@ func (m *managedGroup) removeLock() {
 	}
 }
 
+// processLock handles setting and removing the managedGroup's lock status:
+// - Lock the group, if "lock" is true and cmdLock.LockBefore is true
+// - Unlock the group, if "lock" is false and cmdLock.UnlockAfter is true
+// Returns an error if the lock.Token field doesn't match the existing token (for any case even if
+// no CommandLock is provided), as this indicates that the group is locked by the other token.
+func (m *managedGroupImpl) processLock(cmdLock *commands.CommandLock, lock bool) error {
+
+	token := ""
+	if cmdLock != nil {
+		token = cmdLock.Token
+	}
+
+	if !m.canUnlock(token) {
+		m.logger.Info("Managed group access denied; already locked with a different token",
+			zap.String("Token", token))
+		return GroupLockedError // Already locked by a different command token
+	}
+
+	if cmdLock == nil {
+		return nil // If neither a lock nor unlock were requested, no need to go any further
+	}
+
+	if lock && cmdLock.LockBefore {
+		timeout := cmdLock.Timeout
+		if timeout == 0 {
+			timeout = defaultLockTimeout
+		}
+		m.resetLock(cmdLock.Token, timeout)
+	} else if !lock && cmdLock.UnlockAfter {
+		m.removeLock()
+	}
+
+	return nil // Lock succeeded
+}
+
 // isStopped is an accessor for the restartWaitChannel channel's status, which if non-nil indicates
 // that the KafkaConsumerGroupManager stopped ("paused") the managed ConsumerGroup (versus it having
 // been closed outside the manager)
-func (m *managedGroup) isStopped() bool {
+func (m *managedGroupImpl) isStopped() bool {
 	return m.stopped.Load().(bool)
 }
 
 // createRestartChannel sets the state of the managed group to "stopped" by creating the restartWaitChannel
 // channel that will be closed when the group is restarted.
-func (m *managedGroup) createRestartChannel() {
+func (m *managedGroupImpl) createRestartChannel() {
 	// Don't re-create the channel if it already exists (the managed group is already stopped)
 	if !m.isStopped() {
 		m.restartWaitChannel = make(chan struct{})
@@ -138,7 +259,7 @@ func (m *managedGroup) createRestartChannel() {
 }
 
 // closeRestartChannel sets the state of the managed group to "started" by closing the restartWaitChannel channel.
-func (m *managedGroup) closeRestartChannel() {
+func (m *managedGroupImpl) closeRestartChannel() {
 	// If the managed group is already started, don't try to close the restart wait channel
 	if m.isStopped() {
 		m.stopped.Store(false)
@@ -148,7 +269,7 @@ func (m *managedGroup) closeRestartChannel() {
 
 // waitForStart will block until a stopped ("paused") ConsumerGroup has been restarted by the
 // KafkaConsumerGroupManager, returning true in that case or false if the context's cancel function is called
-func (m *managedGroup) waitForStart(ctx context.Context) bool {
+func (m *managedGroupImpl) waitForStart(ctx context.Context) bool {
 	if !m.isStopped() {
 		return true // group is already started; don't try to read from closed channel
 	}
@@ -165,18 +286,18 @@ func (m *managedGroup) waitForStart(ctx context.Context) bool {
 // and sends them to the m.errors channel.  This is done so that when the group.Errors() channel is closed during
 // a stop ("pause") of the group, the m.errors channel can remain open (so that users of the manager do not
 // receive a closed error channel during stop/start events).
-func (m *managedGroup) transferErrors(ctx context.Context) {
+func (m *managedGroupImpl) transferErrors(ctx context.Context) {
 	go func() {
 		for {
 			m.logger.Debug("Starting managed group error transfer")
 			for groupErr := range m.group.Errors() {
-				m.errors <- groupErr
+				m.groupErrors <- groupErr
 			}
 			if !m.isStopped() {
 				// If the error channel was closed without the consumergroup being marked as stopped,
 				// or if we were unable to wait for the group to be restarted, that is outside
 				// of the manager's responsibility, so we are finished transferring errors.
-				close(m.errors)
+				close(m.groupErrors)
 				return
 			}
 			// Wait for the manager to restart the Consumer Group before calling m.group.Errors() again

--- a/pkg/common/consumer/managed_group.go
+++ b/pkg/common/consumer/managed_group.go
@@ -87,12 +87,13 @@ func (m *managedGroupImpl) stop() error {
 	// as "stopped") before closing the internal ConsumerGroup, otherwise the consume function would
 	// return control to the factory.
 	m.createRestartChannel()
-	// Close the inner sarama ConsumerGroup, which will cause our consume() function to stop
-	// and wait for the managedGroup to start again.
+
 	m.groupMutex.Lock()
 	group := m.group
 	m.groupMutex.Unlock()
 
+	// Close the inner sarama ConsumerGroup, which will cause our consume() function to stop
+	// and wait for the managedGroup to start again.
 	if err := group.Close(); err != nil {
 		// Don't leave the start channel open if the group.Close() call failed; that would be misleading
 		m.closeRestartChannel()

--- a/pkg/common/consumer/managed_group_test.go
+++ b/pkg/common/consumer/managed_group_test.go
@@ -357,16 +357,16 @@ func TestStopStart(t *testing.T) {
 			name: "Initially Started",
 		},
 		{
-			name: "Initially Started, Error Stopping",
+			name:        "Initially Started, Error Stopping",
 			errStopping: true,
 		},
 		{
-			name: "Initially Stopped",
+			name:    "Initially Stopped",
 			stopped: true,
 		},
 		{
-			name: "Initially Stopped, Error Starting",
-			stopped: true,
+			name:        "Initially Stopped, Error Starting",
+			stopped:     true,
 			errStarting: true,
 		},
 	} {
@@ -390,7 +390,8 @@ func TestStopStart(t *testing.T) {
 				if !testCase.errStarting {
 					startErr = nil
 				}
-				return mockGroup, startErr })
+				return mockGroup, startErr
+			})
 			assert.Equal(t, testCase.errStarting, err != nil)
 
 			// Verify that the group is not stopped (unless there was an error)

--- a/pkg/common/consumer/managed_group_test.go
+++ b/pkg/common/consumer/managed_group_test.go
@@ -466,6 +466,7 @@ func TestTransferErrors(t *testing.T) {
 				logger:      logtesting.TestLogger(t).Desugar(),
 				group:       mockGrp,
 				groupErrors: make(chan error),
+				groupMutex:  sync.Mutex{},
 			}
 			managedGrp.lockedBy.Store("")
 			managedGrp.stopped.Store(false)

--- a/pkg/common/consumer/managed_group_test.go
+++ b/pkg/common/consumer/managed_group_test.go
@@ -23,6 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/mock"
+	"knative.dev/eventing-kafka/pkg/common/controlprotocol/commands"
+
 	"github.com/stretchr/testify/assert"
 	logtesting "knative.dev/pkg/logging/testing"
 
@@ -55,7 +59,10 @@ func TestManagedGroup(t *testing.T) {
 			// Test stop/start of a managedGroup
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			group := createManagedGroup(logtesting.TestLogger(t).Desugar(), nil, cancel)
+
+			mockGroup := kafkatesting.NewMockConsumerGroup()
+			mockGroup.On("Errors").Return(make(chan error))
+			group := createManagedGroup(ctx, logtesting.TestLogger(t).Desugar(), mockGroup, cancel, func() {}).(*managedGroupImpl)
 			waitGroup := sync.WaitGroup{}
 			assert.False(t, group.isStopped())
 
@@ -80,6 +87,110 @@ func TestManagedGroup(t *testing.T) {
 		})
 	}
 
+}
+
+func TestProcessLock(t *testing.T) {
+	defer restoreNewConsumerGroup(newConsumerGroup) // must use if calling getManagerWithMockGroup in the test
+	const newToken = "new-token"
+	const shortTimeout = 60 * time.Millisecond
+
+	for _, testCase := range []struct {
+		name            string
+		lock            *commands.CommandLock
+		existingToken   string
+		expectLock      string
+		expectUnlock    string
+		expectErrBefore error
+		expectErrAfter  error
+		expectTimerStop bool
+	}{
+		{
+			name: "Nil LockCommand",
+		},
+		{
+			name:            "Different Lock Token",
+			existingToken:   "existing-token",
+			expectLock:      "existing-token",
+			expectUnlock:    "existing-token",
+			lock:            &commands.CommandLock{LockBefore: true, UnlockAfter: true, Token: newToken},
+			expectErrBefore: GroupLockedError,
+			expectErrAfter:  GroupLockedError,
+		},
+		{
+			name:            "No Lock Provided, ManagedGroup Locked",
+			existingToken:   "existing-token",
+			expectLock:      "existing-token",
+			expectUnlock:    "existing-token",
+			expectErrBefore: GroupLockedError,
+			expectErrAfter:  GroupLockedError,
+		},
+		{
+			name:            "Empty Token, ManagedGroup Locked",
+			existingToken:   "existing-token",
+			expectLock:      "existing-token",
+			expectUnlock:    "existing-token",
+			lock:            &commands.CommandLock{LockBefore: true, UnlockAfter: true, Token: ""},
+			expectErrBefore: GroupLockedError,
+			expectErrAfter:  GroupLockedError,
+		},
+		{
+			name:            "Different Lock Token, No LockBefore Or UnlockAfter Specified",
+			existingToken:   "existing-token",
+			expectLock:      "existing-token",
+			expectUnlock:    "existing-token",
+			lock:            &commands.CommandLock{Token: newToken},
+			expectErrBefore: GroupLockedError,
+			expectErrAfter:  GroupLockedError,
+		},
+		{
+			name:          "Same Lock Token",
+			existingToken: newToken,
+			expectLock:    newToken,
+			lock:          &commands.CommandLock{LockBefore: true, UnlockAfter: true, Token: newToken},
+		},
+		{
+			name:       "Zero Timeout",
+			lock:       &commands.CommandLock{LockBefore: true, UnlockAfter: true, Token: newToken},
+			expectLock: newToken,
+		},
+		{
+			name:            "Explicit Timeout",
+			lock:            &commands.CommandLock{LockBefore: true, UnlockAfter: true, Token: newToken, Timeout: shortTimeout},
+			expectLock:      newToken,
+			expectTimerStop: true,
+		},
+		{
+			name:         "LockBefore Only",
+			lock:         &commands.CommandLock{LockBefore: true, Token: newToken},
+			expectLock:   newToken,
+			expectUnlock: newToken,
+		},
+		{
+			name: "UnlockAfter Only",
+			lock: &commands.CommandLock{UnlockAfter: true, Token: newToken},
+		},
+		{
+			name: "No Lock Or Unlock",
+			lock: &commands.CommandLock{Token: newToken},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, managedGrp := createMockAndManagedGroups(t)
+			if testCase.existingToken != "" {
+				managedGrp.lockedBy.Store(testCase.existingToken)
+			}
+			errBefore := managedGrp.processLock(testCase.lock, true)
+			assert.Equal(t, testCase.expectLock, managedGrp.lockedBy.Load())
+			if testCase.expectTimerStop {
+				time.Sleep(2 * shortTimeout)
+				assert.Equal(t, "", managedGrp.lockedBy.Load())
+			}
+			errAfter := managedGrp.processLock(testCase.lock, false)
+			assert.Equal(t, testCase.expectUnlock, managedGrp.lockedBy.Load())
+			assert.Equal(t, testCase.expectErrBefore, errBefore)
+			assert.Equal(t, testCase.expectErrAfter, errAfter)
+		})
+	}
 }
 
 func TestResetLockTimer(t *testing.T) {
@@ -144,7 +255,7 @@ func TestResetLockTimer(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			time.Sleep(time.Millisecond)
-			_, managedGrp := createTestGroup(t)
+			_, managedGrp := createMockAndManagedGroups(t)
 			if testCase.cancelTimer != nil {
 				managedGrp.cancelLockTimeout = testCase.cancelTimer
 			}
@@ -171,6 +282,152 @@ func TestResetLockTimer(t *testing.T) {
 				time.Sleep(2 * testCase.timeout)
 				assert.Equal(t, "", managedGrp.lockedBy.Load())
 			}
+		})
+	}
+}
+
+func TestManagedGroupConsume(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name      string
+		stopped   bool
+		cancel    bool
+		expectErr string
+	}{
+		{
+			name:      "Started",
+			expectErr: "kafka: tried to use a consumer group that was closed",
+		},
+		{
+			name:      "Stopped",
+			stopped:   true,
+			expectErr: "kafka: tried to use a consumer group that was closed",
+		},
+		{
+			name:      "Canceled",
+			stopped:   true,
+			cancel:    true,
+			expectErr: "context was canceled waiting for group to start",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			mockGroup, mgdGroup := createMockAndManagedGroups(t)
+			mockGroup.On("Consume", ctx, []string{"topic"}, nil).Return(sarama.ErrClosedConsumerGroup)
+			mockGroup.On("Close").Return(nil)
+
+			if testCase.stopped {
+				mgdGroup.createRestartChannel()
+			}
+			waitGroup := sync.WaitGroup{}
+			waitGroup.Add(1)
+			go func() {
+				err := mgdGroup.consume(ctx, []string{"topic"}, nil)
+				if testCase.expectErr != "" {
+					assert.NotNil(t, err)
+					assert.Equal(t, testCase.expectErr, err.Error())
+				} else {
+					assert.Nil(t, err)
+				}
+				waitGroup.Done()
+			}()
+			time.Sleep(5 * time.Millisecond) // Give Consume() a chance to call waitForStart()
+			if mgdGroup != nil {
+				if testCase.cancel {
+					cancel()
+				} else {
+					mgdGroup.closeRestartChannel()
+				}
+				assert.Nil(t, mgdGroup.group.Close()) // Stops the MockConsumerGroup's Consume() call
+			}
+			waitGroup.Wait() // Allows the goroutine with the consume call to finish
+		})
+	}
+}
+
+func TestStopStart(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name        string
+		errStopping bool
+		stopped     bool
+	}{
+		{
+			name: "Initially Started",
+		},
+		{
+			name:        "Initially Started, Error Stopping",
+			errStopping: true,
+		},
+		{
+			name:    "Initially Stopped",
+			stopped: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockGroup, mgdGroup := createMockAndManagedGroups(t)
+			errStopped := fmt.Errorf("error stopping")
+			if !testCase.errStopping {
+				errStopped = nil
+			}
+			mockGroup.On("Close").Return(errStopped)
+
+			if testCase.stopped {
+				// Simulate a stopped group
+				mgdGroup.createRestartChannel()
+			} else {
+				mgdGroup.stopped.Store(testCase.stopped)
+			}
+
+			mgdGroup.start(mockGroup)
+
+			// Verify that the group is not stopped, regardless of initial state
+			assert.False(t, mgdGroup.stopped.Load().(bool))
+
+			err := mgdGroup.stop()
+
+			assert.Equal(t, !testCase.errStopping || testCase.stopped, mgdGroup.stopped.Load().(bool))
+			assert.Equal(t, testCase.errStopping, err != nil)
+
+			mockGroup.AssertExpectations(t)
+
+		})
+	}
+}
+
+func TestClose(t *testing.T) {
+
+	for _, testCase := range []struct {
+		name   string
+		cancel bool
+	}{
+		{
+			name:   "With Cancel Functions",
+			cancel: true,
+		},
+		{
+			name: "Without Cancel Functions",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockGroup, mgdGroup := createMockAndManagedGroups(t)
+			mockGroup.On("Close").Return(nil)
+
+			cancelConsumeCalled := false
+			cancelErrorsCalled := false
+			if testCase.cancel {
+				mgdGroup.cancelConsume = func() { cancelConsumeCalled = true }
+				mgdGroup.cancelErrors = func() { cancelErrorsCalled = true }
+			} else {
+				mgdGroup.cancelConsume = nil
+				mgdGroup.cancelErrors = nil
+			}
+
+			err := mgdGroup.close()
+			assert.Nil(t, err)
+			assert.Equal(t, testCase.cancel, cancelConsumeCalled)
+			assert.Equal(t, testCase.cancel, cancelErrorsCalled)
 		})
 	}
 }
@@ -204,14 +461,23 @@ func TestTransferErrors(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			time.Sleep(time.Millisecond)
-			mockGrp, managedGrp := createTestGroup(t)
+
+			mockGrp := kafkatesting.NewMockConsumerGroup()
+			managedGrp := managedGroupImpl{
+				logger:      logtesting.TestLogger(t).Desugar(),
+				group:       mockGrp,
+				groupErrors: make(chan error),
+			}
+			managedGrp.lockedBy.Store("")
+			managedGrp.stopped.Store(false)
+
 			mockGrp.On("Errors").Return(mockGrp.ErrorChan)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			managedGrp.transferErrors(ctx)
 
 			mockGrp.ErrorChan <- fmt.Errorf("test-error")
-			err := <-managedGrp.errors
+			err := <-managedGrp.errors()
 			assert.NotNil(t, err)
 			assert.Equal(t, "test-error", err.Error())
 			if testCase.stopGroup {
@@ -234,7 +500,7 @@ func TestTransferErrors(t *testing.T) {
 				time.Sleep(shortTimeout) // Let the waitForStart function finish
 				// Verify that errors work again after restart
 				mockGrp.ErrorChan <- fmt.Errorf("test-error-2")
-				err = <-managedGrp.errors
+				err = <-managedGrp.errors()
 				assert.NotNil(t, err)
 				assert.Equal(t, "test-error-2", err.Error())
 				close(mockGrp.ErrorChan)
@@ -242,4 +508,37 @@ func TestTransferErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+//
+// Mock managedGroup
+//
+
+// MockManagedGroup implements the managedGroup interface
+type mockManagedGroup struct {
+	mock.Mock
+}
+
+func (m *mockManagedGroup) consume(ctx context.Context, topics []string, handler sarama.ConsumerGroupHandler) error {
+	return m.Called(ctx, topics, handler).Error(0)
+}
+
+func (m *mockManagedGroup) start(group sarama.ConsumerGroup) {
+	_ = m.Called(group)
+}
+
+func (m *mockManagedGroup) stop() error {
+	return m.Called().Error(0)
+}
+
+func (m *mockManagedGroup) close() error {
+	return m.Called().Error(0)
+}
+
+func (m *mockManagedGroup) errors() chan error {
+	return m.Called().Get(0).(chan error)
+}
+
+func (m *mockManagedGroup) processLock(cmdLock *commands.CommandLock, lock bool) error {
+	return m.Called(cmdLock, lock).Error(0)
 }

--- a/pkg/common/consumer/managed_group_test.go
+++ b/pkg/common/consumer/managed_group_test.go
@@ -24,12 +24,11 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/stretchr/testify/mock"
-	"knative.dev/eventing-kafka/pkg/common/controlprotocol/commands"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	logtesting "knative.dev/pkg/logging/testing"
 
+	"knative.dev/eventing-kafka/pkg/common/controlprotocol/commands"
 	kafkatesting "knative.dev/eventing-kafka/pkg/common/kafka/testing"
 )
 

--- a/pkg/common/consumer/managed_group_test.go
+++ b/pkg/common/consumer/managed_group_test.go
@@ -513,7 +513,7 @@ func TestTransferErrors(t *testing.T) {
 // Mock managedGroup
 //
 
-// MockManagedGroup implements the managedGroup interface
+// mockManagedGroup implements the managedGroup interface
 type mockManagedGroup struct {
 	mock.Mock
 }


### PR DESCRIPTION
This fixes a few bugs that cropped up due to #742 

## Proposed Changes

- 🐛 The managedGroup lock/unlock was being allowed if no CommandLock struct was passed to processLock, even if it was already locked with a token.
- 🐛 CloseConsumerGroup was logging warnings indicating that cancelErrors and cancelConsume were nil when they, in fact, were not
- 🧽 Several places were still directly accessing the groups map instead of using the getGroup/setGroup/deleteGroup functions
- 🧽 Added an interface for the managedGroup (now has managedGroupImpl) to clear up some confusion

The lock/unlock bug was due in no small part to functionality not being very well isolated to the appropriate structs (manager vs. managedGroup), so I have changed "managedGroup" to an interface that the manager now uses instead of arbitrarily changing fields.  To that end, this interface now has "consume/start/stop/close/errors/processLock" as the lifecycle functions that the manager calls, and a bit of functionality has moved from the manager into the managedGroupImpl (particularly consume and processLock).

I realize this is a bit of a nuisance refactor right after merging the original lock/unlock code, but none of that is live yet (the resetoffset controller is not enabled which is what would send the control-protocol messages) and I believe this is a much better way to handle the managedGroup.