### PR TITLE
Fix post install jobs golang path

### DIFF
--- a/config/channel/post-install/storage-version-migrator.yaml
+++ b/config/channel/post-install/storage-version-migrator.yaml
@@ -35,6 +35,6 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: ko://knative.dev/eventing-kafka/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+          image: ko://knative.dev/pkg/apiextensions/storageversion/cmd/migrate
           args:
             - "kafkachannels.messaging.knative.dev"

--- a/config/source/post-install/storage-version-migrator.yaml
+++ b/config/source/post-install/storage-version-migrator.yaml
@@ -35,6 +35,6 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: ko://knative.dev/eventing-kafka/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+          image: ko://knative.dev/pkg/apiextensions/storageversion/cmd/migrate
           args:
             - "kafkasources.messaging.knative.dev"


### PR DESCRIPTION
This broke because of Golang 1.17 with the following error

```
package knative.dev/eventing-kafka/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate imports k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset from implicitly required module; to add missing requirements, run:
	go get k8s.io/apiextensions-apiserver@v0.21.4
```

This change is in-line with what we did to other repos.

Nightly is broken because of this.