### PR TITLE
Missing webhook rbac

### DIFF
--- a/config/channel/webhook/webhook-clusterrole.yaml
+++ b/config/channel/webhook/webhook-clusterrole.yaml
@@ -19,96 +19,104 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: devel
 rules:
-  # For watching logging configuration and getting certs.
-  - apiGroups:
-      - ""
-    resources:
-      - "configmaps"
-    verbs:
-      - "get"
-      - "list"
-      - "watch"
+# For watching logging configuration and getting certs.
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
 
-  # For manipulating certs into secrets.
-  - apiGroups:
-      - ""
-    resources:
-      - "secrets"
-    verbs:
-      - "get"
-      - "create"
-      - "list"
-      - "watch"
-      - "update"
+# For manipulating certs into secrets.
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs:
+  - "get"
+  - "create"
+  - "list"
+  - "watch"
+  - "update"
 
-  # For getting our Deployment so we can decorate with ownerref.
-  - apiGroups:
-      - "apps"
-    resources:
-      - "deployments"
-    verbs:
-      - "get"
+# For getting our Deployment so we can decorate with ownerref.
+- apiGroups:
+  - "apps"
+  resources:
+  - "deployments"
+  verbs:
+  - "get"
 
-  # finalizers are needed for the owner reference of the webhook
-  - apiGroups:
-      - ""
-    resources:
-      - "namespaces/finalizers"
-    verbs:
-      - "update"
+# For acquiring namespace for the owner reference of the webhook
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  verbs:
+  - "get"
 
-  - apiGroups:
-      - "apps"
-    resources:
-      - "deployments/finalizers"
-    verbs:
-      - update
+# finalizers are needed for the owner reference of the webhook
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces/finalizers"
+  verbs:
+  - "update"
 
-  # For actually registering our webhook.
-  - apiGroups:
-      - "admissionregistration.k8s.io"
-    resources:
-      - "mutatingwebhookconfigurations"
-      - "validatingwebhookconfigurations"
-    verbs: &everything
-      - "get"
-      - "list"
-      - "create"
-      - "update"
-      - "delete"
-      - "patch"
-      - "watch"
+- apiGroups:
+  - "apps"
+  resources:
+  - "deployments/finalizers"
+  verbs:
+  - update
 
-  # Our own resources and statuses we care about.
-  - apiGroups:
-      - "messaging.knative.dev"
-    resources:
-      - "kafkachannels"
-      - "kafkachannels/status"
-    verbs:
-      - "get"
-      - "list"
-      - "watch"
+# For actually registering our webhook.
+- apiGroups:
+  - "admissionregistration.k8s.io"
+  resources:
+  - "mutatingwebhookconfigurations"
+  - "validatingwebhookconfigurations"
+  verbs: &everything
+  - "get"
+  - "list"
+  - "create"
+  - "update"
+  - "delete"
+  - "patch"
+  - "watch"
 
-  # For leader election
-  - apiGroups:
-      - "coordination.k8s.io"
-    resources:
-      - "leases"
-    verbs: *everything
+# Our own resources and statuses we care about.
+- apiGroups:
+  - "messaging.knative.dev"
+  resources:
+  - "kafkachannels"
+  - "kafkachannels/status"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
 
-  # Necessary for conversion webhook. These are copied from the serving
-  # TODO: Do we really need all these permissions?
-  - apiGroups:
-      - "apiextensions.k8s.io"
-    resources:
-      - "customresourcedefinitions"
-    verbs:
-      - "get"
-      - "list"
-      - "create"
-      - "update"
-      - "delete"
-      - "patch"
-      - "watch"
+# For leader election
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - "leases"
+  verbs: *everything
+
+# Necessary for conversion webhook. These are copied from the serving
+# TODO: Do we really need all these permissions?
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - "customresourcedefinitions"
+  verbs:
+  - "get"
+  - "list"
+  - "create"
+  - "update"
+  - "delete"
+  - "patch"
+  - "watch"
 

--- a/config/channel/webhook/webhook-clusterrole.yaml
+++ b/config/channel/webhook/webhook-clusterrole.yaml
@@ -52,9 +52,9 @@ rules:
   # For acquiring namespace for the owner reference of the webhook
   - apiGroups:
       - ""
-  resources:
+    resources:
       - "namespaces"
-  verbs:
+    verbs:
       - "get"
 
   # finalizers are needed for the owner reference of the webhook

--- a/config/channel/webhook/webhook-clusterrole.yaml
+++ b/config/channel/webhook/webhook-clusterrole.yaml
@@ -19,104 +19,104 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: devel
 rules:
-# For watching logging configuration and getting certs.
-- apiGroups:
-  - ""
+  # For watching logging configuration and getting certs.
+  - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+
+  # For manipulating certs into secrets.
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+      - "create"
+      - "list"
+      - "watch"
+      - "update"
+
+  # For getting our Deployment so we can decorate with ownerref.
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "get"
+
+  # For acquiring namespace for the owner reference of the webhook
+  - apiGroups:
+      - ""
   resources:
-  - "configmaps"
+      - "namespaces"
   verbs:
-  - "get"
-  - "list"
-  - "watch"
+      - "get"
 
-# For manipulating certs into secrets.
-- apiGroups:
-  - ""
-  resources:
-  - "secrets"
-  verbs:
-  - "get"
-  - "create"
-  - "list"
-  - "watch"
-  - "update"
+  # finalizers are needed for the owner reference of the webhook
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces/finalizers"
+    verbs:
+      - "update"
 
-# For getting our Deployment so we can decorate with ownerref.
-- apiGroups:
-  - "apps"
-  resources:
-  - "deployments"
-  verbs:
-  - "get"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments/finalizers"
+    verbs:
+      - update
 
-# For acquiring namespace for the owner reference of the webhook
-- apiGroups:
-  - ""
-  resources:
-  - "namespaces"
-  verbs:
-  - "get"
+  # For actually registering our webhook.
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - "mutatingwebhookconfigurations"
+      - "validatingwebhookconfigurations"
+    verbs: &everything
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
 
-# finalizers are needed for the owner reference of the webhook
-- apiGroups:
-  - ""
-  resources:
-  - "namespaces/finalizers"
-  verbs:
-  - "update"
+  # Our own resources and statuses we care about.
+  - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "kafkachannels"
+      - "kafkachannels/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
 
-- apiGroups:
-  - "apps"
-  resources:
-  - "deployments/finalizers"
-  verbs:
-  - update
+  # For leader election
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs: *everything
 
-# For actually registering our webhook.
-- apiGroups:
-  - "admissionregistration.k8s.io"
-  resources:
-  - "mutatingwebhookconfigurations"
-  - "validatingwebhookconfigurations"
-  verbs: &everything
-  - "get"
-  - "list"
-  - "create"
-  - "update"
-  - "delete"
-  - "patch"
-  - "watch"
-
-# Our own resources and statuses we care about.
-- apiGroups:
-  - "messaging.knative.dev"
-  resources:
-  - "kafkachannels"
-  - "kafkachannels/status"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-
-# For leader election
-- apiGroups:
-  - "coordination.k8s.io"
-  resources:
-  - "leases"
-  verbs: *everything
-
-# Necessary for conversion webhook. These are copied from the serving
-# TODO: Do we really need all these permissions?
-- apiGroups:
-  - "apiextensions.k8s.io"
-  resources:
-  - "customresourcedefinitions"
-  verbs:
-  - "get"
-  - "list"
-  - "create"
-  - "update"
-  - "delete"
-  - "patch"
-  - "watch"
+  # Necessary for conversion webhook. These are copied from the serving
+  # TODO: Do we really need all these permissions?
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
 


### PR DESCRIPTION
The KafkaChannel Webhook is currently broken and not performing validation/mutation/etc.  The logs show the following errors...
```
{"level":"debug","ts":"2021-07-01T20:57:15.279Z","logger":"kafkachannel-webhook.ValidationWebhook","caller":"controller/controller.go:502","msg":"Processing from queue validation.webhook.kafka.messaging.knative.dev (depth: 0)"}
{"level":"error","ts":"2021-07-01T20:57:15.281Z","logger":"kafkachannel-webhook.ValidationWebhook","caller":"controller/controller.go:549","msg":"Reconcile error","duration":0.001437821,"error":"failed to fetch namespace: namespaces \"knative-eventing\" is forbidden: User \"system:serviceaccount:knative-eventing:kafka-webhook\" cannot get resource \"namespaces\" in API group \"\" in the namespace \"knative-eventing\"","stacktrace":"knative.dev/pkg/controller.(*Impl).handleErr\n\tknative.dev/pkg@v0.0.0-20210622173328-dd0db4b05c80/controller/controller.go:549\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\tknative.dev/pkg@v0.0.0-20210622173328-dd0db4b05c80/controller/controller.go:532\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\tknative.dev/pkg@v0.0.0-20210622173328-dd0db4b05c80/controller/controller.go:468"}
{"level":"debug","ts":"2021-07-01T20:57:15.281Z","logger":"kafkachannel-webhook.ValidationWebhook","caller":"controller/controller.go:557","msg":"Requeuing key validation.webhook.kafka.messaging.knative.dev due to non-permanent error (depth: 0)"}
```

This was caused by changes in the `knative.dev/pkg` common webhook reconciliation logic ([PR # 2098](https://github.com/knative/pkg/pull/2098)) which was pulled into the `eventing-kafka` repo on 6/15/21 by PR #713.  The new logic needs to be able to `get` the knative-eventing `namespace` and the webhook doesn't currently have permissions to do so.  

## Proposed Changes

- 🐛  Provide Webhook with `get` permissions for `namespaces` as required by new knative.dev/pkg reconcilers.

**Note**: Once this is approved/merged I will create a backport PR to fix the `release-0.24` branch which also has the new/latest knative.dev/pkg code.