### PR TITLE
Missing webhook rbac (backport)

### DIFF
--- a/config/channel/webhook/webhook-clusterrole.yaml
+++ b/config/channel/webhook/webhook-clusterrole.yaml
@@ -49,6 +49,14 @@ rules:
     verbs:
       - "get"
 
+  # For acquiring namespace for the owner reference of the webhook
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - "get"
+
   # finalizers are needed for the owner reference of the webhook
   - apiGroups:
       - ""


### PR DESCRIPTION
This PR is a backport of the fix in #751 to correct this problem on the release-0.24 branch which is also broken.

**Release Note**

```release-note
- 🐛. Add missing RBAC (get namespaces) to KafkaChannel Webhook ClusterRole to satisfy new implementation. 
```