### PR TITLE
Set resource limit for single-tenant Kafka source

### DIFF
--- a/pkg/source/reconciler/source/resources/receive_adapter.go
+++ b/pkg/source/reconciler/source/resources/receive_adapter.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
 	"knative.dev/eventing/pkg/adapter/v2"
@@ -116,7 +117,16 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 							Name:  "receive-adapter",
 							Image: args.Image,
 							Env:   env,
-							Ports: []corev1.ContainerPort{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("125m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2200m"),
+									corev1.ResourceMemory: resource.MustParse("2048Mi"),
+								},
+							}, Ports: []corev1.ContainerPort{
 								{Name: "metrics", ContainerPort: 9090},
 								{Name: "profiling", ContainerPort: 8008},
 								{Name: "control", ContainerPort: 9000},


### PR DESCRIPTION
Fixes #1008

## Proposed Changes

- 🧽 Limit single-tenant Kafka source use of resources such as CPU and memory

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
