### PR TITLE
Remove sleep and wait for KafkaSource reconciliation

### DIFF
--- a/test/e2e/kafka_source_test.go
+++ b/test/e2e/kafka_source_test.go
@@ -31,6 +31,5 @@ func TestKafkaSource(t *testing.T) {
 }
 
 func TestKafkaSourceUpdate(t *testing.T) {
-	t.Skip("Skip these since they're flaky")
 	helpers.TestKafkaSourceUpdate(t)
 }


### PR DESCRIPTION
The sleep is causing flaky tests in eventing-kafka-broker and
in this repository (as the skip suggests)

Fixes a TODO

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove sleep and wait for KafkaSource reconciliation

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```