### PR TITLE
Validate SourceSpec in KafkaSource

### DIFF
--- a/pkg/apis/sources/v1beta1/kafka_validation.go
+++ b/pkg/apis/sources/v1beta1/kafka_validation.go
@@ -36,8 +36,8 @@ func (ks *KafkaSource) Validate(ctx context.Context) *apis.FieldError {
 func (kss *KafkaSourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 
-	// Validate sink
-	errs = errs.Also(kss.Sink.Validate(ctx).ViaField("sink"))
+	// Validate source spec
+	errs = errs.Also(kss.SourceSpec.Validate(ctx))
 
 	// Check for mandatory fields
 	if len(kss.Topics) <= 0 {

--- a/test/e2e/helpers/kafka_source.go
+++ b/test/e2e/helpers/kafka_source.go
@@ -244,7 +244,6 @@ func AssureKafkaSourceIsOperational(t *testing.T, scope SourceTestScope) {
 				"id":          "A234-1234-1234",
 			}),
 			extensions: map[string]string{
-				"type":                 "my.own.type",
 				"comexampleothervalue": "5",
 			},
 			matcherGen: func(cloudEventsSourceName, cloudEventsEventType string) EventMatcher {


### PR DESCRIPTION
We need to validate the SourceSpec field as part of the KafkaSource
webhook validation.

The E2E test for KafkaSource is trying specify the type as
`CEOverride` which is disallowed by the Source spec:

> When spec.ceOverrides.extensions is specified and non-empty,
> the event sent to the sink is augmented or modified with the
> specified extension attributes.
> The source controller MUST reject extensions overriding the
> required Cloud Events attributes.

Ref: https://github.com/knative/eventing/blob/main/docs/spec/sources.md#duckspec

Signed-off-by: Pierangelo Di Pilato <pdipilat@redhat.com>

Part of upgrading dependencies in #1035

<!-- Please include the 'why' behind your changes if no issue exists -->

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
The KafkaSource webhook reject extensions overriding the required Cloud Events attributes as specified by the SourceSpec
https://github.com/knative/eventing/blob/main/docs/spec/sources.md#duckspec.
```
