### PR TITLE
Make status.address optional in the KafkaChannel CRD

### DIFF
--- a/config/channel/resources/kafkachannel-crd.yaml
+++ b/config/channel/resources/kafkachannel-crd.yaml
@@ -147,8 +147,6 @@ spec:
             status:
               description: Status represents the current state of the KafkaChannel. This data may be out of date.
               type: object
-              required:
-                - address
               properties:
                 address:
                   type: object


### PR DESCRIPTION
Fixes #744

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Make `status.address` optional in KafkaChannel CRD
- It is already marked as optional in the API code
- Check https://github.com/knative-sandbox/eventing-kafka/issues/744 for more details

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug: `status.address` of KafkaChannel is not required anymore, thus conditions are reflected successfully in case of an early stage error
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
