### PR TITLE
Default KafkaSource sink ref namespace to object namespace

### DIFF
--- a/pkg/apis/sources/v1beta1/kafka_defaults.go
+++ b/pkg/apis/sources/v1beta1/kafka_defaults.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/uuid"
 	"k8s.io/utils/pointer"
+	"knative.dev/pkg/apis"
 
 	"knative.dev/eventing-kafka/pkg/apis/sources/config"
 )
@@ -39,6 +40,8 @@ const (
 
 // SetDefaults ensures KafkaSource reflects the default values.
 func (k *KafkaSource) SetDefaults(ctx context.Context) {
+	ctx = apis.WithinParent(ctx, k.ObjectMeta)
+
 	if k.Spec.ConsumerGroup == "" {
 		k.Spec.ConsumerGroup = uuidPrefix + uuid.New().String()
 	}
@@ -66,4 +69,6 @@ func (k *KafkaSource) SetDefaults(ctx context.Context) {
 		k.Annotations[cooldownPeriodAnnotation] = strconv.FormatInt(kafkaDefaults.CooldownPeriod, 10)
 		k.Annotations[kafkaLagThresholdAnnotation] = strconv.FormatInt(kafkaDefaults.KafkaLagThreshold, 10)
 	}
+
+	k.Spec.Sink.SetDefaults(ctx)
 }


### PR DESCRIPTION
Sink namespace is not defaulted to the object namespace for:

- KafkaSource

Forcing every implementation to define the logic:

"If `spec.sink.ref.namespace` is empty, use `metadata.namespace`"

Similar to https://github.com/knative/eventing/pull/5748

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Default KafkaSource sink namespace to object namespace

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The field `spec.sink.ref.namespace` for `KafkaSource` if not specified is defaulted to `metadata.namespace`.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```

/cc @aliok @matzew @lionelvillard  