### PR TITLE
Prevent excessive wait time in KafkaSender for upgrade tests

### DIFF
--- a/test/upgrade/continual/kafkasender.go
+++ b/test/upgrade/continual/kafkasender.go
@@ -74,6 +74,8 @@ func (k *kafkaSender) SendEvent(ce cloudevents.Event, rawEndpoint interface{}) e
 		WithClientId("continualtests-kafka-sender").
 		WithDefaults().
 		Build(k.ctx)
+	// Prevent excessive wait time.
+	conf.Producer.RequiredAcks = sarama.WaitForLocal
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #1103

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Reduce the replica acknowledgements from WaitForAll to WaitForLocal for the KafkaSender in upgrade tests

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
