### PR TITLE
The channelTemplateSpec: is deprecated and replaced by channel-template-spec

### DIFF
--- a/test/upgrade/continual/channel.go
+++ b/test/upgrade/continual/channel.go
@@ -250,7 +250,7 @@ func (b *brokerBackedByKafkaChannelSut) setKafkaAsDefaultForBroker(ctx sut.Conte
 			Name:      "config-br-default-channel",
 		},
 		Data: map[string]string{
-			"channelTemplateSpec": fmt.Sprintf(`apiVersion: %s
+			"channel-template-spec": fmt.Sprintf(`apiVersion: %s
 kind: %s
 spec:
   numPartitions: %d


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

## Proposed Changes

- Follow up for https://github.com/knative/eventing/pull/5875
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
