### PR TITLE
Resetoffset Controller fix MessageHandler record wrong message source

### DIFF
--- a/pkg/common/commands/resetoffset/controller/dataplane_test.go
+++ b/pkg/common/commands/resetoffset/controller/dataplane_test.go
@@ -33,6 +33,7 @@ import (
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
 
+	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/constants"
 	controllertesting "knative.dev/eventing-kafka/pkg/common/commands/resetoffset/controller/testing"
 	refmapperstesting "knative.dev/eventing-kafka/pkg/common/commands/resetoffset/refmappers/testing"
 	"knative.dev/eventing-kafka/pkg/common/controlprotocol"
@@ -186,13 +187,15 @@ func performStartStopConsumerGroupAsyncCommandsTest(t *testing.T, opCode ctrl.Op
 
 			// Create A ResetOffset To Test
 			resetOffset := controllertesting.NewResetOffset()
-			resetOffsetNamespacedName := types.NamespacedName{
-				Namespace: resetOffset.GetNamespace(),
-				Name:      resetOffset.GetName(),
-			}
 
 			// Create A RefInfo To Test
 			refInfo := refmapperstesting.NewRefInfo()
+
+			// Save responses to Dispatcher
+			resetOffsetNamespacedName := types.NamespacedName{
+				Namespace: refInfo.DataPlaneNamespace,
+				Name:      refInfo.DataPlaneLabels[constants.AppLabel],
+			}
 
 			// Determine The Expected CommandIDs
 			commandId1, err := GenerateCommandId(resetOffset, podIp1, opCode)

--- a/pkg/common/commands/resetoffset/controller/reconciler.go
+++ b/pkg/common/commands/resetoffset/controller/reconciler.go
@@ -159,11 +159,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, resetOffset *kafkav1alpha
 	logger := logging.FromContext(ctx)
 	logger.Debug("<==========  START RESET-OFFSET FINALIZATION  ==========>")
 
-	// Clean The AsyncCommandNotificationStore
-	r.asyncCommandNotificationStore.CleanPodsNotifications(types.NamespacedName{
-		Namespace: resetOffset.Namespace,
-		Name:      resetOffset.Name,
-	})
+	// Clean The AsyncCommandNotificationStore in Connention oldServiceCb
 
 	// No-Op Finalization - Nothing To Do
 	logger.Info("No-Op Finalization Successful")

--- a/pkg/common/commands/resetoffset/controller/reconciler_test.go
+++ b/pkg/common/commands/resetoffset/controller/reconciler_test.go
@@ -43,6 +43,7 @@ import (
 	"knative.dev/pkg/system"
 
 	kafkav1alpha1 "knative.dev/eventing-kafka/pkg/apis/kafka/v1alpha1"
+	controllerconstants "knative.dev/eventing-kafka/pkg/channel/distributed/controller/constants"
 	fakekafkaclient "knative.dev/eventing-kafka/pkg/client/injection/client/fake"
 	resetoffsetreconciler "knative.dev/eventing-kafka/pkg/client/injection/reconciler/kafka/v1alpha1/resetoffset"
 	controllertesting "knative.dev/eventing-kafka/pkg/common/commands/resetoffset/controller/testing"
@@ -386,11 +387,14 @@ func TestReconcile(t *testing.T) {
 		mockResetOffsetRefMapper.On("MapRef", mock.Anything).Return(refInfo, mapRefErr)
 
 		// Create A Mock Control-Protocol AsyncCommandNotificationStore & Assign To Reconciler
-		resetOffsetNamespacedName := controllertesting.NewResetOffsetNamespacedName()
+		dataPlaneNamespacedName := types.NamespacedName{
+			Namespace: refInfo.DataPlaneNamespace,
+			Name:      refInfo.DataPlaneLabels[controllerconstants.AppLabel],
+		}
 		successResult := &ctrlmessage.AsyncCommandResult{}
 		mockAsyncCommandNotificationStore := &controlprotocoltesting.MockAsyncCommandNotificationStore{}
-		mockAsyncCommandNotificationStore.On("GetCommandResult", resetOffsetNamespacedName, podIp, stopConsumerGroupAsyncCommand).Return(successResult)
-		mockAsyncCommandNotificationStore.On("GetCommandResult", resetOffsetNamespacedName, podIp, startConsumerGroupAsyncCommand).Return(successResult)
+		mockAsyncCommandNotificationStore.On("GetCommandResult", dataPlaneNamespacedName, podIp, stopConsumerGroupAsyncCommand).Return(successResult)
+		mockAsyncCommandNotificationStore.On("GetCommandResult", dataPlaneNamespacedName, podIp, startConsumerGroupAsyncCommand).Return(successResult)
 		mockAsyncCommandNotificationStore.On("CleanPodsNotifications", types.NamespacedName{
 			Namespace: controllertesting.ResetOffsetNamespace,
 			Name:      controllertesting.ResetOffsetName,

--- a/pkg/common/commands/resetoffset/refmappers/testing/data.go
+++ b/pkg/common/commands/resetoffset/refmappers/testing/data.go
@@ -17,6 +17,10 @@ limitations under the License.
 package testing
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kafkav1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
+	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/constants"
+	"knative.dev/eventing-kafka/pkg/channel/distributed/controller/util"
 	controllertesting "knative.dev/eventing-kafka/pkg/common/commands/resetoffset/controller/testing"
 	"knative.dev/eventing-kafka/pkg/common/commands/resetoffset/refmappers"
 )
@@ -24,6 +28,8 @@ import (
 const (
 	ConnectionPoolKey    = "TestConnectionPoolKey"
 	DataPlaneNamespace   = "TestDataPlaneNamespace"
+	ChannelName          = "TestChannelName"
+	ChannelNamespace     = "TestChannelNamespace"
 	DataPlaneLabelKey1   = "TestDataPlaneLabelKey1"
 	DataPlaneLabelValue1 = "TestDataPlaneLabelValue1"
 	DataPlaneLabelKey2   = "TestDataPlaneLabelKey2"
@@ -48,6 +54,9 @@ func NewRefInfo(options ...RefInfoOption) *refmappers.RefInfo {
 		DataPlaneNamespace: DataPlaneNamespace,
 		DataPlaneLabels:    map[string]string{DataPlaneLabelKey1: DataPlaneLabelValue1, DataPlaneLabelKey2: DataPlaneLabelValue2},
 	}
+
+	channel := &kafkav1beta1.KafkaChannel{ObjectMeta: metav1.ObjectMeta{Name: ChannelName, Namespace: ChannelNamespace}}
+	refInfo.DataPlaneLabels[constants.AppLabel] = util.DispatcherDnsSafeName(channel)
 
 	// Apply The Specified Customizations
 	for _, option := range options {


### PR DESCRIPTION
Fixes #1194

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use dispatcher's app name to receive and save the async message, instead of resetoffset's.
- Make ResetOffset FinalizeKind NOOP, AsyncCommandNotificationStore will be cleaned when connections destroy.
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix: In the same KafkaChannel, after the first ResetOffset, stop consumerGroups timeout occurs in subsequent attempts.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
