### PR TITLE
delete consumer group when deleting source

### DIFF
--- a/pkg/source/mtadapter/adapter.go
+++ b/pkg/source/mtadapter/adapter.go
@@ -222,17 +222,17 @@ func (a *Adapter) Update(ctx context.Context, obj *v1beta1.KafkaSource) error {
 	return nil
 }
 
-func (a *Adapter) Remove(obj *v1beta1.KafkaSource) {
+func (a *Adapter) Remove(name, namespace string) {
 	a.sourcesMu.Lock()
 	defer a.sourcesMu.Unlock()
-	a.logger.Infow("removing source", "name", obj.Name)
+	a.logger.Infow("removing source", "name", name)
 
-	key := obj.Namespace + "/" + obj.Name
+	key := namespace + "/" + name
 
 	cancel, ok := a.sources[key]
 
 	if !ok {
-		a.logger.Infow("source was not running. removed.", "name", obj.Name)
+		a.logger.Infow("source was not running. removed.", "name", name)
 		return
 	}
 
@@ -241,7 +241,7 @@ func (a *Adapter) Remove(obj *v1beta1.KafkaSource) {
 
 	delete(a.sources, key)
 
-	a.logger.Infow("source removed", "name", obj.Name, "remaining", len(a.sources))
+	a.logger.Infow("source removed", "name", name, "remaining", len(a.sources))
 }
 
 // partitionFetchSize determines what should be the default fetch size (in bytes)

--- a/pkg/source/mtadapter/adapter_test.go
+++ b/pkg/source/mtadapter/adapter_test.go
@@ -131,14 +131,7 @@ func TestUpdateRemoveSources(t *testing.T) {
 		t.Error("sub-adapter failed to start after 100 ms")
 	}
 
-	mtadapter.Remove(&sourcesv1beta1.KafkaSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-name",
-			Namespace: "test-ns",
-		},
-		Spec:   sourcesv1beta1.KafkaSourceSpec{},
-		Status: sourcesv1beta1.KafkaSourceStatus{},
-	})
+	mtadapter.Remove("test-name", "test-ns")
 
 	select {
 	case a := <-stoppingAdapterChan:
@@ -153,14 +146,7 @@ func TestUpdateRemoveSources(t *testing.T) {
 		t.Error(`Expected adapter to not contain "test-ns/test-name"`)
 	}
 
-	mtadapter.Remove(&sourcesv1beta1.KafkaSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-name-badBroker",
-			Namespace: "test-ns",
-		},
-		Spec:   sourcesv1beta1.KafkaSourceSpec{},
-		Status: sourcesv1beta1.KafkaSourceStatus{},
-	})
+	mtadapter.Remove("test-name-badBroker", "test-ns")
 
 	select {
 	case a := <-stoppingAdapterChan:

--- a/pkg/source/mtadapter/kafkasource.go
+++ b/pkg/source/mtadapter/kafkasource.go
@@ -54,9 +54,6 @@ func (r *Reconciler) deleteFunc(obj interface{}) {
 	if err != nil {
 		return
 	}
-	source, ok := acc.(*v1beta1.KafkaSource)
-	if !ok || source == nil {
-		return
-	}
-	r.mtadapter.Remove(source)
+
+	r.mtadapter.Remove(acc.GetName(), acc.GetNamespace())
 }

--- a/pkg/source/reconciler/common/finalizer.go
+++ b/pkg/source/reconciler/common/finalizer.go
@@ -34,7 +34,8 @@ import (
 func FinalizeKind(ctx context.Context, kubeClient kubernetes.Interface, src *v1beta1.KafkaSource) reconciler.Event {
 	bs, config, err := client.NewConfigFromSpec(ctx, kubeClient, src)
 	if err != nil {
-		return err
+		// Secrets are no longer valid. Not automatically recoverable.
+		return nil
 	}
 
 	// Version must be at least 1.1
@@ -43,7 +44,9 @@ func FinalizeKind(ctx context.Context, kubeClient kubernetes.Interface, src *v1b
 	c, err := sarama.NewClusterAdmin(bs, config)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("unable to create a kafka client", zap.Error(err))
-		return err
+
+		// not a recoverable error.
+		return nil
 	}
 	defer c.Close()
 

--- a/pkg/source/reconciler/common/finalizer.go
+++ b/pkg/source/reconciler/common/finalizer.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+
+	"github.com/Shopify/sarama"
+	"go.uber.org/zap"
+
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/reconciler"
+
+	"knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
+	"knative.dev/eventing-kafka/pkg/source/client"
+)
+
+const (
+	maxFinalizerAttempts = 10
+)
+
+// BoundedFinalizer limits the number of time a finalizer can run, due to too many errors.
+type BoundedFinalizer struct {
+	FinalizerAttempts map[string]int
+}
+
+func FinalizeKind(ctx context.Context, r *BoundedFinalizer, src *v1beta1.KafkaSource) reconciler.Event {
+	key := src.Namespace + "/" + src.Name
+
+	// Consumer group is an external resource that may not be available anymore so limit the
+	// number of times trying to delete it
+	if r.FinalizerAttempts[key] > maxFinalizerAttempts {
+		logging.FromContext(ctx).Infow("giving up trying to delete consumer group (too many attempts)", zap.String("id", src.Spec.ConsumerGroup))
+		delete(r.FinalizerAttempts, key)
+		return nil
+	}
+	r.FinalizerAttempts[key]++
+
+	bs, config, err := client.NewConfigFromSpec(ctx, kubeclient.Get(ctx), src)
+	c, err := sarama.NewClusterAdmin(bs, config)
+	if err != nil {
+		logging.FromContext(ctx).Errorw("unable to create a kafka client", zap.Error(err))
+		return err
+	}
+	defer c.Close()
+
+	if err := c.DeleteConsumerGroup(src.Spec.ConsumerGroup); err != nil {
+		logging.FromContext(ctx).Errorw("unable to delete the consumer group", zap.Error(err))
+		return err
+	}
+
+	logging.FromContext(ctx).Infow("consumer group deleted", zap.String("id", src.Spec.ConsumerGroup))
+	delete(r.FinalizerAttempts, key)
+	return nil
+}

--- a/pkg/source/reconciler/common/finalizer_test.go
+++ b/pkg/source/reconciler/common/finalizer_test.go
@@ -51,7 +51,6 @@ func TestFinalizer(t *testing.T) {
 	ctx := logtesting.TestContextWithLogger(t)
 	ctx, _ = fakekubeclient.With(ctx)
 
-	bf := &BoundedFinalizer{FinalizerAttempts: map[string]int{}}
 	src := &v1beta1.KafkaSource{
 		Spec: v1beta1.KafkaSourceSpec{
 			KafkaAuthSpec: bindingsv1beta1.KafkaAuthSpec{
@@ -61,7 +60,7 @@ func TestFinalizer(t *testing.T) {
 			ConsumerGroup: group,
 		},
 	}
-	err := FinalizeKind(ctx, fakekubeclient.Get(ctx), bf, src)
+	err := FinalizeKind(ctx, fakekubeclient.Get(ctx), src)
 	if err != nil {
 		t.Error("unexpected error: ", err)
 	}

--- a/pkg/source/reconciler/common/finalizer_test.go
+++ b/pkg/source/reconciler/common/finalizer_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/Shopify/sarama"
+
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	logtesting "knative.dev/pkg/logging/testing"
+
+	bindingsv1beta1 "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
+	"knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
+)
+
+func TestFinalizer(t *testing.T) {
+	broker := sarama.NewMockBroker(t, 1)
+	defer broker.Close()
+
+	group := "my-group"
+	deleteGroupsResponse := sarama.NewMockDeleteGroupsRequest(t).SetDeletedGroups([]string{group})
+
+	metadataResponse := sarama.NewMockMetadataResponse(t).
+		SetController(broker.BrokerID()).
+		SetBroker(broker.Addr(), broker.BrokerID())
+
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"DeleteGroupsRequest": deleteGroupsResponse,
+
+		"FindCoordinatorRequest": sarama.NewMockFindCoordinatorResponse(t).
+			SetCoordinator(sarama.CoordinatorGroup, group, broker),
+
+		"MetadataRequest": metadataResponse,
+	})
+
+	ctx := logtesting.TestContextWithLogger(t)
+	ctx, _ = fakekubeclient.With(ctx)
+
+	bf := &BoundedFinalizer{FinalizerAttempts: map[string]int{}}
+	src := &v1beta1.KafkaSource{
+		Spec: v1beta1.KafkaSourceSpec{
+			KafkaAuthSpec: bindingsv1beta1.KafkaAuthSpec{
+				BootstrapServers: []string{broker.Addr()},
+			},
+			Topics:        nil,
+			ConsumerGroup: group,
+		},
+	}
+	err := FinalizeKind(ctx, fakekubeclient.Get(ctx), bf, src)
+	if err != nil {
+		t.Error("unexpected error: ", err)
+	}
+
+}

--- a/pkg/source/reconciler/mtsource/controller.go
+++ b/pkg/source/reconciler/mtsource/controller.go
@@ -26,8 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/eventing-kafka/pkg/source/reconciler/common"
-
 	"knative.dev/pkg/apis/duck"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	nodeinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/node"
@@ -74,7 +72,6 @@ func NewController(
 	nodeInformer := nodeinformer.Get(ctx)
 
 	c := &Reconciler{
-		BoundedFinalizer:              common.BoundedFinalizer{FinalizerAttempts: map[string]int{}},
 		KubeClientSet:                 kubeclient.Get(ctx),
 		kafkaClientSet:                kafkaclient.Get(ctx),
 		kafkaLister:                   kafkaInformer.Lister(),

--- a/pkg/source/reconciler/mtsource/controller.go
+++ b/pkg/source/reconciler/mtsource/controller.go
@@ -21,14 +21,16 @@ import (
 	"fmt"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/eventing-kafka/pkg/source/reconciler/common"
+
 	"knative.dev/pkg/apis/duck"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	nodeinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/node"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -43,9 +45,8 @@ import (
 	kafkainformer "knative.dev/eventing-kafka/pkg/client/injection/informers/sources/v1beta1/kafkasource"
 	"knative.dev/eventing-kafka/pkg/client/injection/reconciler/sources/v1beta1/kafkasource"
 	"knative.dev/eventing-kafka/pkg/common/constants"
-	scheduler "knative.dev/eventing-kafka/pkg/common/scheduler"
+	"knative.dev/eventing-kafka/pkg/common/scheduler"
 	stsscheduler "knative.dev/eventing-kafka/pkg/common/scheduler/statefulset"
-	nodeinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/node"
 )
 
 type envConfig struct {
@@ -73,6 +74,7 @@ func NewController(
 	nodeInformer := nodeinformer.Get(ctx)
 
 	c := &Reconciler{
+		BoundedFinalizer:              common.BoundedFinalizer{FinalizerAttempts: map[string]int{}},
 		KubeClientSet:                 kubeclient.Get(ctx),
 		kafkaClientSet:                kafkaclient.Get(ctx),
 		kafkaLister:                   kafkaInformer.Lister(),

--- a/pkg/source/reconciler/mtsource/kafkasource.go
+++ b/pkg/source/reconciler/mtsource/kafkasource.go
@@ -163,7 +163,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1beta1.KafkaSource
 }
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, src *v1beta1.KafkaSource) reconciler.Event {
-	return common.FinalizeKind(ctx, r.KubeClientSet, &r.BoundedFinalizer, src)
+	if src.Status.Placement != nil {
+		src.Status.Placement = nil
+
+		// return an error to 1. update the status. 2. not clear the finalizer
+		return errors.New("placement list was not empty")
+	}
+
+	return common.FinalizeKind(ctx, r.KubeClientSet, src)
 }
 
 func (r *Reconciler) reconcileMTReceiveAdapter(src *v1beta1.KafkaSource) error {

--- a/pkg/source/reconciler/mtsource/kafkasource.go
+++ b/pkg/source/reconciler/mtsource/kafkasource.go
@@ -163,7 +163,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1beta1.KafkaSource
 }
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, src *v1beta1.KafkaSource) reconciler.Event {
-	return common.FinalizeKind(ctx, &r.BoundedFinalizer, src)
+	return common.FinalizeKind(ctx, r.KubeClientSet, &r.BoundedFinalizer, src)
 }
 
 func (r *Reconciler) reconcileMTReceiveAdapter(src *v1beta1.KafkaSource) error {

--- a/pkg/source/reconciler/mtsource/kafkasource.go
+++ b/pkg/source/reconciler/mtsource/kafkasource.go
@@ -29,21 +29,25 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
-	"knative.dev/eventing-kafka/pkg/common/kafka/offset"
-	"knative.dev/eventing/pkg/reconciler/source"
+
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/reconciler"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/system"
+
+	"knative.dev/eventing/pkg/reconciler/source"
 
 	"knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
 	"knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 	reconcilerkafkasource "knative.dev/eventing-kafka/pkg/client/injection/reconciler/sources/v1beta1/kafkasource"
 	listers "knative.dev/eventing-kafka/pkg/client/listers/sources/v1beta1"
+	"knative.dev/eventing-kafka/pkg/common/kafka/offset"
 	"knative.dev/eventing-kafka/pkg/common/scheduler"
 	"knative.dev/eventing-kafka/pkg/source/client"
+	"knative.dev/eventing-kafka/pkg/source/reconciler/common"
 )
 
 const (
@@ -156,6 +160,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1beta1.KafkaSource
 	src.Status.CloudEventAttributes = r.createCloudEventAttributes(src)
 
 	return nil
+}
+
+func (r *Reconciler) FinalizeKind(ctx context.Context, src *v1beta1.KafkaSource) reconciler.Event {
+	return common.FinalizeKind(ctx, &r.BoundedFinalizer, src)
 }
 
 func (r *Reconciler) reconcileMTReceiveAdapter(src *v1beta1.KafkaSource) error {

--- a/pkg/source/reconciler/source/controller.go
+++ b/pkg/source/reconciler/source/controller.go
@@ -37,6 +37,7 @@ import (
 	kafkainformer "knative.dev/eventing-kafka/pkg/client/injection/informers/sources/v1beta1/kafkasource"
 	"knative.dev/eventing-kafka/pkg/client/injection/reconciler/sources/v1beta1/kafkasource"
 	kafkasourcecontrol "knative.dev/eventing-kafka/pkg/source/control"
+	"knative.dev/eventing-kafka/pkg/source/reconciler/common"
 )
 
 func NewController(
@@ -55,6 +56,7 @@ func NewController(
 	podInformer := podinformer.Get(ctx)
 
 	c := &Reconciler{
+		BoundedFinalizer:    common.BoundedFinalizer{FinalizerAttempts: map[string]int{}},
 		KubeClientSet:       kubeclient.Get(ctx),
 		kafkaClientSet:      kafkaclient.Get(ctx),
 		kafkaLister:         kafkaInformer.Lister(),

--- a/pkg/source/reconciler/source/controller.go
+++ b/pkg/source/reconciler/source/controller.go
@@ -37,7 +37,6 @@ import (
 	kafkainformer "knative.dev/eventing-kafka/pkg/client/injection/informers/sources/v1beta1/kafkasource"
 	"knative.dev/eventing-kafka/pkg/client/injection/reconciler/sources/v1beta1/kafkasource"
 	kafkasourcecontrol "knative.dev/eventing-kafka/pkg/source/control"
-	"knative.dev/eventing-kafka/pkg/source/reconciler/common"
 )
 
 func NewController(
@@ -56,7 +55,6 @@ func NewController(
 	podInformer := podinformer.Get(ctx)
 
 	c := &Reconciler{
-		BoundedFinalizer:    common.BoundedFinalizer{FinalizerAttempts: map[string]int{}},
 		KubeClientSet:       kubeclient.Get(ctx),
 		kafkaClientSet:      kafkaclient.Get(ctx),
 		kafkaLister:         kafkaInformer.Lister(),

--- a/pkg/source/reconciler/source/kafkasource.go
+++ b/pkg/source/reconciler/source/kafkasource.go
@@ -57,6 +57,7 @@ import (
 	"knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 	reconcilerkafkasource "knative.dev/eventing-kafka/pkg/client/injection/reconciler/sources/v1beta1/kafkasource"
 	listers "knative.dev/eventing-kafka/pkg/client/listers/sources/v1beta1"
+	"knative.dev/eventing-kafka/pkg/source/reconciler/common"
 )
 
 const (
@@ -94,6 +95,8 @@ func newDeploymentFailed(namespace, name string, err error) pkgreconciler.Event 
 }
 
 type Reconciler struct {
+	common.BoundedFinalizer
+
 	// KubeClientSet allows us to talk to the k8s for core APIs
 	KubeClientSet kubernetes.Interface
 
@@ -279,7 +282,8 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, src *v1beta1.KafkaSource)
 		Namespace: src.Namespace,
 		Name:      src.Name,
 	})
-	return nil
+
+	return common.FinalizeKind(ctx, &r.BoundedFinalizer, src)
 }
 
 func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1beta1.KafkaSource, sinkURI *apis.URL) (*appsv1.Deployment, error) {

--- a/pkg/source/reconciler/source/kafkasource.go
+++ b/pkg/source/reconciler/source/kafkasource.go
@@ -283,7 +283,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, src *v1beta1.KafkaSource)
 		Name:      src.Name,
 	})
 
-	return common.FinalizeKind(ctx, &r.BoundedFinalizer, src)
+	return common.FinalizeKind(ctx, r.KubeClientSet, &r.BoundedFinalizer, src)
 }
 
 func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1beta1.KafkaSource, sinkURI *apis.URL) (*appsv1.Deployment, error) {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -586,7 +586,7 @@ function test_mt_source() {
     progress="${progress}."
     iterations=$((iterations + 1))
     kubectl get kafkasources --all-namespaces -oyaml
-    sleep 3
+    sleep 5
   done
 
   uninstall_mt_source || return 1


### PR DESCRIPTION
Fixes #839

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Delete consumer group associated to KafkaSource instances marked for deletion  
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🎁 When a KafkaSource instance is deleted, the associated consumer group is also deleted
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
 