### PR TITLE
Change kafkachannel status when paused

### DIFF
--- a/pkg/channel/distributed/dispatcher/constants/constants.go
+++ b/pkg/channel/distributed/dispatcher/constants/constants.go
@@ -23,4 +23,7 @@ const (
 	MetricsInterval = 5 * time.Second
 
 	Component = "eventing-kafka-channel-dispatcher"
+
+	// GroupStoppedMessage is the message that will be in a subscriber's status when a group is stopped ("paused")
+	GroupStoppedMessage = "group is stopped"
 )

--- a/pkg/channel/distributed/dispatcher/constants/constants.go
+++ b/pkg/channel/distributed/dispatcher/constants/constants.go
@@ -25,5 +25,5 @@ const (
 	Component = "eventing-kafka-channel-dispatcher"
 
 	// GroupStoppedMessage is the message that will be in a subscriber's status when a group is stopped ("paused")
-	GroupStoppedMessage = "group is stopped"
+	GroupStoppedMessage = "consumer group is stopped"
 )

--- a/pkg/channel/distributed/dispatcher/controller/kafkachannel_test.go
+++ b/pkg/channel/distributed/dispatcher/controller/kafkachannel_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"knative.dev/eventing-kafka/pkg/common/consumer"
+
 	commonenv "knative.dev/eventing-kafka/pkg/channel/distributed/common/env"
 
 	"github.com/stretchr/testify/assert"
@@ -68,9 +70,10 @@ func TestNewController(t *testing.T) {
 	kafkaInformerFactory := externalversions.NewSharedInformerFactory(fakeKafkaChannelClientSet, kncontroller.DefaultResyncPeriod)
 	kafkaChannelInformer := kafkaInformerFactory.Messaging().V1beta1().KafkaChannels()
 	stopChan := make(chan struct{})
+	eventsChan := make(chan consumer.ManagerEvent)
 
 	// Perform The Test
-	c := NewController(logger, channelKey, mockDispatcher, kafkaChannelInformer, fakeK8sClientSet, fakeKafkaChannelClientSet, stopChan)
+	c := NewController(logger, channelKey, mockDispatcher, kafkaChannelInformer, fakeK8sClientSet, fakeKafkaChannelClientSet, stopChan, eventsChan)
 
 	// Verify Results
 	assert.NotNil(t, c)
@@ -214,8 +217,8 @@ func NewMockDispatcher(t *testing.T) MockDispatcher {
 func (m MockDispatcher) Shutdown() {
 }
 
-func (m MockDispatcher) UpdateSubscriptions(_ []eventingduck.SubscriberSpec) map[eventingduck.SubscriberSpec]error {
-	return nil
+func (m MockDispatcher) UpdateSubscriptions(_ []eventingduck.SubscriberSpec) (map[eventingduck.SubscriberSpec]error, map[eventingduck.SubscriberSpec]struct{}) {
+	return nil, nil
 }
 
 func (m MockDispatcher) SecretChanged(_ context.Context, _ *corev1.Secret) {}

--- a/pkg/channel/distributed/dispatcher/controller/kafkachannel_test.go
+++ b/pkg/channel/distributed/dispatcher/controller/kafkachannel_test.go
@@ -138,7 +138,7 @@ func TestProcessManagerEvents(t *testing.T) {
 	events <- consumer.ManagerEvent{Event: consumer.GroupStarted, GroupId: "test-group-id"}
 	events <- consumer.ManagerEvent{Event: consumer.GroupClosed, GroupId: "test-group-id"}
 
-	// Send an unexpected event types to the events channel
+	// Send an unexpected event type to the events channel
 	events <- consumer.ManagerEvent{Event: consumer.EventIndex(9999), GroupId: "test-group-id"}
 
 	// Close The Channels

--- a/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/dispatcher.go
@@ -183,7 +183,6 @@ func (d *DispatcherImpl) UpdateSubscriptions(subscriberSpecs []eventingduck.Subs
 
 			// If the group is stopped, it's still active but the reconciler needs to know about it in order
 			// to not treat it as a failure (which would re-create the group, effectively un-stopping it)
-			// TODO:  The active/stopped/failed subscription map might be better as a single map with a custom struct?
 			if d.consumerMgr.IsStopped(groupId) {
 				d.Logger.Debug("Adding Stopped ConsumerGroup To Stopped Map", zap.String("GroupId", groupId))
 				stoppedSubscriptions[subscriberSpec.UID] = struct{}{}

--- a/pkg/channel/distributed/dispatcher/testing/factory.go
+++ b/pkg/channel/distributed/dispatcher/testing/factory.go
@@ -19,14 +19,14 @@ package testing
 import (
 	"testing"
 
-	"knative.dev/eventing-kafka/pkg/common/consumer"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"knative.dev/eventing-kafka/pkg/client/clientset/versioned"
-	fakeclientset "knative.dev/eventing-kafka/pkg/client/clientset/versioned/fake"
+	"knative.dev/eventing-kafka/pkg/common/consumer"
 	"knative.dev/pkg/controller"
 	. "knative.dev/pkg/reconciler/testing"
+
+	fakeclientset "knative.dev/eventing-kafka/pkg/client/clientset/versioned/fake"
 )
 
 const (

--- a/pkg/channel/distributed/dispatcher/testing/factory.go
+++ b/pkg/channel/distributed/dispatcher/testing/factory.go
@@ -46,10 +46,7 @@ type Ctor func(
 
 // MakeFactory creates a reconciler factory with fake clients and controller created by `ctor`.
 func MakeFactory(ctor Ctor) Factory {
-	return func(t *testing.T, r *TableRow) (
-		controller.Reconciler,
-		ActionRecorderList,
-		EventList) {
+	return func(t *testing.T, r *TableRow) (controller.Reconciler, ActionRecorderList, EventList) {
 		ls := NewListers(r.Objects)
 
 		client := fakeclientset.NewSimpleClientset(ls.GetMessagingObjects()...)

--- a/pkg/channel/distributed/dispatcher/testing/kafkachannel.go
+++ b/pkg/channel/distributed/dispatcher/testing/kafkachannel.go
@@ -99,3 +99,16 @@ func WithSubscriberReady(uid types.UID) KafkaChannelOption {
 		})
 	}
 }
+
+func WithSubscriberNotReady(uid types.UID, message string) KafkaChannelOption {
+	return func(kafkachannel *v1beta1.KafkaChannel) {
+		if kafkachannel.Status.SubscribableStatus.Subscribers == nil {
+			kafkachannel.Status.SubscribableStatus.Subscribers = []eventingduck.SubscriberStatus{}
+		}
+		kafkachannel.Status.SubscribableStatus.Subscribers = append(kafkachannel.Status.SubscribableStatus.Subscribers, eventingduck.SubscriberStatus{
+			Ready:   corev1.ConditionFalse,
+			UID:     uid,
+			Message: message,
+		})
+	}
+}

--- a/pkg/common/consumer/consumer_manager.go
+++ b/pkg/common/consumer/consumer_manager.go
@@ -52,7 +52,7 @@ const (
 	internalToken      = "internal-token"
 )
 
-// EventIndex is the type used when sending ManagerEvent structs via the notifyChannls list
+// EventIndex is the type of Event used when sending ManagerEvent structs via the notifyChannels list
 type EventIndex int
 
 // Events
@@ -63,6 +63,7 @@ const (
 	GroupClosed
 )
 
+// ManagerEvent is the struct used by the notification channel
 type ManagerEvent struct {
 	Event   EventIndex
 	GroupId string

--- a/pkg/common/consumer/consumer_manager.go
+++ b/pkg/common/consumer/consumer_manager.go
@@ -52,6 +52,22 @@ const (
 	internalToken      = "internal-token"
 )
 
+// EventIndex is the type used when sending ManagerEvent structs via the notifyChannls list
+type EventIndex int
+
+// Events
+const (
+	GroupCreated EventIndex = iota + 1
+	GroupStopped
+	GroupStarted
+	GroupClosed
+)
+
+type ManagerEvent struct {
+	Event   EventIndex
+	GroupId string
+}
+
 // KafkaConsumerGroupManager keeps track of Sarama consumer groups and handles messages from control-protocol clients
 type KafkaConsumerGroupManager interface {
 	Reconfigure(brokers []string, config *sarama.Config) error
@@ -59,6 +75,9 @@ type KafkaConsumerGroupManager interface {
 	CloseConsumerGroup(groupId string) error
 	Errors(groupId string) <-chan error
 	IsManaged(groupId string) bool
+	IsStopped(groupId string) bool
+	AddNotification() <-chan ManagerEvent
+	ClearNotifications()
 }
 
 // groupMap is a mapping of GroupIDs to managed Consumer Group interfaces
@@ -67,11 +86,13 @@ type groupMap map[string]managedGroup
 // kafkaConsumerGroupManagerImpl is the primary implementation of a KafkaConsumerGroupManager, which
 // handles control protocol messages and stopping/starting ("pausing/resuming") of ConsumerGroups.
 type kafkaConsumerGroupManagerImpl struct {
-	logger    *zap.Logger
-	server    controlprotocol.ServerHandler
-	factory   *kafkaConsumerGroupFactoryImpl
-	groups    groupMap
-	groupLock sync.RWMutex // Synchronizes write access to the groupMap
+	logger         *zap.Logger
+	server         controlprotocol.ServerHandler
+	factory        *kafkaConsumerGroupFactoryImpl
+	groups         groupMap
+	groupLock      sync.RWMutex // Synchronizes write access to the groupMap
+	notifyChannels []chan ManagerEvent
+	eventLock      sync.Mutex
 }
 
 // Verify that the kafkaConsumerGroupManagerImpl satisfies the KafkaConsumerGroupManager interface
@@ -86,6 +107,7 @@ func NewConsumerGroupManager(logger *zap.Logger, serverHandler controlprotocol.S
 		groups:    make(groupMap),
 		factory:   &kafkaConsumerGroupFactoryImpl{addrs: brokers, config: config},
 		groupLock: sync.RWMutex{},
+		eventLock: sync.Mutex{},
 	}
 
 	logger.Info("Registering Consumer Group Manager Control-Protocol Handlers")
@@ -109,6 +131,38 @@ func NewConsumerGroupManager(logger *zap.Logger, serverHandler controlprotocol.S
 		})
 
 	return manager
+}
+
+// AddNotification creates a new ManagerEvent channel and returns it.  Manager events will be
+// broadcast to all channels created this way.
+func (m *kafkaConsumerGroupManagerImpl) AddNotification() <-chan ManagerEvent {
+	eventChan := make(chan ManagerEvent)
+	m.eventLock.Lock()
+	m.notifyChannels = append(m.notifyChannels, eventChan)
+	m.eventLock.Unlock()
+	return eventChan
+}
+
+// ClearNotifications closes and removes all channels from the notification list
+func (m *kafkaConsumerGroupManagerImpl) ClearNotifications() {
+	for _, eventChan := range m.notifyChannels {
+		close(eventChan)
+	}
+	m.eventLock.Lock()
+	m.notifyChannels = nil
+	m.eventLock.Unlock()
+}
+
+// notify will send the given ManagerEvent to all channels in the notifyChannels list
+func (m *kafkaConsumerGroupManagerImpl) notify(event ManagerEvent) {
+	m.logger.Debug("Notifying channels", zap.Int("count", len(m.notifyChannels)), zap.Any("event", event))
+	for _, eventChan := range m.notifyChannels {
+		// Don't block if the receiver isn't listening
+		select {
+		case eventChan <- event:
+		default:
+		}
+	}
 }
 
 // Reconfigure will incorporate a new set of brokers and Sarama config settings into the manager
@@ -172,6 +226,7 @@ func (m *kafkaConsumerGroupManagerImpl) StartConsumerGroup(groupId string, topic
 	// Add the Sarama ConsumerGroup we obtained from the factory to the managed group map,
 	// so that it can be stopped and started via control-protocol messages.
 	m.setGroup(groupId, managedGrp)
+	m.notify(ManagerEvent{Event: GroupCreated, GroupId: groupId})
 	return nil
 }
 
@@ -193,6 +248,7 @@ func (m *kafkaConsumerGroupManagerImpl) CloseConsumerGroup(groupId string) error
 
 	// Remove this groupId from the map so that manager functions may not be called on it
 	m.removeGroup(groupId)
+	m.notify(ManagerEvent{Event: GroupClosed, GroupId: groupId})
 
 	return nil
 }
@@ -211,6 +267,16 @@ func (m *kafkaConsumerGroupManagerImpl) Errors(groupId string) <-chan error {
 // IsManaged returns true if the given groupId corresponds to a managed ConsumerGroup
 func (m *kafkaConsumerGroupManagerImpl) IsManaged(groupId string) bool {
 	return m.getGroup(groupId) != nil
+}
+
+// IsStopped returns true if the given groupId corresponds to a stopped ConsumerGroup
+func (m *kafkaConsumerGroupManagerImpl) IsStopped(groupId string) bool {
+	group := m.getGroup(groupId)
+	if group == nil {
+		return false // If it's not a managed group, it can't be stopped
+	}
+
+	return group.isStopped()
 }
 
 // Consume calls the Consume method of a managed consumer group, using a loop to call it again if that
@@ -253,6 +319,7 @@ func (m *kafkaConsumerGroupManagerImpl) stopConsumerGroup(lock *commands.Command
 		groupLogger.Error("Failed to unlock consumer group after stopping", zap.Error(err))
 		return err
 	}
+	m.notify(ManagerEvent{Event: GroupStopped, GroupId: groupId})
 	return nil
 }
 
@@ -289,6 +356,7 @@ func (m *kafkaConsumerGroupManagerImpl) startConsumerGroup(lock *commands.Comman
 		groupLogger.Error("Failed to unlock consumer group after starting", zap.Error(err))
 		return err
 	}
+	m.notify(ManagerEvent{Event: GroupStarted, GroupId: groupId})
 	return nil
 }
 

--- a/pkg/common/consumer/consumer_manager_test.go
+++ b/pkg/common/consumer/consumer_manager_test.go
@@ -506,7 +506,7 @@ func TestManagerEvents(t *testing.T) {
 
 			var notifyChannels []<-chan ManagerEvent
 			for i := 0; i < testCase.channels; i++ {
-				notifyChannels = append(notifyChannels, manager.AddNotification())
+				notifyChannels = append(notifyChannels, manager.GetNotificationChannel())
 			}
 
 			waitGroup := sync.WaitGroup{}

--- a/pkg/common/consumer/consumer_manager_test.go
+++ b/pkg/common/consumer/consumer_manager_test.go
@@ -19,6 +19,8 @@ package consumer
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -244,9 +246,11 @@ func TestErrors(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			manager, _, _, server := getManagerWithMockGroup(t, testCase.groupId, false)
 			valid := manager.IsManaged(testCase.groupId)
+			stopped := manager.IsStopped(testCase.groupId)
 			mgrErrors := manager.Errors(testCase.groupId)
 			assert.Equal(t, testCase.expectErr, mgrErrors == nil)
 			assert.Equal(t, !testCase.expectErr, valid)
+			assert.False(t, stopped) // Not actually using a stopped group in this test
 			server.AssertExpectations(t)
 		})
 	}
@@ -448,6 +452,97 @@ func TestNotifications(t *testing.T) {
 				group.AssertExpectations(t)
 			}
 			serverHandler.AssertExpectations(t)
+		})
+	}
+}
+
+func TestManagerEvents(t *testing.T) {
+	defer restoreNewConsumerGroup(newConsumerGroup) // must use if calling getManagerWithMockGroup in the test
+	for _, testCase := range []struct {
+		name        string
+		channels    int
+		listen      bool
+		expectEvent int32
+		expectClose int32
+	}{
+		{
+			name: "Notify Zero Channels",
+		},
+		{
+			name:        "Notify One Channel",
+			channels:    1,
+			listen:      true,
+			expectEvent: 1,
+			expectClose: 1,
+		},
+		{
+			name:        "Notify Two Channels",
+			channels:    2,
+			listen:      true,
+			expectEvent: 2,
+			expectClose: 2,
+		},
+		{
+			name:        "Notify Ten Channels",
+			channels:    10,
+			listen:      true,
+			expectEvent: 10,
+			expectClose: 10,
+		},
+		{
+			name:        "Notify Non-Listening Channel",
+			channels:    1,
+			expectClose: 1,
+		},
+		{
+			name:        "Notify Five Non-Listening Channels",
+			channels:    5,
+			expectClose: 5,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			manager, _, _, _ := getManagerWithMockGroup(t, "", false)
+			impl := manager.(*kafkaConsumerGroupManagerImpl)
+
+			var notifyChannels []<-chan ManagerEvent
+			for i := 0; i < testCase.channels; i++ {
+				notifyChannels = append(notifyChannels, manager.AddNotification())
+			}
+
+			waitGroup := sync.WaitGroup{}
+			count := int32(0)
+
+			if testCase.listen {
+				waitGroup.Add(len(notifyChannels))
+				for _, notifyChan := range notifyChannels {
+					go func(channel <-chan ManagerEvent) {
+						<-channel
+						atomic.AddInt32(&count, 1)
+						waitGroup.Done()
+					}(notifyChan)
+				}
+			}
+
+			time.Sleep(50 * time.Millisecond)
+			impl.notify(ManagerEvent{Event: GroupCreated, GroupId: "created-group-id"})
+			waitGroup.Wait()
+			assert.Equal(t, testCase.expectEvent, count)
+
+			waitGroup = sync.WaitGroup{}
+			count = int32(0)
+			waitGroup.Add(len(notifyChannels))
+			for _, notifyChan := range notifyChannels {
+				go func(channel <-chan ManagerEvent) {
+					<-channel
+					atomic.AddInt32(&count, 1)
+					waitGroup.Done()
+				}(notifyChan)
+			}
+
+			time.Sleep(50 * time.Millisecond)
+			manager.ClearNotifications()
+			waitGroup.Wait()
+			assert.Equal(t, testCase.expectClose, count)
 		})
 	}
 }

--- a/pkg/common/consumer/managed_group.go
+++ b/pkg/common/consumer/managed_group.go
@@ -43,6 +43,7 @@ type managedGroup interface {
 	close() error
 	errors() chan error
 	processLock(*commands.CommandLock, bool) error
+	isStopped() bool
 }
 
 // managedGroupImpl implements the managedGroup interface

--- a/pkg/common/consumer/managed_group_test.go
+++ b/pkg/common/consumer/managed_group_test.go
@@ -32,6 +32,8 @@ import (
 	kafkatesting "knative.dev/eventing-kafka/pkg/common/kafka/testing"
 )
 
+const shortTimeout = 200 * time.Millisecond
+
 func TestManagedGroup(t *testing.T) {
 	for _, testCase := range []struct {
 		name     string
@@ -91,7 +93,6 @@ func TestManagedGroup(t *testing.T) {
 func TestProcessLock(t *testing.T) {
 	defer restoreNewConsumerGroup(newConsumerGroup) // must use if calling getManagerWithMockGroup in the test
 	const newToken = "new-token"
-	const shortTimeout = 60 * time.Millisecond
 
 	for _, testCase := range []struct {
 		name            string
@@ -193,8 +194,6 @@ func TestProcessLock(t *testing.T) {
 }
 
 func TestResetLockTimer(t *testing.T) {
-	const shortTimeout = 60 * time.Millisecond
-
 	for _, testCase := range []struct {
 		name          string
 		cancelTimer   func()
@@ -445,8 +444,6 @@ func TestClose(t *testing.T) {
 }
 
 func TestTransferErrors(t *testing.T) {
-	const shortTimeout = 60 * time.Millisecond
-
 	for _, testCase := range []struct {
 		name       string
 		stopGroup  bool
@@ -554,4 +551,8 @@ func (m *mockManagedGroup) errors() chan error {
 
 func (m *mockManagedGroup) processLock(cmdLock *commands.CommandLock, lock bool) error {
 	return m.Called(cmdLock, lock).Error(0)
+}
+
+func (m *mockManagedGroup) isStopped() bool {
+	return m.Called().Bool(0)
 }

--- a/pkg/common/consumer/testing/mocks.go
+++ b/pkg/common/consumer/testing/mocks.go
@@ -57,31 +57,38 @@ func NewMockConsumerGroupManager() *MockConsumerGroupManager {
 var _ consumer.KafkaConsumerGroupManager = (*MockConsumerGroupManager)(nil)
 
 func (m *MockConsumerGroupManager) Reconfigure(brokers []string, config *sarama.Config) error {
-	args := m.Called(brokers, config)
-	return args.Error(0)
+	return m.Called(brokers, config).Error(0)
 }
 
 func (m *MockConsumerGroupManager) StartConsumerGroup(groupId string, topics []string, logger *zap.SugaredLogger,
 	handler consumer.KafkaConsumerHandler, options ...consumer.SaramaConsumerHandlerOption) error {
-	args := m.Called(groupId, topics, logger, handler, options)
-	return args.Error(0)
+	return m.Called(groupId, topics, logger, handler, options).Error(0)
 }
 
 func (m *MockConsumerGroupManager) CloseConsumerGroup(groupId string) error {
-	args := m.Called(groupId)
 	if group, ok := m.Groups[groupId]; ok {
 		_ = group.Close()
 		delete(m.Groups, groupId)
 	}
-	return args.Error(0)
+	return m.Called(groupId).Error(0)
 }
 
 func (m *MockConsumerGroupManager) IsManaged(groupId string) bool {
-	args := m.Called(groupId)
-	return args.Bool(0)
+	return m.Called(groupId).Bool(0)
+}
+
+func (m *MockConsumerGroupManager) IsStopped(groupId string) bool {
+	return m.Called(groupId).Bool(0)
 }
 
 func (m *MockConsumerGroupManager) Errors(groupId string) <-chan error {
-	args := m.Called(groupId)
-	return args.Get(0).(<-chan error)
+	return m.Called(groupId).Get(0).(<-chan error)
+}
+
+func (m *MockConsumerGroupManager) AddNotification() <-chan consumer.ManagerEvent {
+	return m.Called().Get(0).(<-chan consumer.ManagerEvent)
+}
+
+func (m *MockConsumerGroupManager) ClearNotifications() {
+	_ = m.Called()
 }

--- a/pkg/common/consumer/testing/mocks.go
+++ b/pkg/common/consumer/testing/mocks.go
@@ -85,7 +85,7 @@ func (m *MockConsumerGroupManager) Errors(groupId string) <-chan error {
 	return m.Called(groupId).Get(0).(<-chan error)
 }
 
-func (m *MockConsumerGroupManager) AddNotification() <-chan consumer.ManagerEvent {
+func (m *MockConsumerGroupManager) GetNotificationChannel() <-chan consumer.ManagerEvent {
 	return m.Called().Get(0).(<-chan consumer.ManagerEvent)
 }
 


### PR DESCRIPTION
Subtask of #588 to update the "subscribers" section of the status block for KafkaChannel resources when a ConsumerGroup is started or stopped.

## Proposed Changes
🎁  Added Go channel notification option to the KafkaConsumerGroupManager (GetNotificationChannel) so that external entities may be informed of changes to a managed ConsumerGroup's status (create/start/stop/close)
🎁. Modified the distributed Dispatcher's KafkaChannel controller to use this new channel from the Manager and call EnqueueKey in order to trigger a reconciliation when Consumer Groups are started or stopped.
🎁  Modified the distributed Dispatcher's UpdateSubscriptions() call to return a map of status infomation that includes "stopped," so that the reconciler can use that information to update the subscribers status block properly.

**Notes**

- When the KafkaChannel's status is updated, the related Knative Eventing subscription resource is automatically (no change by this PR) changed to a status of "False" with a reason of SubscriptionNotMarkedReadyByChannel ("Subscription marked by Channel as False").  I believe this is sufficient.
- The ResetOffset Controller is still "inactive" and has not been added to any Channels/Sources/etc.


**Release Note**
Release Notes will be provided near the end of the ResetOffset feature development.

**Docs**
Documentation will be provided near the end of the ResetOffset feature development.