### PR TITLE
Generate consumer group in KafkaSourceUpdate test

### DIFF
--- a/test/e2e/helpers/kafka_source_test_helper.go
+++ b/test/e2e/helpers/kafka_source_test_helper.go
@@ -78,6 +78,7 @@ func testKafkaSourceUpdate(t *testing.T, name string, test updateTest) {
 	client.WaitForAllTestResourcesReadyOrFail(context.Background())
 
 	kafkaSourceName := "e2e-kafka-source-" + name
+	groupId := client.Namespace + "-" + name
 
 	t.Logf("Creating kafkasource: %s\n", kafkaSourceName)
 	contribtestlib.CreateKafkaSourceV1Beta1OrFail(client, contribresources.KafkaSourceV1Beta1(
@@ -86,6 +87,7 @@ func testKafkaSourceUpdate(t *testing.T, name string, test updateTest) {
 		resources.ServiceRef(defaultKafkaSource.sinkName),
 		contribresources.WithNameV1Beta1(kafkaSourceName),
 		withAuthEnablementV1Beta1(defaultKafkaSource.auth),
+		contribresources.WithConsumerGroupV1Beta1(groupId),
 	))
 	client.WaitForAllTestResourcesReadyOrFail(context.Background())
 


### PR DESCRIPTION
Using the same consumer group for the different sources might produce
unreliable results because Kafka group ids are shared.

This is particularly evident in eventing-kafka-broker where the same
tests (`KafkaSourceUpdate`) is executed 5 times [1] in parallel [2]
(to catch flakes early), which means that there might be different
sources with the same consumer group pointing to 2 different sinks.

[1] https://github.com/knative-sandbox/eventing-kafka-broker/blob/e169e2cb923890a23e8d65651876292283b63908/test/e2e/kafka_source_test.go#L31
[2] https://github.com/knative-sandbox/eventing-kafka-broker/blob/e169e2cb923890a23e8d65651876292283b63908/test/pkg/testing/run.go#L52-L67

Signed-off-by: Pierangelo Di Pilato <pdipilat@redhat.com>