### PR TITLE
Add IsReady & Increase timeout to KafkaSource tests

### DIFF
--- a/test/e2e/helpers/kafka_helper.go
+++ b/test/e2e/helpers/kafka_helper.go
@@ -50,7 +50,7 @@ const (
 	strimziApiVersion    = "v1beta2"
 	strimziTopicResource = "kafkatopics"
 	interval             = 3 * time.Second
-	timeout              = 30 * time.Second
+	timeout              = 4 * time.Minute
 	kafkaCatImage        = "docker.io/edenhill/kafkacat:1.6.0"
 )
 
@@ -239,11 +239,9 @@ func MustCreateTopic(client *testlib.Client, clusterName, clusterNamespace, topi
 	}
 
 	_, err := client.Dynamic.Resource(topicGVR).Namespace(clusterNamespace).Create(context.Background(), &obj, metav1.CreateOptions{})
-
 	if err != nil {
 		client.T.Fatalf("Error while creating the topic %s: %v", topicName, err)
 	}
-
 	client.Tracker.Add(topicGVR.Group, topicGVR.Version, topicGVR.Resource, clusterNamespace, topicName)
 
 	// Wait for the topic to be ready

--- a/test/e2e/helpers/kafka_source_test_helper.go
+++ b/test/e2e/helpers/kafka_source_test_helper.go
@@ -142,7 +142,7 @@ func waitForKafkaSourceReconcilerToReconcileSource(t *testing.T, client *testlib
 		if ksObj == nil {
 			t.Fatalf("Unabled to Get kafkasource: %s/%s\n", client.Namespace, kafkaSourceName)
 		}
-		return ksObj.Status.ObservedGeneration == ksObj.Generation, nil
+		return ksObj.Status.IsReady() && ksObj.Status.ObservedGeneration == ksObj.Generation, nil
 	})
 	if err != nil {
 		t.Fatalf("Failed to wait for KafkaSource reconciler to reconcile KafkaSource: %v", ksObj)


### PR DESCRIPTION
- Check KafkaSource IsReady before moving on to the next step.
- Increase waiting for resource ready timeout since errors like:
```
             {
                "lastTransitionTime": "2021-11-22T07:08:42.968600Z",
                "message": "This server does not host this topic-partition.",
                "reason": "UnknownTopicOrPartitionException",
                "status": "True",
                "type": "NotReady"
              }
```
seems to take longer to resolve.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
None
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```