### PR TITLE
Add linters that are used in eventing

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,15 @@ run:
 
 linters:
   enable:
-    - unconvert
+    - asciicheck
     - prealloc
+    - unconvert
+    - unparam
   disable:
     - errcheck
+
+issues:
+  exclude-rules:
+    - path: test # Excludes /test, *_test.go etc.
+      linters:
+        - unparam

--- a/pkg/channel/consolidated/reconciler/controller/controller.go
+++ b/pkg/channel/consolidated/reconciler/controller/controller.go
@@ -106,7 +106,7 @@ func NewController(
 	impl := kafkaChannelReconciler.NewImpl(ctx, r)
 
 	// Call GlobalResync on kafkachannels.
-	grCh := func(obj interface{}) {
+	grCh := func(interface{}) {
 		logger.Debug("Changes detected, doing global resync")
 		impl.GlobalResync(kafkaChannelInformer.Informer())
 	}

--- a/pkg/channel/distributed/controller/kafkachannel/controller.go
+++ b/pkg/channel/distributed/controller/kafkachannel/controller.go
@@ -121,7 +121,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	controllerImpl := kafkachannelreconciler.NewImpl(ctx, rec)
 
 	// Call GlobalResync on kafkachannels.
-	grCh := func(obj interface{}) {
+	grCh := func(interface{}) {
 		logger.Info("Changes detected, doing global resync")
 		controllerImpl.GlobalResync(kafkachannelInformer.Informer())
 	}

--- a/test/e2e/helpers/kafka_source_test_helper.go
+++ b/test/e2e/helpers/kafka_source_test_helper.go
@@ -142,10 +142,9 @@ func testKafkaSourceUpdate(t *testing.T, name string, test updateTest) {
 }
 
 type message struct {
-	cloudEventType string
-	payload        []byte
-	headers        map[string]string
-	key            string
+	payload []byte
+	headers map[string]string
+	key     string
 }
 
 type updateTest struct {


### PR DESCRIPTION
## Proposed Changes

As per title, this introduces a few new linters that come via Eventing.

**Note:** We should take a look at enabling `gosec`, but it had a few complaints I was not comfortable fixing without context.

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
