### PR TITLE
SourceCRDRegistryTest

### DIFF
--- a/test/conformance/source_crd_registry_test.go
+++ b/test/conformance/source_crd_registry_test.go
@@ -1,0 +1,32 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"testing"
+
+	srchelpers "knative.dev/eventing/test/conformance/helpers/sources"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestSourceCRDRegistry(t *testing.T) {
+	srchelpers.SourceCRDRegistryTestHelperWithChannelTestRunner(t,
+		sourcesTestRunner, testlib.SetupClientOptionNoop)
+}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #
lets see ... 
/hold