### PR TITLE
[trivial] Add test directory to ignored codecov directory

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,5 +1,6 @@
 ignore:
   - "**/zz_generated*.go" # Ignore generated files.
   - "pkg/client"
+  - "test"
   - "third_party"
   - "vendor"


### PR DESCRIPTION
Similar to eventing, drop test directory from the codecov results
(getting a better understanding of unit testing coverage is currently
at)