### PR TITLE
Add delete deployment permission to kafka channel controller

### DIFF
--- a/config/channel/consolidated/roles/controller-clusterrole.yaml
+++ b/config/channel/consolidated/roles/controller-clusterrole.yaml
@@ -88,7 +88,14 @@ rules:
     resources:
       - deployments
       - deployments/status
-    verbs: *everything
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:


### PR DESCRIPTION
## Proposed Changes

- Add delete deployment permission to the consolidated KafkaChannel controller.


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The consolidated KafkaChannel controller now has the permission to delete deployment which it needs to update the owner ref of its dispatcher deployment.
```