### PR TITLE
fix-reconfigure-and-reconciliation-issues

### DIFF
--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -232,7 +232,7 @@ func NewSecretObserver(kcController *kncontroller.Impl, channelKey string, dispa
 		// Signal The Dispatcher To Recreate Kafka Config And Reconnect All Current ConsumerGroups
 		dispatcher.SecretChanged(ctx, secret)
 
-		// Requeue The KafkaChannel To Fix Any "Stuck" Subscriptions From A Prior Bad Kafka Secret
+		// Requeue The KafkaChannel To Fix Any Not-Ready Subscriptions
 		channelNamespace, channelName, err := cache.SplitMetaNamespaceKey(channelKey)
 		if err != nil {
 			logger.Error("Invalid KafkaChannel Key", zap.String("ChannelKey", channelKey), zap.Error(err))

--- a/cmd/channel/distributed/dispatcher/main.go
+++ b/cmd/channel/distributed/dispatcher/main.go
@@ -24,8 +24,10 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"knative.dev/eventing/pkg/kncloudevents"
 	injectionclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
@@ -54,7 +56,6 @@ import (
 
 // Variables
 var (
-	logger        *zap.Logger
 	dispatcher    dispatch.Dispatcher
 	managerEvents <-chan commonconsumer.ManagerEvent
 )
@@ -85,7 +86,7 @@ func main() {
 	ctx = commonk8s.LoggingContext(ctx, constants.Component, k8sClient)
 
 	// Get The Logger From The Context & Defer Flushing Any Buffered Log Entries On Exit
-	logger = logging.FromContext(ctx).Desugar()
+	logger := logging.FromContext(ctx).Desugar()
 	defer flush(logger)
 
 	// Load Environment Variables
@@ -161,35 +162,32 @@ func main() {
 	}
 	dispatcher, managerEvents = dispatch.NewDispatcher(dispatcherConfig, controlProtocolServer)
 
+	// Create KafkaChannel Informer
+	kafkaClient := kafkaclientset.NewForConfigOrDie(k8sConfig)
+	kafkaInformerFactory := externalversions.NewSharedInformerFactory(kafkaClient, environment.ResyncPeriod)
+	kafkaChannelInformer := kafkaInformerFactory.Messaging().V1beta1().KafkaChannels()
+
+	// Construct The KafkaChannel Controller
+	kcController := controller.NewController(
+		logger,
+		environment.ChannelKey,
+		dispatcher,
+		kafkaChannelInformer,
+		k8sClient,
+		kafkaClient,
+		ctx.Done(),
+		managerEvents,
+	)
+
 	// Watch The Secret For Changes
+	secretObserver := NewSecretObserver(kcController, environment.ChannelKey)
 	err = distributedcommonconfig.InitializeSecretWatcher(ctx, environment.KafkaSecretNamespace, environment.KafkaSecretName, environment.ResyncPeriod, secretObserver)
 	if err != nil {
 		logger.Fatal("Failed To Start Secret Watcher", zap.Error(err))
 	}
 
-	kafkaClient := kafkaclientset.NewForConfigOrDie(k8sConfig)
-
-	kafkaInformerFactory := externalversions.NewSharedInformerFactory(kafkaClient, environment.ResyncPeriod)
-
-	// Create KafkaChannel Informer
-	kafkaChannelInformer := kafkaInformerFactory.Messaging().V1beta1().KafkaChannels()
-
-	// Construct Array Of Controllers, In Our Case Just The One
-	controllers := [...]*kncontroller.Impl{
-		controller.NewController(
-			logger,
-			environment.ChannelKey,
-			dispatcher,
-			kafkaChannelInformer,
-			k8sClient,
-			kafkaClient,
-			ctx.Done(),
-			managerEvents,
-		),
-	}
-
 	// Start The Informers
-	logger.Info("Starting informers.")
+	logger.Info("Starting Informers")
 	if err := kncontroller.StartInformers(ctx.Done(), kafkaChannelInformer.Informer()); err != nil {
 		logger.Error("Failed to start informers", zap.Error(err))
 		return
@@ -201,8 +199,8 @@ func main() {
 	healthServer.SetDispatcherReady(true)
 
 	// Start The Controllers (Blocking WaitGroup.Wait Call)
-	logger.Info("Starting controllers.")
-	kncontroller.StartAll(ctx, controllers[:]...)
+	logger.Info("Starting KafkaChannel Controller")
+	kncontroller.StartAll(ctx, kcController)
 
 	// Reset The Liveness and Readiness Flags In Preparation For Shutdown
 	healthServer.Shutdown()
@@ -219,21 +217,35 @@ func flush(logger *zap.Logger) {
 	eventingmetrics.FlushExporter()
 }
 
-// secretObserver is the callback function that handles changes to our Secret
-func secretObserver(ctx context.Context, secret *corev1.Secret) {
-	secretLogger := logging.FromContext(ctx)
+// NewSecretObserver is a factory for creating the callback function that handles changes to the Kafka Secret.
+func NewSecretObserver(kcController *kncontroller.Impl, channelKey string) func(ctx context.Context, secret *corev1.Secret) {
+	return func(ctx context.Context, secret *corev1.Secret) {
 
-	if secret == nil {
-		secretLogger.Warn("Nil Secret passed to secretObserver; ignoring")
-		return
+		// Get The Logger From The Context
+		logger := logging.FromContext(ctx)
+
+		// Validate The Secret (Ignore Invalid)
+		if secret == nil {
+			logger.Warn("Nil Secret passed to secretObserver; ignoring")
+			return
+		}
+
+		// Ignore Startup Scenario Where Dispatcher Reference Might Be Nil
+		if dispatcher == nil {
+			logger.Debug("Dispatcher is nil during call to secretObserver; ignoring changes")
+			return
+		}
+
+		// Signal The Dispatcher To Recreate Kafka Config And Reconnect All Current ConsumerGroups
+		dispatcher.SecretChanged(ctx, secret)
+
+		// Requeue The KafkaChannel To Fix Any "Stuck" Subscriptions From A Prior Bad Kafka Secret
+		channelNamespace, channelName, err := cache.SplitMetaNamespaceKey(channelKey)
+		if err != nil {
+			logger.Error("Invalid KafkaChannel Key", zap.String("ChannelKey", channelKey), zap.Error(err))
+		} else {
+			logger.Debug("Requeue-ing KafkaChannel due to Kafka Secret change", zap.String("ChannelKey", channelKey))
+			kcController.EnqueueKey(types.NamespacedName{Namespace: channelNamespace, Name: channelName})
+		}
 	}
-
-	if dispatcher == nil {
-		// This typically happens during startup
-		secretLogger.Debug("Dispatcher is nil during call to secretObserver; ignoring changes")
-		return
-	}
-
-	// Toss the new secret to the dispatcher for inspection and action
-	dispatcher.SecretChanged(ctx, secret)
 }

--- a/pkg/channel/distributed/common/kafka/util/util.go
+++ b/pkg/channel/distributed/common/kafka/util/util.go
@@ -20,8 +20,12 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
 )
+
+const GroupIdPrefix = "kafka"
 
 // TopicName returns a formatted string representing the Kafka Topic name.
 func TopicName(namespace string, name string) string {
@@ -30,7 +34,12 @@ func TopicName(namespace string, name string) string {
 
 // GroupId returns a formatted string representing the Kafka ConsumerGroup ID.
 func GroupId(uid string) string {
-	return fmt.Sprintf("kafka.%s", uid)
+	return fmt.Sprintf("%s.%s", GroupIdPrefix, uid)
+}
+
+// Uid returns a UID from the specified GroupId, which is the inverse of GroupId().
+func Uid(groupId string) types.UID {
+	return types.UID(strings.TrimPrefix(groupId, GroupIdPrefix+"."))
 }
 
 // AppendKafkaChannelServiceNameSuffix appends the KafkaChannel Service name suffix to the specified string.

--- a/pkg/channel/distributed/common/kafka/util/util_test.go
+++ b/pkg/channel/distributed/common/kafka/util/util_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+
 	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
 )
 
@@ -51,6 +53,21 @@ func TestGroupId(t *testing.T) {
 	// Verify The Results
 	expectedGroupId := "kafka." + uid
 	assert.Equal(t, expectedGroupId, actualGroupId)
+}
+
+// Test The Uid() Functionality
+func TestUid(t *testing.T) {
+
+	// Test Data
+	uidString := "TestUID"
+	groupId := GroupIdPrefix + "." + uidString
+
+	// Perform The Test
+	actualUid := Uid(groupId)
+
+	// Verify The Results
+	expectedUid := types.UID(uidString)
+	assert.Equal(t, expectedUid, actualUid)
 }
 
 // Test The AppendChannelServiceNameSuffix() Functionality

--- a/pkg/channel/distributed/dispatcher/controller/kafkachannel_test.go
+++ b/pkg/channel/distributed/dispatcher/controller/kafkachannel_test.go
@@ -290,7 +290,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithSubscriberReady("1")),
 			},
 			Key:     kcKey,
-			WantErr: false,
+			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewKafkaChannel(kcName, testNS,
 					reconciletesting.WithInitKafkaChannelConditions,

--- a/pkg/common/consumer/consumer_manager.go
+++ b/pkg/common/consumer/consumer_manager.go
@@ -221,7 +221,7 @@ func (m *kafkaConsumerGroupManagerImpl) Reconfigure(brokers []string, config *sa
 				// in a practical sense, the new brokers/config will be used when whatever locked the group
 				// restarts it anyway.
 				multierr.AppendInto(&multiErr, err)
-				
+
 				// Remove The Group From The Manager So That It Will Be Restarted On Next Reconciliation
 				m.removeGroup(groupId)
 				failedGroups = append(failedGroups, groupId)

--- a/pkg/common/consumer/consumer_manager.go
+++ b/pkg/common/consumer/consumer_manager.go
@@ -127,8 +127,12 @@ type ReconfigureError struct {
 }
 
 // Error implements the golang error interface.
-func (r *ReconfigureError) Error() string {
-	return r.MultiError.Error()
+func (r ReconfigureError) Error() string {
+	var multiErrString string
+	if r.MultiError != nil {
+		multiErrString = r.MultiError.Error()
+	}
+	return fmt.Sprintf("Reconfigure Failed: MultiErr='%s', GroupIds='%+v'", multiErrString, r.GroupIds)
 }
 
 // Ensure ReconfigureError Is A Valid Error

--- a/pkg/common/consumer/consumer_manager_test.go
+++ b/pkg/common/consumer/consumer_manager_test.go
@@ -86,6 +86,8 @@ func TestReconfigure(t *testing.T) {
 			} else {
 				assert.NotNil(t, err)
 				assert.Equal(t, testCase.expectErr, err.Error())
+				assert.Len(t, err.GroupIds, 1)
+				assert.Equal(t, testCase.groupId, err.GroupIds[0])
 			}
 			server.AssertExpectations(t)
 		})

--- a/pkg/common/consumer/consumer_manager_test.go
+++ b/pkg/common/consumer/consumer_manager_test.go
@@ -66,13 +66,13 @@ func TestReconfigure(t *testing.T) {
 			name:      "Error stopping groups",
 			groupId:   "test-id1",
 			closeErr:  fmt.Errorf("error closing consumer group"),
-			expectErr: "error closing consumer group",
+			expectErr: "Reconfigure Failed: MultiErr='error closing consumer group', GroupIds='[test-id1]'",
 		},
 		{
 			name:       "Error starting groups",
 			groupId:    "test-id1",
 			factoryErr: true,
-			expectErr:  "factory error",
+			expectErr:  "Reconfigure Failed: MultiErr='factory error', GroupIds='[test-id1]'",
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/pkg/common/consumer/consumer_manager_test.go
+++ b/pkg/common/consumer/consumer_manager_test.go
@@ -94,6 +94,51 @@ func TestReconfigure(t *testing.T) {
 	}
 }
 
+func TestReconfigureError(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		err    ReconfigureError
+		result string
+	}{
+		{
+			name: "Empty",
+			err: ReconfigureError{
+				MultiError: nil,
+				GroupIds:   nil,
+			},
+			result: "Reconfigure Failed: MultiErr='', GroupIds='[]'",
+		},
+		{
+			name: "MultiErr Only",
+			err: ReconfigureError{
+				MultiError: fmt.Errorf("test-error"),
+				GroupIds:   nil,
+			},
+			result: "Reconfigure Failed: MultiErr='test-error', GroupIds='[]'",
+		},
+		{
+			name: "GroupIds Only",
+			err: ReconfigureError{
+				MultiError: nil,
+				GroupIds:   []string{"one", "two", "three"},
+			},
+			result: "Reconfigure Failed: MultiErr='', GroupIds='[one two three]'",
+		},
+		{
+			name: "Complete",
+			err: ReconfigureError{
+				MultiError: fmt.Errorf("test-error"),
+				GroupIds:   []string{"one", "two", "three"},
+			},
+			result: "Reconfigure Failed: MultiErr='test-error', GroupIds='[one two three]'",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.result, testCase.err.Error())
+		})
+	}
+}
+
 func TestStartConsumerGroup(t *testing.T) {
 	defer restoreNewConsumerGroup(newConsumerGroup)
 

--- a/pkg/common/consumer/testing/mocks.go
+++ b/pkg/common/consumer/testing/mocks.go
@@ -56,8 +56,8 @@ func NewMockConsumerGroupManager() *MockConsumerGroupManager {
 
 var _ consumer.KafkaConsumerGroupManager = (*MockConsumerGroupManager)(nil)
 
-func (m *MockConsumerGroupManager) Reconfigure(brokers []string, config *sarama.Config) error {
-	return m.Called(brokers, config).Error(0)
+func (m *MockConsumerGroupManager) Reconfigure(brokers []string, config *sarama.Config) *consumer.ReconfigureError {
+	return m.Called(brokers, config).Get(0).(*consumer.ReconfigureError)
 }
 
 func (m *MockConsumerGroupManager) StartConsumerGroup(groupId string, topics []string, logger *zap.SugaredLogger,


### PR DESCRIPTION
Fixes #794 

## Proposed Changes

- 🧽  Restructure Dispatcher main() to create Controller prior to SecretWatcher.
- 🧽  Change Dispatcher's SecretObserver to be a factory capable of requeueing KafkaChannels.
- 🧽  Add util function to convert from GroupId back to Subscription.UID.
- 🧽  Return errors from Dispatcher Controller Reconcile() to requeue on failure.
- 🧽  Create new ReconfigureError type to contain the failed ConsumerGroup IDs
- 🧽  Dispatcher.SecretChanged() should handle ReconfigureErrors by removing failed ConsumerGroups from Dispatcher.subscribers so that the next reconcile will not ignore them (as being previously closed)
- 🐛 Dispatcher.Reconfigure() bug fixed so that "paused" (stopped) aren't restarted.
- 🧽  Dispatcher.Reconfigure() tracks failed ConsumerGroup IDs and returns new ReconfigureError type.
- 🧽  Removed unneeded DispatcherConfig.SubscriberSpecs

**Release Note**

```release-note
Distributed KafkaChannel Dispatcher will now re-queue KafkaChannels after failed reconciliation which will improve various failure recovery scenarios, but could consume CPU resources if reconciliation is blocked by underlying system issues (bad Kafka Secret config, etc.)
```

Holding for further testing...
/hold