### PR TITLE
Address TODO from releases 0.22 and 0.23

### DIFF
--- a/pkg/apis/messaging/v1beta1/kafka_channel_defaults.go
+++ b/pkg/apis/messaging/v1beta1/kafka_channel_defaults.go
@@ -33,13 +33,9 @@ func (c *KafkaChannel) SetDefaults(ctx context.Context) {
 		c.Annotations = make(map[string]string)
 	}
 
-	// TODO this should be wrapped in a if to avoid conversion of ducks and let some other duck controller do that?!
-	//   BUT we need this hack to properly update from v1alpha1 to v1beta1, so:
-	//   * KEEP THIS FOR THE WHOLE 0.22 LIFECYCLE
-	//   * REMOVE THIS BEFORE 0.23 RELEASE
-	//if _, ok := c.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
-	c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
-	//}
+	if _, ok := c.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
+		c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
+	}
 
 	c.Spec.SetDefaults(ctx)
 }


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Removes a hack/todo from between 0.22 and 0.23 release. Reference PR: 
https://github.com/knative-sandbox/eventing-kafka/commit/59b7a9b1bce96c025ed348e494da0b99b22cff33#diff-b1219d1afc23409422ab316a2b695a33d92ec74fcc53b98691e9cd3058d8a106L35-R42

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- remove hard coded `SubscribableDuckVersionAnnotation` 
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
