### PR TITLE
Fix release labels missing release version because of missing kafka prefix

### DIFF
--- a/config/channel/post-install/200-clusterrole.yaml
+++ b/config/channel/post-install/200-clusterrole.yaml
@@ -17,7 +17,7 @@ kind: ClusterRole
 metadata:
   name: eventing-kafka-v0.26-channel-post-install-job
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 rules:
 - apiGroups:
   - "messaging.knative.dev"

--- a/config/channel/post-install/400-kafkachannel-update-job.yaml
+++ b/config/channel/post-install/400-kafkachannel-update-job.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         app: "kafkachannel-v0.26-post-install"
-        eventing.knative.dev/release: devel
+        kafka.eventing.knative.dev/release: devel
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/config/channel/webhook/webhook-hpa.yaml
+++ b/config/channel/webhook/webhook-hpa.yaml
@@ -18,7 +18,7 @@ metadata:
   name: kafka-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -41,7 +41,7 @@ metadata:
   name: kafka-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
 spec:
   minAvailable: 80%
   selector:

--- a/config/source/common/configmaps/config-kafka-source-defaults.yaml
+++ b/config/source/common/configmaps/config-kafka-source-defaults.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-kafka-source-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    kafka.eventing.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "b6ed351d"
 data:


### PR DESCRIPTION
Fixes #
I ran into issues installing eventing, and I think this is the cause.

I was trying to install knative-eventing version 0.22.2 with the knative operator 0.25.2.
I also wanted to install kafka-source/kafka-channel/ and apache kafka broker
Here's a snippet of my operator manifest:
```
apiVersion: operator.knative.dev/v1alpha1
kind: KnativeEventing
metadata:
  name: knative-eventing
  namespace: knative-eventing
spec:
  version: "0.22.2"
  additionalManifests: # Originally I mistakenly put "manifests:" here. After fixing it I ran into the same issue
    ## Source
    - URL: https://github.com/knative-sandbox/eventing-kafka/releases/download/v${VERSION}/source.yaml
    ## Channel
    - URL: https://github.com/knative-sandbox/eventing-kafka/releases/download/v${VERSION}/channel-consolidated.yaml
    ## Broker
    - URL: https://github.com/knative-sandbox/eventing-kafka-broker/releases/download/v${VERSION}/eventing-kafka-controller.yaml
    - URL: https://github.com/knative-sandbox/eventing-kafka-broker/releases/download/v${VERSION}/eventing-kafka-broker.yaml
  # configs
  config-kafka:
  ....
  ```

The operator started outputting errors. They all referenced this text (I assume multiple logs for one error). 
`The version of the manifests devel does not match the target version of the operator CR v0.22.2. The resource name is kafka-webhook`

Here's one of them:
```
{"severity":"ERROR","timestamp":"2021-09-17T23:37:16.937755376Z","logger":"knative-operator","caller":"knativeeventing/reconciler.go:305","message":"Returned an error","knative.dev/pod":"knative-operator-7cb4cd5877-5cw5s","knative.dev/controller":"knative.dev.operator.pkg.reconciler.knativeeventing.Reconciler","knative.dev/kind":"operator.knative.dev.KnativeEventing","knative.dev/traceid":"9f7b66bb-5cc7-4a09-b760-ef8b0e17c48d","knative.dev/key":"knative-eventing/knative-eventing","targetMethod":"ReconcileKind","error":"The version of the manifests devel does not match the target version of the operator CR v0.22.2. The resource name is kafka-webhook.","stacktrace":"knative.dev/operator/pkg/client/injection/reconciler/operator/v1alpha1/knativeeventing.(*reconcilerImpl).Reconcile\n\tknative.dev/operator/pkg/client/injection/reconciler/operator/v1alpha1/knativeeventing/reconciler.go:305\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\tknative.dev/pkg@v0.0.0-20210902173607-844a6bc45596/controller/controller.go:540\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\tknative.dev/pkg@v0.0.0-20210902173607-844a6bc45596/controller/controller.go:477"}
```
When downloading the manifest https://github.com/knative-sandbox/eventing-kafka/releases/download/v0.22.2/channel-consolidated.yaml
You can see that the webhook-hpa.yaml contents don't have a release version applied. I think that's because they are tagged with
`eventing.knative.dev/release: devel` in the repo instead of `kafka.eventing.knative.dev/release: devel`

I fixed that specific file and the other files I found in the repo that might be suffering from the same issue.
## Proposed Changes
- All kafka k8s objects should have the label kafka.eventing.knative.dev/release: devel instead of eventing.knative.dev...

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix operator installation issue cause by missing release label
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
