### PR TITLE
Being explicit about authorization for our test kafkausers

### DIFF
--- a/test/config/100-kafka-ephemeral-triple-3.1.0.yaml
+++ b/test/config/100-kafka-ephemeral-triple-3.1.0.yaml
@@ -23,6 +23,8 @@ spec:
         tls: true
         authentication:
           type: scram-sha-512
+    authorization:
+      type: simple
     config:
       auto.create.topics.enable: false
       offsets.topic.replication.factor: 3


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Being explicit about authorization for our test kafkausers. Because: In newer versions of (like 0.27+) Strimzi changed the approach from silently ignoring it to rejecting `KafkaUser` with `Authorization` when the cluster has it (Authorization) disabled.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
