### PR TITLE
[distributed KafkaChannel] Kafka AdminClient Error Handling

### DIFF
--- a/pkg/channel/distributed/controller/kafkachannel/reconciler.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler.go
@@ -81,7 +81,7 @@ var (
 // not have to support both use cases.
 //
 func (r *Reconciler) SetKafkaAdminClient(ctx context.Context) error {
-	_ = r.ClearKafkaAdminClient(ctx)
+	_ = r.ClearKafkaAdminClient(ctx) // Attempt to close any lingering connections, ignore errors and continue
 	var err error
 	brokers := strings.Split(r.config.Kafka.Brokers, ",")
 	r.adminClient, err = admin.CreateAdminClient(ctx, brokers, r.config.Sarama.Config, r.adminClientType)
@@ -134,7 +134,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, channel *kafkav1beta1.Ka
 	if err != nil {
 		return err
 	}
-	defer func() { _ = r.ClearKafkaAdminClient(ctx) }()
+	defer func() { _ = r.ClearKafkaAdminClient(ctx) }() // Ignore errors as nothing else can be done
 
 	// Reset The Channel's Status Conditions To Unknown (Addressable, Topic, Service, Deployment, etc...)
 	channel.Status.InitializeConditions()
@@ -174,7 +174,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, channel *kafkav1beta1.Kaf
 	if err != nil {
 		return err
 	}
-	defer func() { _ = r.ClearKafkaAdminClient(ctx) }()
+	defer func() { _ = r.ClearKafkaAdminClient(ctx) }() // Ignore errors as nothing else can be done
 
 	// Finalize The Dispatcher (Manual Finalization Due To Cross-Namespace Ownership)
 	err = r.finalizeDispatcher(ctx, channel)

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
@@ -424,7 +424,7 @@ func TestReconcile(t *testing.T) {
 	// Run The TableTest Using The KafkaChannel Reconciler Provided By The Factory
 	logger := logtesting.TestLogger(t)
 	tableTest.Test(t, controllertesting.MakeFactory(func(ctx context.Context, listers *controllertesting.Listers, cmw configmap.Watcher, options map[string]interface{}) controller.Reconciler {
-		
+
 		// Use Table Row AdminClient If Specified, Otherwise Use Valid Success Mock AdminClient
 		newAdminClientFnInterface, ok := options["newAdminClientFn"]
 		if !ok || newAdminClientFnInterface == nil {

--- a/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
+++ b/pkg/channel/distributed/controller/kafkachannel/reconciler_test.go
@@ -424,8 +424,7 @@ func TestReconcile(t *testing.T) {
 	// Run The TableTest Using The KafkaChannel Reconciler Provided By The Factory
 	logger := logtesting.TestLogger(t)
 	tableTest.Test(t, controllertesting.MakeFactory(func(ctx context.Context, listers *controllertesting.Listers, cmw configmap.Watcher, options map[string]interface{}) controller.Reconciler {
-
-		// TODO - NEW
+		
 		// Use Table Row AdminClient If Specified, Otherwise Use Valid Success Mock AdminClient
 		newAdminClientFnInterface, ok := options["newAdminClientFn"]
 		if !ok || newAdminClientFnInterface == nil {


### PR DESCRIPTION
Fixes #774

Handle Kafka AdminClient failures by requeuing the KafkaChannel instead of panic/crashing.  Note... KafkaChannel will remain in perpetual reconcile/finalize loop until underlying Kafka connection issue is resolved.  If the user is intending to delete a KafkaChannel instance whose backing Kafka cluster has been torn down, they will need to manually remove the Finalizer from the KafkaChannel to escape this loop.  This is as intended ; )

### Proposed Changes
-🐛  Throw and handle Kafka AdminClient creation error instead of just logging error and continuing until NPE occurs.

