### PR TITLE
Resolve deadLetterSink uri and set it in the KafkaChannel status

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/controller.go
+++ b/pkg/channel/consolidated/reconciler/controller/controller.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	knativeReconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/system"
 
 	kafkaChannelClient "knative.dev/eventing-kafka/pkg/client/injection/client"
@@ -104,6 +105,7 @@ func NewController(
 	r.controllerRef = *ownerRef
 
 	impl := kafkaChannelReconciler.NewImpl(ctx, r)
+	r.resolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
 	// Call GlobalResync on kafkachannels.
 	grCh := func(interface{}) {


### PR DESCRIPTION
The subscription reconciler requires that the resolved
deadLetterSink, if specified, is set in the status.

Signed-off-by: Pierangelo Di Pilato <pdipilat@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Resolve deadLetterSink uri and set it in the KafkaChannel status

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Resolve deadLetterSink uri and set it in the KafkaChannel status
```
