### PR TITLE
Rename Placeable.Placement to Placements

### DIFF
--- a/pkg/apis/duck/v1alpha1/placement_types.go
+++ b/pkg/apis/duck/v1alpha1/placement_types.go
@@ -28,7 +28,7 @@ import (
 // Each pair represents the assignment of virtual replicas to a pod
 type Placeable struct {
 	MaxAllowedVReplicas *int32      `json:"maxAllowedVReplicas,omitempty"`
-	Placement           []Placement `json:"placements,omitempty"`
+	Placements          []Placement `json:"placements,omitempty"`
 }
 
 // PlaceableType is a skeleton type wrapping Placeable in the manner we expect
@@ -67,7 +67,7 @@ func (*Placeable) GetFullType() duck.Populatable {
 
 // Populate implements duck.Populatable
 func (t *PlaceableType) Populate() {
-	t.Status.Placement = []Placement{{PodName: "pod-0", VReplicas: int32(1)}}
+	t.Status.Placements = []Placement{{PodName: "pod-0", VReplicas: int32(1)}}
 }
 
 // GetListType implements apis.Listable

--- a/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
@@ -32,8 +32,8 @@ func (in *Placeable) DeepCopyInto(out *Placeable) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.Placement != nil {
-		in, out := &in.Placement, &out.Placement
+	if in.Placements != nil {
+		in, out := &in.Placements, &out.Placements
 		*out = make([]Placement, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/apis/sources/v1beta1/kafka_scheduling.go
+++ b/pkg/apis/sources/v1beta1/kafka_scheduling.go
@@ -41,10 +41,10 @@ func (k *KafkaSource) GetVReplicas() int32 {
 }
 
 func (k *KafkaSource) GetPlacements() []v1alpha1.Placement {
-	if k.Status.Placeable.Placement == nil {
+	if k.Status.Placeable.Placements == nil {
 		return nil
 	}
-	return k.Status.Placeable.Placement
+	return k.Status.Placeable.Placements
 }
 
 func (k *KafkaSource) GetResourceVersion() string {

--- a/pkg/apis/sources/v1beta1/kafka_scheduling_test.go
+++ b/pkg/apis/sources/v1beta1/kafka_scheduling_test.go
@@ -52,7 +52,7 @@ func TestScheduling(t *testing.T) {
 					Consumers: pointer.Int32Ptr(4),
 				},
 				Status: KafkaSourceStatus{
-					Placeable: v1alpha1.Placeable{Placement: []v1alpha1.Placement{
+					Placeable: v1alpha1.Placeable{Placements: []v1alpha1.Placement{
 						{PodName: "apod", VReplicas: 4},
 					}},
 				},

--- a/pkg/source/mtadapter/adapter.go
+++ b/pkg/source/mtadapter/adapter.go
@@ -139,7 +139,7 @@ func (a *Adapter) Update(ctx context.Context, obj *v1beta1.KafkaSource) error {
 	// Enforce memory limits
 	if a.memLimit > 0 {
 		// TODO: periodically enforce limits as the number of partitions can dynamically change
-		fetchSizePerVReplica, err := a.partitionFetchSize(ctx, logger, &kafkaEnvConfig, obj.Spec.Topics, scheduler.GetPodCount(obj.Status.Placement))
+		fetchSizePerVReplica, err := a.partitionFetchSize(ctx, logger, &kafkaEnvConfig, obj.Spec.Topics, scheduler.GetPodCount(obj.Status.Placements))
 		if err != nil {
 			return err
 		}

--- a/pkg/source/mtadapter/adapter_test.go
+++ b/pkg/source/mtadapter/adapter_test.go
@@ -73,7 +73,7 @@ func TestUpdateRemoveSources(t *testing.T) {
 		Spec: sourcesv1beta1.KafkaSourceSpec{},
 		Status: sourcesv1beta1.KafkaSourceStatus{
 			Placeable: duckv1alpha1.Placeable{
-				Placement: []duckv1alpha1.Placement{
+				Placements: []duckv1alpha1.Placement{
 					{PodName: podName, VReplicas: int32(1)},
 				}},
 		},
@@ -108,7 +108,7 @@ func TestUpdateRemoveSources(t *testing.T) {
 		},
 		Status: sourcesv1beta1.KafkaSourceStatus{
 			Placeable: duckv1alpha1.Placeable{
-				Placement: []duckv1alpha1.Placement{
+				Placements: []duckv1alpha1.Placement{
 					{PodName: podName, VReplicas: int32(1)},
 				}},
 		},
@@ -219,7 +219,7 @@ func TestSourceMTAdapter(t *testing.T) {
 				},
 				Status: sourcesv1beta1.KafkaSourceStatus{
 					Placeable: duckv1alpha1.Placeable{
-						Placement: []duckv1alpha1.Placement{
+						Placements: []duckv1alpha1.Placement{
 							{PodName: podName, VReplicas: int32(1)},
 						}},
 				},
@@ -261,7 +261,7 @@ func TestSourceMTAdapter(t *testing.T) {
 				},
 				Status: sourcesv1beta1.KafkaSourceStatus{
 					Placeable: duckv1alpha1.Placeable{
-						Placement: []duckv1alpha1.Placement{
+						Placements: []duckv1alpha1.Placement{
 							{PodName: podName, VReplicas: int32(1)},
 						}},
 				},
@@ -291,7 +291,7 @@ func TestSourceMTAdapter(t *testing.T) {
 				},
 				Status: sourcesv1beta1.KafkaSourceStatus{
 					Placeable: duckv1alpha1.Placeable{
-						Placement: []duckv1alpha1.Placement{
+						Placements: []duckv1alpha1.Placement{
 							{PodName: podName, VReplicas: int32(1)},
 						}},
 				},
@@ -321,7 +321,7 @@ func TestSourceMTAdapter(t *testing.T) {
 				},
 				Status: sourcesv1beta1.KafkaSourceStatus{
 					Placeable: duckv1alpha1.Placeable{
-						Placement: []duckv1alpha1.Placement{
+						Placements: []duckv1alpha1.Placement{
 							{PodName: podName, VReplicas: int32(1)},
 						}},
 				},

--- a/pkg/source/reconciler/mtsource/controller.go
+++ b/pkg/source/reconciler/mtsource/controller.go
@@ -126,7 +126,7 @@ func NewController(
 					ap = append(ap, p)
 				}
 			}
-			after.Status.Placement = ap
+			after.Status.Placements = ap
 
 			jsonPatch, err := duck.CreatePatch(before, after)
 			if err != nil {

--- a/pkg/source/reconciler/mtsource/kafkasource.go
+++ b/pkg/source/reconciler/mtsource/kafkasource.go
@@ -163,8 +163,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1beta1.KafkaSource
 }
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, src *v1beta1.KafkaSource) reconciler.Event {
-	if src.Status.Placement != nil {
-		src.Status.Placement = nil
+	if src.Status.Placements != nil {
+		src.Status.Placements = nil
 
 		// return an error to 1. update the status. 2. not clear the finalizer
 		return errors.New("placement list was not empty")
@@ -178,7 +178,7 @@ func (r *Reconciler) reconcileMTReceiveAdapter(src *v1beta1.KafkaSource) error {
 
 	// Update placements, even partial ones.
 	if placements != nil {
-		src.Status.Placement = placements
+		src.Status.Placements = placements
 	}
 
 	if err != nil {

--- a/test/rekt/features/kafkasource/mt_data_plane.go
+++ b/test/rekt/features/kafkasource/mt_data_plane.go
@@ -132,7 +132,7 @@ func sourcesPlaced(name string, matchers EventMatcher) func(ctx context.Context,
 					return fmt.Errorf("Error when getting Kafka source2")
 				}
 
-				if source1.Status.Placement[0].PodName != source2.Status.Placement[0].PodName && len(source2.Status.Placement[0].PodName) != 0 {
+				if source1.Status.Placements[0].PodName != source2.Status.Placements[0].PodName && len(source2.Status.Placements[0].PodName) != 0 {
 					return fmt.Errorf("Two Kafka source do not belong to the same pod")
 				}
 


### PR DESCRIPTION
Fixes #

Resolve the issue https://github.com/knative-sandbox/eventing-kafka/issues/920

## Proposed Changes

- Rename `Placeable.Placement` to `Placements`.

**Release Note**

```release-note
The `Placeable.Placement` field is an array and is serialized as `placements`, so now it will be called `Placements`.
```
