### PR TITLE
[distributed KafkaChannel] Add receiver/dispatcher labels to Pods as well as Deployments

### DIFF
--- a/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
+++ b/pkg/channel/distributed/controller/kafkachannel/dispatcher.go
@@ -22,14 +22,13 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -485,7 +484,10 @@ func (r *Reconciler) newDispatcherDeployment(logger *zap.Logger, channel *kafkav
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						constants.AppLabel: deploymentName, // Matched By Deployment Selector Above
+						constants.AppLabel:                    deploymentName,    // Matched By Deployment Selector Above
+						constants.KafkaChannelDispatcherLabel: "true",            // Identifies the Pod as being a KafkaChannel "Dispatcher"
+						constants.KafkaChannelNameLabel:       channel.Name,      // Identifies the Pod's Owning KafkaChannel's Name
+						constants.KafkaChannelNamespaceLabel:  channel.Namespace, // Identifies the Pod's Owning KafkaChannel's Namespace
 					},
 					Annotations: map[string]string{
 						commonconstants.ConfigMapHashAnnotationKey: r.kafkaConfigMapHash,

--- a/pkg/channel/distributed/controller/kafkachannel/receiver.go
+++ b/pkg/channel/distributed/controller/kafkachannel/receiver.go
@@ -22,26 +22,25 @@ import (
 	"strconv"
 	"time"
 
-	"knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
-
-	"k8s.io/apimachinery/pkg/types"
-
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/system"
+
+	"knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 	commonenv "knative.dev/eventing-kafka/pkg/channel/distributed/common/env"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/health"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/constants"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/event"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/util"
 	commonconstants "knative.dev/eventing-kafka/pkg/common/constants"
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
-	"knative.dev/pkg/system"
 )
 
 // reconcileReceiver Reconciles The Receiver (Kafka Producer) For The Specified KafkaChannel
@@ -382,7 +381,7 @@ func (r *Reconciler) newReceiverDeployment(secret *corev1.Secret) *appsv1.Deploy
 			Namespace: r.environment.SystemNamespace,
 			Labels: map[string]string{
 				constants.AppLabel:                  deploymentName, // Matches Service Selector Key/Value Below
-				constants.KafkaChannelReceiverLabel: "true",         // Allows for identification of Receivers
+				constants.KafkaChannelReceiverLabel: "true",         // Allows for identification of Receiver Deployments
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -395,7 +394,8 @@ func (r *Reconciler) newReceiverDeployment(secret *corev1.Secret) *appsv1.Deploy
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						constants.AppLabel: deploymentName, // Matched By Deployment Selector Above
+						constants.AppLabel:                  deploymentName, // Matched By Deployment Selector Above
+						constants.KafkaChannelReceiverLabel: "true",         // Allows for identification of Receiver Pods
 					},
 					Annotations: map[string]string{
 						commonconstants.ConfigMapHashAnnotationKey: r.kafkaConfigMapHash,

--- a/pkg/channel/distributed/controller/testing/data.go
+++ b/pkg/channel/distributed/controller/testing/data.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/utils/pointer"
-	"knative.dev/eventing-kafka/pkg/common/client"
 	"knative.dev/eventing/pkg/apis/messaging"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
@@ -46,6 +45,7 @@ import (
 	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/env"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/event"
 	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/util"
+	"knative.dev/eventing-kafka/pkg/common/client"
 	commonconfig "knative.dev/eventing-kafka/pkg/common/config"
 	commonconstants "knative.dev/eventing-kafka/pkg/common/constants"
 	commontesting "knative.dev/eventing-kafka/pkg/common/testing"
@@ -769,21 +769,22 @@ func NewKafkaChannelReceiverDeployment(options ...DeploymentOption) *appsv1.Depl
 			Name:      ReceiverDeploymentName,
 			Namespace: systemNamespace,
 			Labels: map[string]string{
-				"app":                   ReceiverDeploymentName,
-				"kafkachannel-receiver": "true",
+				constants.AppLabel:                  ReceiverDeploymentName,
+				constants.KafkaChannelReceiverLabel: "true",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": ReceiverDeploymentName,
+					constants.AppLabel: ReceiverDeploymentName,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": ReceiverDeploymentName,
+						constants.AppLabel:                  ReceiverDeploymentName,
+						constants.KafkaChannelReceiverLabel: "true",
 					},
 					Annotations: map[string]string{
 						commonconstants.ConfigMapHashAnnotationKey: ConfigMapHash,
@@ -1002,13 +1003,16 @@ func NewKafkaChannelDispatcherDeployment(options ...DeploymentOption) *appsv1.De
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": dispatcherName,
+					constants.AppLabel: dispatcherName,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": dispatcherName,
+						constants.AppLabel:                    dispatcherName,
+						constants.KafkaChannelNameLabel:       KafkaChannelName,
+						constants.KafkaChannelNamespaceLabel:  KafkaChannelNamespace,
+						constants.KafkaChannelDispatcherLabel: "true",
 					},
 					Annotations: map[string]string{
 						commonconstants.ConfigMapHashAnnotationKey: ConfigMapHash,


### PR DESCRIPTION
It is useful in production environments to be able to identify KafkaChannel Dispatcher Pods via a label.  Currently we have labels on the Deployments but not the Pods.  This PR fixes that by applying the labels in both places.

## Proposed Changes
- 🧽  Enhance the Controller logic for creating Receiver/Dispatcher Deployments so that the labels are applied to resulting Pods as well.

