### PR TITLE
Custom leader-election configuration for KafkaChannel

### DIFF
--- a/config/channel/config/leader-election-configmap.yaml
+++ b/config/channel/config/leader-election-configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    leaseDuration: "15s"
+
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renewDeadline: "10s"
+
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retryPeriod: "2s"
+
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+kind: ConfigMap
+metadata:
+  labels:
+    kafka.eventing.knative.dev/release: devel
+  name: config-leader-election-kafkachannel
+  namespace: knative-eventing

--- a/config/channel/consolidated/400-leaderelection-configmap.yaml
+++ b/config/channel/consolidated/400-leaderelection-configmap.yaml
@@ -1,0 +1,1 @@
+../config/leader-election-configmap.yaml

--- a/config/channel/consolidated/deployments/controller.yaml
+++ b/config/channel/consolidated/deployments/controller.yaml
@@ -49,7 +49,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: CONFIG_LEADERELECTION_NAME
-          value: config-leader-election
+          value: config-leader-election-kafkachannel
         - name: DISPATCHER_IMAGE
           value: ko://knative.dev/eventing-kafka/cmd/channel/consolidated/dispatcher
         # service account used in the dispatcher

--- a/config/channel/distributed/300-leaderelection-configmap.yaml
+++ b/config/channel/distributed/300-leaderelection-configmap.yaml
@@ -1,0 +1,1 @@
+../config/leader-election-configmap.yaml

--- a/config/channel/distributed/500-controller-deployment.yaml
+++ b/config/channel/distributed/500-controller-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: CONFIG_LEADERELECTION_NAME
-          value: config-leader-election
+          value: config-leader-election-kafkachannel
         - name: SERVICE_ACCOUNT
           valueFrom:
             fieldRef:
@@ -70,9 +70,9 @@ spec:
             cpu: 20m
             memory: 25Mi
         volumeMounts:
-          - name: config-kafka
-            mountPath: /etc/config-kafka
-      volumes:
         - name: config-kafka
-          configMap:
-            name: config-kafka
+          mountPath: /etc/config-kafka
+      volumes:
+      - name: config-kafka
+        configMap:
+          name: config-kafka

--- a/config/channel/distributed/500-controller-deployment.yaml
+++ b/config/channel/distributed/500-controller-deployment.yaml
@@ -70,9 +70,9 @@ spec:
             cpu: 20m
             memory: 25Mi
         volumeMounts:
-        - name: config-kafka
-          mountPath: /etc/config-kafka
+          - name: config-kafka
+            mountPath: /etc/config-kafka
       volumes:
-      - name: config-kafka
-        configMap:
-          name: config-kafka
+        - name: config-kafka
+          configMap:
+            name: config-kafka

--- a/config/channel/webhook/webhook-deployment-ro.yaml
+++ b/config/channel/webhook/webhook-deployment-ro.yaml
@@ -51,6 +51,8 @@ spec:
           value: "8443"
         - name: RESETOFFSET_SUPPORT
           value: "true"
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-kafkachannel
         ports:
         - name: https-webhook
           containerPort: 8443

--- a/config/channel/webhook/webhook-deployment.yaml
+++ b/config/channel/webhook/webhook-deployment.yaml
@@ -49,6 +49,8 @@ spec:
           value: kafka-webhook
         - name: WEBHOOK_PORT
           value: "8443"
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-kafkachannel
         ports:
         - name: https-webhook
           containerPort: 8443


### PR DESCRIPTION
The semi-recent automated update of dependencies #1058 pulled in changes in **knative.dev/pkg/leader-election/config.go** which are breaking the startup of the KafkaChannel Webhook.  Specifically the default config timings were relaxed to be less frequent...

```
func defaultConfig() *Config {
	return &Config{
		Buckets:       1,
		LeaseDuration: 60 * time.Second,
		RenewDeadline: 40 * time.Second,
		RetryPeriod:   10 * time.Second,
	}
}
```

The KafkaChannel Webhook deployment has a 20 second delay on the initial liveness probe...
```
        livenessProbe:
          <<: *probe
          initialDelaySeconds: 20
```

So the webhook is restarted continually before it can finish the leader election setup.

This is a problem when uninstalling and re-installing in an existing namespace as the leases are not removed.  If the namespace is removed this shouldn't be an issue.  For "optional" components like eventing-kakfa that live in the knative-eventing namespace, though it is common.  There is a large Slack thread on this outage in the eventing-kafka channel on Jan 26, 2022.

## Proposed Changes

The goal of this PR is a quick rollback/override to use the prior configuration values so that build/releases may proceed.  If in the future we want to undo this and find another solution we can always do so.

- Add a new **config/channel/config/leader-election-configmap.yaml** with prior configuration values.
- Symlinks from **config/channel/consolidated** and **config/channel/distributed** to include the new ConfigMap
- Change both consolidated and distributed controller Deployments to use the new ConfigMap instead of relying on the standard knative-eventing leader-election ConfigMap.
- Add the CONFIG_LEADERELECTION_NAME env var to the Webhook Deployment(s) referencing the new ConfigMap.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

