### PR TITLE
[1.7] Use PodDisruptionBudget v1

### DIFF
--- a/config/channel/webhook/webhook-hpa.yaml
+++ b/config/channel/webhook/webhook-hpa.yaml
@@ -35,7 +35,7 @@ spec:
         averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: kafka-webhook


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use PodDisruptionBudget v1
- Need to fix this old release as there are issues when we try `eventing-kafka` with newer Kubernetes versions
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Upgrade PodDisruptionBudget used in KafkaChannel webhook from policy/v1beta1 to policy/v1
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
