### PR TITLE
KafkaSource continues Trace from messages

### DIFF
--- a/pkg/channel/consolidated/dispatcher/consumer_message_handler.go
+++ b/pkg/channel/consolidated/dispatcher/consumer_message_handler.go
@@ -76,7 +76,7 @@ func (c consumerMessageHandler) Handle(ctx context.Context, consumerMessage *sar
 	// serialization.  Also, filtering CloudEvent "ce" headers which are already taken from the Message.
 	httpHeader := tracing.ConvertRecordHeadersToHttpHeader(tracing.FilterCeRecordHeaders(consumerMessage.Headers))
 
-	ctx, span := tracing.StartTraceFromMessage(c.logger, ctx, message, consumerMessage.Topic)
+	ctx, span := tracing.StartTraceFromMessage(c.logger, ctx, message, "kafkachannel-"+consumerMessage.Topic)
 	defer span.End()
 
 	te := kncloudevents.TypeExtractorTransformer("")

--- a/pkg/channel/distributed/dispatcher/dispatcher/handler.go
+++ b/pkg/channel/distributed/dispatcher/dispatcher/handler.go
@@ -135,7 +135,7 @@ func (h *Handler) Handle(ctx context.Context, consumerMessage *sarama.ConsumerMe
 	}
 
 	// Start Tracing
-	ctx, span := tracing.StartTraceFromMessage(h.Logger.Sugar(), ctx, message, consumerMessage.Topic)
+	ctx, span := tracing.StartTraceFromMessage(h.Logger.Sugar(), ctx, message, "kafkachannel-"+consumerMessage.Topic)
 	defer span.End()
 
 	// Dispatch The Message With Configured Retries, DLQ, etc

--- a/pkg/common/tracing/tracing.go
+++ b/pkg/common/tracing/tracing.go
@@ -61,14 +61,14 @@ func SerializeTrace(spanContext trace.SpanContext) []sarama.RecordHeader {
 // in order to trace the flow of a message.  Multiple spans may be part of a single trace, for
 // example, a dead letter message or a reply should be easy to match with the original message based
 // on the trace ID.  This ID is originally set in the first message header using the SerializeTrace function.
-func StartTraceFromMessage(logger *zap.SugaredLogger, inCtx context.Context, message *protocolkafka.Message, topic string) (context.Context, *trace.Span) {
+func StartTraceFromMessage(logger *zap.SugaredLogger, inCtx context.Context, message *protocolkafka.Message, spanName string) (context.Context, *trace.Span) {
 	sc, ok := ParseSpanContext(message.Headers)
 	if !ok {
 		logger.Warn("Cannot parse the spancontext, creating a new span")
-		return trace.StartSpan(inCtx, "kafkachannel-"+topic)
+		return trace.StartSpan(inCtx, spanName)
 	}
 
-	return trace.StartSpanWithRemoteParent(inCtx, "kafkachannel-"+topic, sc)
+	return trace.StartSpanWithRemoteParent(inCtx, spanName, sc)
 }
 
 // ParseSpanContext takes the "traceparent" and "tracestate" headers and regenerates the

--- a/pkg/common/tracing/tracing_test.go
+++ b/pkg/common/tracing/tracing_test.go
@@ -83,7 +83,7 @@ func TestStartTraceFromMessage(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 
 	// Verify that "message without headers" starts a new span without errors
-	ctx, span := StartTraceFromMessage(logger, context.TODO(), &protocolkafka.Message{}, "testTopic")
+	ctx, span := StartTraceFromMessage(logger, context.TODO(), &protocolkafka.Message{}, "kafkachannel-testTopic")
 	require.NotNil(t, ctx)
 	require.NotNil(t, span)
 
@@ -100,7 +100,7 @@ func TestStartTraceFromMessage(t *testing.T) {
 	}
 
 	// Verify that a span can be generated from existing span headers
-	ctx, span = StartTraceFromMessage(logger, context.TODO(), &protocolkafka.Message{Headers: headers}, "testTopic")
+	ctx, span = StartTraceFromMessage(logger, context.TODO(), &protocolkafka.Message{Headers: headers}, "kafkachannel-testTopic")
 	require.NotNil(t, ctx)
 	require.NotNil(t, span)
 }


### PR DESCRIPTION
Fixes #1105

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- KafkaSource continues Zipkin traces stored in message headers.
- 🐛 Fix bug

The Trace is now visible from the start while previously it was starting at Kafka source
![kafka_source_trace](https://user-images.githubusercontent.com/336823/155325069-75ca9435-c1df-4113-b905-6d5c0a4a039b.png)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature

- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
