### PR TITLE
[release-0.26] Backport of #954

### DIFF
--- a/pkg/apis/messaging/v1beta1/kafka_channel_validation.go
+++ b/pkg/apis/messaging/v1beta1/kafka_channel_validation.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/pkg/apis"
@@ -82,8 +84,20 @@ func (kc *KafkaChannel) CheckImmutableFields(_ context.Context, original *KafkaC
 		return nil
 	}
 
-	ignoreArguments := cmpopts.IgnoreFields(KafkaChannelSpec{}, "ChannelableSpec")
-	if diff, err := kmp.ShortDiff(original.Spec, kc.Spec, ignoreArguments); err != nil {
+	ignoreArguments := []cmp.Option{cmpopts.IgnoreFields(KafkaChannelSpec{}, "ChannelableSpec")}
+
+	// In the specific case of the original RetentionDuration being an empty string, allow it
+	// as an exception to the immutability requirement.
+	//
+	// KafkaChannels created pre-v0.26 will not have a RetentionDuration field (thus an empty
+	// string), and in v0.26 there is a post-install job that updates this to its proper value.
+	// This immutability check was added after the post-install job, and without this exception
+	// it will fail attempting to upgrade those pre-v0.26 channels.
+	if original.Spec.RetentionDuration == "" && kc.Spec.RetentionDuration != "" {
+		ignoreArguments = append(ignoreArguments, cmpopts.IgnoreFields(KafkaChannelSpec{}, "RetentionDuration"))
+	}
+
+	if diff, err := kmp.ShortDiff(original.Spec, kc.Spec, ignoreArguments...); err != nil {
 		return &apis.FieldError{
 			Message: "Failed to diff KafkaChannel",
 			Paths:   []string{"spec"},


### PR DESCRIPTION
Backport of #954  (issue #952)

**Release Note**

```release-note
Permit RetentionDuration immutability exception to allow the v0.26 channel-post-install.yaml to upgrade kafkachannels successfully.
```