### PR TITLE
Adding noop migrator for kafkachannels

### DIFF
--- a/config/channel/post-install/clusterrole.yaml
+++ b/config/channel/post-install/clusterrole.yaml
@@ -41,7 +41,6 @@ rules:
       - "list"
       - "create"
       - "update"
-      - "delete"
       - "patch"
       - "watch"
   - apiGroups:

--- a/config/channel/post-install/clusterrole.yaml
+++ b/config/channel/post-install/clusterrole.yaml
@@ -1,0 +1,53 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-kafka-post-install-job-role
+  labels:
+    kafka.eventing.knative.dev/release: devel
+rules:
+  # Storage version upgrader needs to be able to patch CRDs.
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+      - "customresourcedefinitions/status"
+    verbs:
+      - "get"
+      - "list"
+      - "update"
+      - "patch"
+      - "watch"
+  # Our own resources we care about.
+  - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "kafkachannels"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - "get"
+      - "list"

--- a/config/channel/post-install/clusterrole.yaml
+++ b/config/channel/post-install/clusterrole.yaml
@@ -15,7 +15,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: knative-eventing-kafka-post-install-job-role
+  name: knative-eventing-kafka-channel-post-install-job-role
   labels:
     kafka.eventing.knative.dev/release: devel
 rules:

--- a/config/channel/post-install/placeholder.go
+++ b/config/channel/post-install/placeholder.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package post_install is a placeholder that allows us to pull in config files
+// via go mod vendor.
+package post_install

--- a/config/channel/post-install/serviceaccount.yaml
+++ b/config/channel/post-install/serviceaccount.yaml
@@ -1,0 +1,38 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-eventing-kafka-post-install-job
+  namespace: knative-eventing
+  labels:
+    kafka.eventing.knative.dev/release: devel
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-eventing-kafka-post-install-job-role-binding
+  labels:
+    kafka.eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: knative-eventing-kafka-post-install-job
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-kafka-post-install-job-role
+  apiGroup: rbac.authorization.k8s.io

--- a/config/channel/post-install/serviceaccount.yaml
+++ b/config/channel/post-install/serviceaccount.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: knative-eventing-kafka-post-install-job
+  name: knative-eventing-kafka-channel-post-install-job
   namespace: knative-eventing
   labels:
     kafka.eventing.knative.dev/release: devel
@@ -25,14 +25,14 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: knative-eventing-kafka-post-install-job-role-binding
+  name: knative-eventing-kafka-channel-post-install-job-role-binding
   labels:
     kafka.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
-    name: knative-eventing-kafka-post-install-job
+    name: knative-eventing-kafka-channel-post-install-job
     namespace: knative-eventing
 roleRef:
   kind: ClusterRole
-  name: knative-eventing-kafka-post-install-job-role
+  name: knative-eventing-kafka-channel-post-install-job-role
   apiGroup: rbac.authorization.k8s.io

--- a/config/channel/post-install/storage-version-migrator.yaml
+++ b/config/channel/post-install/storage-version-migrator.yaml
@@ -15,10 +15,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: storage-version-migration-eventing-kafka-
+  generateName: storage-version-migration-eventing-kafka-channel-
   namespace: knative-eventing
   labels:
-    app: "storage-version-migration-eventing-kafka"
+    app: "storage-version-migration-eventing-kafka-channel"
     kafka.eventing.knative.dev/release: devel
 spec:
   ttlSecondsAfterFinished: 600
@@ -26,12 +26,12 @@ spec:
   template:
     metadata:
       labels:
-        app: "storage-version-migration-eventing-kafka"
+        app: "storage-version-migration-eventing-kafka-channel"
         kafka.eventing.knative.dev/release: devel
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: knative-eventing-kafka-post-install-job
+      serviceAccountName: knative-eventing-kafka-channel-post-install-job
       restartPolicy: OnFailure
       containers:
         - name: migrate

--- a/config/channel/post-install/storage-version-migrator.yaml
+++ b/config/channel/post-install/storage-version-migrator.yaml
@@ -1,0 +1,40 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: storage-version-migration-eventing-kafka-
+  namespace: knative-eventing
+  labels:
+    app: "storage-version-migration-eventing-kafka"
+    kafka.eventing.knative.dev/release: devel
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: "storage-version-migration-eventing-kafka"
+        kafka.eventing.knative.dev/release: devel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: knative-eventing-kafka-post-install-job
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: ko://knative.dev/eventing-kafka/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+          args:
+            - "kafkachannels.messaging.knative.dev"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

- :broom: Adding noop migrator for the `kafkachannels.messaging.knative.dev` to always have a migrator manifest on each release. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
