### PR TITLE
removing confusing error message

### DIFF
--- a/pkg/source/mtadapter/controller.go
+++ b/pkg/source/mtadapter/controller.go
@@ -44,12 +44,14 @@ type MTAdapter interface {
 // registers event handlers to enqueue events.
 func NewController(ctx context.Context, adapter adapter.Adapter) *controller.Impl {
 	mtadapter, ok := adapter.(*Adapter)
+	logger := logging.FromContext(ctx)
 	if !ok {
-		logging.FromContext(ctx).Fatal("Multi-tenant adapters must implement the MTAdapter interface")
+		logger.Fatal("Multi-tenant adapters must implement the MTAdapter interface")
 	}
 
 	r := &Reconciler{
 		mtadapter: mtadapter,
+		logger:    logger,
 	}
 
 	impl := kafkasourcereconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {

--- a/pkg/source/mtadapter/kafkasource.go
+++ b/pkg/source/mtadapter/kafkasource.go
@@ -18,8 +18,8 @@ package mtadapter
 
 import (
 	"context"
-	"fmt"
 
+	"go.uber.org/zap"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/reconciler"
 
@@ -30,6 +30,7 @@ import (
 // Reconciler updates the internal Adapter cache kafkaSources
 type Reconciler struct {
 	mtadapter MTAdapter
+	logger    *zap.SugaredLogger
 }
 
 // Check that our Reconciler implements ReconcileKind.
@@ -37,7 +38,8 @@ var _ kafkasourcereconciler.Interface = (*Reconciler)(nil)
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1beta1.KafkaSource) reconciler.Event {
 	if !source.Status.IsReady() {
-		return fmt.Errorf("warning: KafkaSource is not ready")
+		r.logger.Warn("warning: KafkaSource is not ready")
+		return nil
 	}
 
 	// Update the adapter state


### PR DESCRIPTION
Fixes #810 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Remove confusing error message `Kafka source is not ready`. This error is returned as an event regardless the Kafka source has any real issue or not and users should not see this error message unless it is a legitimate error or it is an error they can fix. 
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
