### PR TITLE
Fix wrong KafkaSource test with CE overrides

### DIFF
--- a/test/e2e/helpers/kafka_source.go
+++ b/test/e2e/helpers/kafka_source.go
@@ -250,7 +250,6 @@ func AssureKafkaSourceIsOperational(t *testing.T, scope SourceTestScope) {
 			matcherGen: func(cloudEventsSourceName, cloudEventsEventType string) EventMatcher {
 				return AllOf(
 					HasSpecVersion(cloudevents.VersionV1),
-					HasType("my.own.type"), // TODO: this is wrong (bug in CloudEvent SDK)
 					HasSource("https://github.com/cloudevents/spec/pull"),
 					HasExtension("comexampleothervalue", "5"),
 				)


### PR DESCRIPTION
As the `TODO` reports, this test is wrong:
```golang
// TODO: this is wrong (bug in CloudEvent SDK)
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix wrong KafkaSource test with CE overrides

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```

/cc lionelvillard matzew aliok
