### PR TITLE
Close OffsetManager on init offsets

### DIFF
--- a/pkg/common/kafka/offset/offsets.go
+++ b/pkg/common/kafka/offset/offsets.go
@@ -37,6 +37,7 @@ func InitOffsets(ctx context.Context, kafkaClient sarama.Client, kafkaAdminClien
 	if err != nil {
 		return -1, err
 	}
+	defer offsetManager.Close()
 
 	totalPartitions, topicPartitions, err := retrieveAllPartitions(topics, kafkaClient)
 	if err != nil {


### PR DESCRIPTION
The OffsetManager wasn't closed after initializing the offsets
leading to go routing leaks.

Signed-off-by: Pierangelo Di Pilato <pdipilat@redhat.com>

Fixes https://github.com/knative-sandbox/eventing-kafka-broker/issues/2417

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

```release-note
The OffsetManager wasn't closed after initializing the offsets leading to go routing leaks.
```