### PR TITLE
Revert new defaults and do not skip the Channel Spec Conformance tests 

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -21,10 +21,10 @@ import "time"
 const (
 
 	// DefaultNumPartitions is the KafkaChannel Spec default for the number of partitions
-	DefaultNumPartitions = 10
+	DefaultNumPartitions = 1
 
 	// DefaultReplicationFactor is the KafkaChannel Spec default for the replication factor
-	DefaultReplicationFactor = 3
+	DefaultReplicationFactor = 1
 
 	// DefaultRetentionISO8601Duration is the KafkaChannel Spec default for the retention duration as an ISO-8601 string
 	DefaultRetentionISO8601Duration = "PT168H" // Precise 7 Days

--- a/test/conformance/channel_spec_test.go
+++ b/test/conformance/channel_spec_test.go
@@ -27,6 +27,5 @@ import (
 )
 
 func TestChannelSpec(t *testing.T) {
-	t.Skip()
 	eventingconformancehelpers.ChannelSpecTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }


### PR DESCRIPTION
## Proposed Changes

- Enable a test that was skipped last June: https://github.com/knative-sandbox/eventing-kafka/pull/713/files#diff-ff7272c1d2d48ab61f1fbfdd068acd9127a52d305ee356918233e5e8a087ec2dR29
- Revert the defaulting to 10 partitions and 3 replicas


When enabling the test, without reverting, we are seeing:

```
    channel_spec_test_helper.go:104: Failed to update channel spec at attempt 0 "KafkaChannel" "channel-spec-subscribers-wwfgg": admission webhook "validation.webhook.kafka.messaging.knative.dev" denied the request: validation failed: Immutable fields changed (-old +new): spec
        {v1beta1.KafkaChannelSpec}.NumPartitions:
        	-: "10"
        	+: "1"
        {v1beta1.KafkaChannelSpec}.ReplicationFactor:
        	-: "3"
        	+: "1"
    channel_spec_test_helper.go:111: Error updating {KafkaChannel messaging.knative.dev/v1beta1} with subscribers in spec: admission webhook "validation.webhook.kafka.messaging.knative.dev" denied the request: validation failed: Immutable fields changed (-old +new): spec
        {v1beta1.KafkaChannelSpec}.NumPartitions:
        	-: "10"
        	+: "1"
        {v1beta1.KafkaChannelSpec}.ReplicationFactor:
        	-: "3"
        	+: "1"
    test_runner.go:284: Ev

```

Hence I propose to:
* revert
* enable the test (as it should be)


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
