### PR TITLE
Correctly handle KafkaChannels with long names

### DIFF
--- a/pkg/channel/consolidated/reconciler/controller/resources/service.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/service.go
@@ -21,9 +21,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/network"
+
+	"knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
 )
 
 const (
@@ -31,13 +32,21 @@ const (
 	portNumber         = 80
 	MessagingRoleLabel = "messaging.knative.dev/role"
 	MessagingRole      = "kafka-channel"
+
+	ChannelSuffix = "-kn-channel"
+	// MaxResourceNameLength is the maximum number of characters for a Kubernetes resource name.
+	// See vendor/k8s.io/apiserver/pkg/storage/names/generate.go
+	MaxResourceNameLength = 63
 )
 
 // ServiceOption can be used to optionally modify the K8s service in MakeK8sService.
 type ServiceOption func(*corev1.Service) error
 
 func MakeChannelServiceName(name string) string {
-	return fmt.Sprintf("%s-kn-channel", name)
+	if len(name)+len(ChannelSuffix) > MaxResourceNameLength {
+		return name
+	}
+	return fmt.Sprintf("%s%s", name, ChannelSuffix)
 }
 
 // ExternalService is a functional option for MakeK8sService to create a K8s service of type ExternalName

--- a/pkg/channel/consolidated/reconciler/controller/resources/service_test.go
+++ b/pkg/channel/consolidated/reconciler/controller/resources/service_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMakeChannelServiceName(t *testing.T) {
+	tt := []struct {
+		name  string
+		given string
+		want  string
+	}{
+		{
+			name:  "63 chars",
+			given: strings.Repeat("a", 63),
+			want:  strings.Repeat("a", 63),
+		},
+		{
+			name:  "64 chars",
+			given: strings.Repeat("a", 64),
+			want:  strings.Repeat("a", 64),
+		},
+		{
+			name:  fmt.Sprintf("%d chars", 65-len(ChannelSuffix)),
+			given: strings.Repeat("a", 65-len(ChannelSuffix)),
+			want:  strings.Repeat("a", 65-len(ChannelSuffix)),
+		},
+		{
+			name:  fmt.Sprintf("%d chars", 64-len(ChannelSuffix)),
+			given: strings.Repeat("a", 64-len(ChannelSuffix)),
+			want:  strings.Repeat("a", 64-len(ChannelSuffix)),
+		},
+		{
+			name:  fmt.Sprintf("%d chars", 63-len(ChannelSuffix)),
+			given: strings.Repeat("a", 63-len(ChannelSuffix)),
+			want:  strings.Repeat("a", 63-len(ChannelSuffix)) + "-kn-channel",
+		},
+		{
+			name:  fmt.Sprintf("%d chars", 62-len(ChannelSuffix)),
+			given: strings.Repeat("a", 62-len(ChannelSuffix)),
+			want:  strings.Repeat("a", 62-len(ChannelSuffix)) + "-kn-channel",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MakeChannelServiceName(tc.given); got != tc.want {
+				t.Errorf("want %s, got %s", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Appending a suffix to the service associated with a KafkaChannel
cannot be done when the resulting name is too long.

Signed-off-by: Pierangelo Di Pilato <pdipilat@redhat.com>

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Correctly handle KafkaChannels with long names
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
