### PR TITLE
Fix array comparison in tracing unit test.

### DIFF
--- a/pkg/common/tracing/tracing_test.go
+++ b/pkg/common/tracing/tracing_test.go
@@ -148,7 +148,7 @@ func TestConvertHttpHeaderToRecordHeaders(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			actual := ConvertHttpHeaderToRecordHeaders(testCase.header)
-			assert.Equal(t, testCase.want, actual)
+			assert.ElementsMatch(t, testCase.want, actual)
 		})
 	}
 }
@@ -196,7 +196,9 @@ func TestConvertRecordHeadersToHttpHeader(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			actual := ConvertRecordHeadersToHttpHeader(testCase.recordHeaders)
-			assert.Equal(t, testCase.want, actual)
+			for wantKey, wantValues := range testCase.want {
+				assert.ElementsMatch(t, wantValues, actual[wantKey])
+			}
 		})
 	}
 }
@@ -244,7 +246,7 @@ func TestFilterCeRecordHeaders(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			actual := FilterCeRecordHeaders(testCase.recordHeaders)
-			assert.Equal(t, testCase.want, actual)
+			assert.ElementsMatch(t, testCase.want, actual)
 		})
 	}
 }


### PR DESCRIPTION
Stupid oversight in recent creation of unit tests for tracing utility functions.  Was order dependent when should not have been.  Crazy it has been passing for this long ; )

## Proposed Changes

- 🐛  Fix testify assertion utilities used to compare array contents.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
