### PR TITLE
Upgrade KafkaCat image used in KafkaSource e2e tests

### DIFF
--- a/test/e2e/helpers/kafka_helper.go
+++ b/test/e2e/helpers/kafka_helper.go
@@ -47,6 +47,7 @@ const (
 	strimziTopicResource = "kafkatopics"
 	interval             = 3 * time.Second
 	timeout              = 30 * time.Second
+	kafkaCatImage        = "docker.io/edenhill/kafkacat:1.6.0"
 )
 
 var (
@@ -102,7 +103,7 @@ func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, top
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Image:   "docker.io/edenhill/kafkacat:1.5.0",
+				Image:   kafkaCatImage,
 				Name:    cgName + "-producer-container",
 				Command: []string{"kafkacat"},
 				Args:    args,


### PR DESCRIPTION
The 1.6.0 version includes built-in retrying.

Fixes #789 