### PR TITLE
Activating HA scheduler for scaling and scheduling KafkaSource consumers

### DIFF
--- a/config/source/common/configmaps/config-descheduler.yaml
+++ b/config/source/common/configmaps/config-descheduler.yaml
@@ -20,35 +20,9 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: devel
 data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-    #
-    # These predicate plugins are used to filter out pods that
-    # a vreplica cannot be removed from due to not satisfying the
-    # predicate condition. For each pod, the descheduler
-    # will call filter plugins in their configured order.
-    # predicates: |+
+    predicates: |+
                     []
-    #
-    # These priority plugins are used to score each pod that
-    # has passed the filtering phase. The scheduler will then
-    # select the pod with the highest weighted score sum to
-    # remove vreplica from. If two pods have an equal score,
-    # a pod is chosen randomly.
-    # priorities: |+
+    priorities: |+
                   [
                     {"Name": "RemoveWithEvenPodSpreadPriority",
                     "Weight": 10,

--- a/config/source/common/configmaps/config-scheduler.yaml
+++ b/config/source/common/configmaps/config-scheduler.yaml
@@ -20,44 +20,20 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: devel
 data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-    #
-    # These predicate plugins are used to filter out pods that
-    # a vreplica cannot be placed on due to not satisfying the
-    # predicate condition. For each pod, the scheduler
-    # will call filter plugins in their configured order.
-    # predicates: |+
+    predicates: |+
                   [
                     {"Name": "PodFitsResources"},
                     {"Name": "NoMaxResourceCount",
-                    "Args": "{\"NumPartitions\": 100}"},
-                    {"Name": "EvenPodSpread",
-                    "Args": "{\"MaxSkew\": 2}"}
+                    "Args": "{\"NumPartitions\": 100}"}
                   ]
-    #
-    # These priority plugins are used to score each pod that
-    # has passed the filtering phase. The scheduler will then
-    # select the pod with the highest weighted score sum. If
-    # two pods have an equal score, a pod is chosen randomly.
-    # priorities: |+
+    priorities: |+
                   [
                     {"Name": "AvailabilityZonePriority",
                     "Weight": 10,
                     "Args":  "{\"MaxSkew\": 2}"},
                     {"Name": "LowestOrdinalPriority",
-                    "Weight": 2}
+                    "Weight": 2},
+                    {"Name": "EvenPodSpread",
+                    "Weight": 2,
+                    "Args": "{\"MaxSkew\": 2}"}
                   ]

--- a/config/source/multi/deployments/controller.yaml
+++ b/config/source/multi/deployments/controller.yaml
@@ -59,15 +59,11 @@ spec:
         - name: VREPLICA_LIMITS_MPS
           value: '250'
 
-        # The scheduling policy type for placing vreplicas on pods (see type SchedulerPolicyType for enum list)
-        - name: SCHEDULER_POLICY_TYPE
-          value: 'MAXFILLUP'
-
         - name: SCHEDULER_CONFIG
-          value: ''
+          value: 'config-kafka-source-scheduler'
 
         - name: DESCHEDULER_CONFIG
-          value: ''
+          value: 'config-kafka-source-descheduler'
 
         resources:
           requests:

--- a/pkg/source/reconciler/mtsource/controller.go
+++ b/pkg/source/reconciler/mtsource/controller.go
@@ -47,13 +47,12 @@ import (
 )
 
 type envConfig struct {
-	SchedulerRefreshPeriod        int64                         `envconfig:"AUTOSCALER_REFRESH_PERIOD" required:"true"`
-	PodCapacity                   int32                         `envconfig:"POD_CAPACITY" required:"true"`
-	VReplicaMPS                   int32                         `envconfig:"VREPLICA_LIMITS_MPS" required:"false" default:"-1"`
-	MaxEventPerSecondPerPartition int32                         `envconfig:"MAX_MPS_PER_PARTITION" required:"false" default:"-1"`
-	SchedulerPolicyType           scheduler.SchedulerPolicyType `envconfig:"SCHEDULER_POLICY_TYPE" required:"true"`
-	SchedulerPolicyConfigMap      string                        `envconfig:"SCHEDULER_CONFIG" required:"true"`
-	DeSchedulerPolicyConfigMap    string                        `envconfig:"DESCHEDULER_CONFIG" required:"true"`
+	SchedulerRefreshPeriod        int64  `envconfig:"AUTOSCALER_REFRESH_PERIOD" required:"true"`
+	PodCapacity                   int32  `envconfig:"POD_CAPACITY" required:"true"`
+	VReplicaMPS                   int32  `envconfig:"VREPLICA_LIMITS_MPS" required:"false" default:"-1"`
+	MaxEventPerSecondPerPartition int32  `envconfig:"MAX_MPS_PER_PARTITION" required:"false" default:"-1"`
+	SchedulerPolicyConfigMap      string `envconfig:"SCHEDULER_CONFIG" required:"true"`
+	DeSchedulerPolicyConfigMap    string `envconfig:"DESCHEDULER_CONFIG" required:"true"`
 }
 
 func NewController(
@@ -167,7 +166,17 @@ func NewController(
 	}
 
 	logging.FromContext(ctx).Debugw("Scheduler Policy Config Map read", zap.Any("policy", policy))
-	c.scheduler = stsscheduler.NewScheduler(ctx, system.Namespace(), mtadapterName, c.vpodLister, rp, env.PodCapacity, env.SchedulerPolicyType, nodeInformer.Lister(), evictor, policy, removalpolicy)
+	c.scheduler = stsscheduler.NewScheduler(ctx,
+		system.Namespace(),
+		mtadapterName,
+		c.vpodLister,
+		rp,
+		env.PodCapacity,
+		"", //  scheduler.SchedulerPolicyType field only applicable for old scheduler policy
+		nodeInformer.Lister(),
+		evictor,
+		policy,
+		removalpolicy)
 
 	logging.FromContext(ctx).Info("Setting up kafka event handlers")
 	kafkaInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Removing `MAXFILLUP` scheduling strategy and replacing with [Multi-Tenant HA Scheduler](https://github.com/knative/eventing/tree/main/pkg/scheduler)