### PR TITLE
[release-1.2] Going with debug to reduce verbosity for retention duration default usage

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
+++ b/pkg/channel/consolidated/reconciler/controller/kafkachannel.go
@@ -585,7 +585,7 @@ func (r *Reconciler) reconcileTopic(ctx context.Context, channel *v1beta1.KafkaC
 	retentionDuration, err := channel.Spec.ParseRetentionDuration()
 	if err != nil {
 		// Should never happen with webhook defaulting and validation in place.
-		logger.Errorw("Error parsing RetentionDuration, using default instead", zap.String("RetentionDuration", channel.Spec.RetentionDuration), zap.Error(err))
+		logger.Debugw("Error parsing RetentionDuration, using default instead", zap.String("RetentionDuration", channel.Spec.RetentionDuration), zap.Error(err))
 		retentionDuration = constants.DefaultRetentionDuration
 	}
 	retentionMillisString := strconv.FormatInt(retentionDuration.Milliseconds(), 10)


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

## Proposed Changes

- As per title: There is no reason to do an error log, since we do have a default value to be used. Going with debug to reduce verbosity...

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
