### PR TITLE
Post-Install Release Artifacts Bug

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,7 +1,7 @@
 # Assorted scripts for development
 
 This directory contains several scripts useful in the development process of
-Knative Eventing Sources.
+Knative Eventing Kafka.
 
 - `boilerplate-go.txt` Used by kubebuilder to set the boilerplate.
 - `release.sh` Creates a new release.

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -46,16 +46,22 @@ function build_release() {
   local all_yamls=()
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
-    echo "Building Knative Eventing Contrib - ${config}"
+    echo "Building Knative Eventing Kafka - ${config}"
     ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done
 
-  if [ -d "${YAML_REPO_ROOT}/config/post-install" ]; then
-    echo "Resolving post install manifests"
+  if [ -d "${REPO_ROOT_DIR}/config/post-install/channel" ]; then
+    echo "Resolving channel post-install manifests"
+    local yaml="channel-post-install.yaml"
+    ko resolve ${KO_FLAGS} -f config/post-install/channel | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    all_yamls+=(${yaml})
+  fi
 
-    local yaml="post-install.yaml"
-    ko resolve ${KO_FLAGS} -f config/post-install/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
+  if [ -d "${REPO_ROOT_DIR}/config/post-install/source" ]; then
+    echo "Resolving source post-install manifests"
+    local yaml="source-post-install.yaml"
+    ko resolve ${KO_FLAGS} -f config/post-install/source | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   fi
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -51,17 +51,17 @@ function build_release() {
     all_yamls+=(${yaml})
   done
 
-  if [ -d "${REPO_ROOT_DIR}/config/post-install/channel" ]; then
+  if [ -d "${REPO_ROOT_DIR}/config/channel/post-install" ]; then
     echo "Resolving channel post-install manifests"
     local yaml="channel-post-install.yaml"
-    ko resolve ${KO_FLAGS} -f config/post-install/channel | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    ko resolve ${KO_FLAGS} -f config/channel/post-install | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   fi
 
-  if [ -d "${REPO_ROOT_DIR}/config/post-install/source" ]; then
+  if [ -d "${REPO_ROOT_DIR}/config/source/post-install" ]; then
     echo "Resolving source post-install manifests"
     local yaml="source-post-install.yaml"
-    ko resolve ${KO_FLAGS} -f config/post-install/source | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    ko resolve ${KO_FLAGS} -f config/source/post-install | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   fi
 


### PR DESCRIPTION
Fixes #749 

## Proposed Changes
- 🐛  Use **REPO_ROOT_DIR** instead of **YAML_REPO_ROOT**.  The latter was copied from _generate-yamls.sh_ which we are not using and so the value was not set.
- 🎁  Support more granular "channel" and "source" level post-install artifacts, so that users can more easily decide if they are necessary.
