### PR TITLE
Update KafkaChannel CRD to support experimental-features in Delivery

### DIFF
--- a/config/channel/resources/kafkachannel-crd.yaml
+++ b/config/channel/resources/kafkachannel-crd.yaml
@@ -88,6 +88,7 @@ spec:
                       description: Retry is the minimum number of retries the sender should attempt when sending an event before moving it to the dead letter sink.
                       type: integer
                       format: int32
+                  x-kubernetes-preserve-unknown-fields: true # This is necessary to enable experimental features in the delivery
                 subscribers:
                   description: This is the list of subscriptions for this subscribable.
                   type: array
@@ -131,6 +132,7 @@ spec:
                             description: Retry is the minimum number of retries the sender should attempt when sending an event before moving it to the dead letter sink.
                             type: integer
                             format: int32
+                        x-kubernetes-preserve-unknown-fields: true # This is necessary to enable experimental features in the delivery
                       generation:
                         description: Generation of the origin of the subscriber with uid:UID.
                         type: integer


### PR DESCRIPTION
In order to allow experimental-features related to the Delivery Spec (Timeout, RetryAfterMax, etc.) we need to loosen constraints on that part of the KafkaChannel CRD.

## Proposed Changes

- 🧽  Add preserve-unknown-fields flag to "delivery" portions of the KafkaChannel CRD.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
