### PR TITLE
[WIP] Update KinD workflows to use k8s 1.20, 1.21 and 1.22

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.17.11
-        - v1.18.8
-        - v1.19.1
+        - v1.20.7
+        - v1.21.1
+        - v1.22.0
 
         test-suite:
         - ./test/e2e
@@ -31,15 +31,16 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
         include:
-        - k8s-version: v1.17.11
-          kind-version: v0.9.0
-          kind-image-sha: sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
-        - k8s-version: v1.18.8
-          kind-version: v0.9.0
-          kind-image-sha: sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
-        - k8s-version: v1.19.1
-          kind-version: v0.9.0
-          kind-image-sha: sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
+        - k8s-version: v1.20.7
+          kind-version: v0.11.1
+          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+        - k8s-version: v1.21.1
+          kind-version: v0.11.1
+          kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        - k8s-version: v1.22.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717
+
 
         # Add the flags we use for each of these test suites.
         - test-suite: ./test/e2e
@@ -180,8 +181,6 @@ jobs:
         kubectl get pod -n knative-eventing
 
         kubectl get pod --all-namespaces
-
-      - name: Install Test Images
 
     - name: Install Knative Eventing Kafka
       run: |

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -147,8 +147,8 @@ jobs:
 
     - name: Install Knative
       env:
-        SERVING_VERSION: v0.18.0
-        KOURIER_VERSION: v0.18.0
+        SERVING_VERSION: v0.26.0
+        KOURIER_VERSION: v0.26.0
       run: |
         # Prerequisites
         sudo pip install yq

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -150,6 +150,8 @@ jobs:
         SERVING_VERSION: v0.26.0
         KOURIER_VERSION: v0.26.0
       run: |
+        set -x
+        
         # Prerequisites
         sudo pip install yq
 


### PR DESCRIPTION
There was a syntax error in the KinD workflow and
k8s 1.17, 1.18, 1.19 are not supported anymore.

## Proposed Changes

- Use k8s 1.20, 1.21, 1.22
- Fix syntax error
- Ugrade serving version to 0.26