### PR TITLE
Update API versions of HorizontalPodAutoscaler and PodDisruptionBudget

### DIFF
--- a/config/channel/webhook/webhook-hpa.yaml
+++ b/config/channel/webhook/webhook-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: kafka-webhook

--- a/config/channel/webhook/webhook-hpa.yaml
+++ b/config/channel/webhook/webhook-hpa.yaml
@@ -35,7 +35,7 @@ spec:
         averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: kafka-webhook


### PR DESCRIPTION
The [nightly release job](https://prow.knative.dev/view/gs/knative-prow/logs/nightly_eventing-kafka_main_periodic/1616369505573801984) has some issues with deprecated APIs on upgrade jobs:

```
Jan 20 10:02:44.846 install_released_consolidated_channel [OUT] Applying: /logs/artifacts/channel-consolidated-knative-v1.8.1.yaml
...
Jan 20 10:02:50.925 install_released_consolidated_channel [ERR] Warning: autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
Jan 20 10:02:51.081 install_released_consolidated_channel [OUT] horizontalpodautoscaler.autoscaling/kafka-webhook created
...
Jan 20 10:02:51.298 install_released_consolidated_channel [ERR] error: resource mapping not found for name: "kafka-webhook" namespace: "knative-eventing" from "/logs/artifacts/channel-consolidated-knative-v1.8.1.yaml": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
Jan 20 10:02:51.298 install_released_consolidated_channel [ERR] ensure CRDs are installed first
    shell.go:28: exit status 1
```

This PR addresses it and updates the API versions of `HorizontalPodAutoscaler` to `autoscaling/v2` (d70442713eb5e4c7873b89b3903b76ef02041078) and `PodDisruptionBudget` to `policy/v1` (c10f2ff8632bd8761addf65ca8f733b26a824d15).
This will require to backport this PR for a few releases to make the upgrade tests work.

Deprecation guide for 1.25: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125

**Release Note**
```release-note
Update HorizontalPodAutoscaler API version to autoscaling/v2
Update PodDisruptionBudget API version to policy/v1
```