### PR TITLE
Change KafkaChannel default replication factor and num partitions

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -21,10 +21,10 @@ import "time"
 const (
 
 	// DefaultNumPartitions is the KafkaChannel Spec default for the number of partitions
-	DefaultNumPartitions = 1
+	DefaultNumPartitions = 10
 
 	// DefaultReplicationFactor is the KafkaChannel Spec default for the replication factor
-	DefaultReplicationFactor = 1
+	DefaultReplicationFactor = 3
 
 	// DefaultRetentionISO8601Duration is the KafkaChannel Spec default for the retention duration as an ISO-8601 string
 	DefaultRetentionISO8601Duration = "PT168H" // Precise 7 Days


### PR DESCRIPTION
Fixes #1006

The current defaults of setting partitions and replication factor to 1
aren't safe defaults for performance and durability.

This PR sets KafkaChannel default replication factor to 3 and
num partitions to 10.

## Proposed Changes

- Change KafkaChannel default replication factor and num partitions

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
KafkaChannel default replication factor is 3 and num partitions is 10.
```
